### PR TITLE
content: update pricing wording to $75/h

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.15.2",
+      "version": "1.15.3",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -69,8 +69,8 @@ const faqItems: ReadonlyArray<FaqItem> = [
     answer: (
       <>
         <p>
-          I charge $50 per hour, but it depends on the complexity of the task. I'll give you a clear
-          estimate before starting so there are no surprises.
+          I charge $75 per hour. I'll give you a clear estimate before starting so there are no
+          surprises.
         </p>
         <p className={cn("text-rich-black/80 mt-2")}>
           See the{" "}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -47,7 +47,7 @@ export default function PricingPage(): React.ReactElement {
 
             <div className={cn("bg-seasalt-900/40 border-seasalt-400/60 rounded-lg border p-5")}>
               <p className={cn("text-russian-violet mb-2 text-3xl font-bold sm:text-4xl")}>
-                $50 per hour
+                $75 per hour
               </p>
               <p className={cn("text-rich-black/80 text-sm sm:text-base")}>
                 Billed fairly for the time I work. On-site visits and most remote support - remote


### PR DESCRIPTION
## Summary

- Updated FAQ and pricing pages to reflect the new $75/h rate
- Removed the old flat-rate framing; wording is now consistent across both pages