### PR TITLE
Revise pricing to two-tier rates and fix booking/CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
 
       - name: Build application
+        if: github.actor != 'dependabot[bot]'
         run: npm run build
 
   type-check:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.15.4",
+      "version": "1.15.5",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.15.2",
+      "version": "1.15.3",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.15.5",
+      "version": "1.15.6",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
@@ -4474,9 +4474,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.15.3",
+      "version": "1.15.4",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -95,7 +95,7 @@
     "glob": {
       "minimatch": "^10.2.1"
     },
-    "basic-ftp": "5.2.1",
+    "basic-ftp": "5.3.0",
     "vite": "^7.3.2",
     "typescript-eslint": "8.58.1"
   },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "simple-git-hooks": {
     "pre-commit": "npm install && git add package-lock.json && npx lint-staged",
-    "pre-push": "npm run smoke:fast"
+    "pre-push": "npm run test -- --run && npm run build && npm run smoke:fast"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "build:poster": "npx tsx scripts/export-poster-screenshot.ts",
     "build:all": "npm run build:icons && npm run build",
     "test": "vitest",
-    "smoke": "tsx scripts/smoke-test.ts",
-    "smoke:fast": "tsx scripts/smoke-test.ts --skip-build"
+    "smoke": "dotenv -e .env.local -- tsx scripts/smoke-test.ts",
+    "smoke:fast": "dotenv -e .env.local -- tsx scripts/smoke-test.ts --skip-build"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",

--- a/src/app/booking/edit/page.tsx
+++ b/src/app/booking/edit/page.tsx
@@ -26,6 +26,8 @@ import BookingForm, {
 } from "@/features/booking/components/BookingForm";
 import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
 
+export const dynamic = "force-dynamic";
+
 /**
  * Derive NZ dateKey (YYYY-MM-DD) from a UTC Date.
  * @param date - UTC date object.

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -18,10 +18,10 @@ import BookingForm from "@/features/booking/components/BookingForm";
 import { FrostedSection, PageShell, CARD, SOFT_CARD } from "@/shared/components/PageLayout";
 import { FaCalendarCheck, FaClock, FaEnvelopeOpenText, FaListCheck } from "react-icons/fa6";
 
-// ISR (Incremental Static Regeneration) with 5-minute revalidation window
-// Ensures calendar availability is never more than 5 minutes stale
-// (cron-job.org refreshes every 15 minutes, so 5-min ISR is a safe buffer)
-export const revalidate = 300; // 5 minutes (300 seconds)
+// Always render fresh - slot availability is time-sensitive and ISR can serve
+// stale pages indefinitely on low-traffic routes (Vercel only revalidates on
+// the next request *after* the window, not proactively).
+export const dynamic = "force-dynamic";
 
 /**
  * Get calendar events, preferring cache but falling back to live API

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -69,8 +69,8 @@ const faqItems: ReadonlyArray<FaqItem> = [
     answer: (
       <>
         <p>
-          I charge $50 per hour, but it depends on the complexity of the task. I'll give you a clear
-          estimate before starting so there are no surprises.
+          I charge $75 per hour. I'll give you a clear estimate before starting so there are no
+          surprises.
         </p>
         <p className={cn("text-rich-black/80 mt-2")}>
           See the{" "}

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -69,8 +69,8 @@ const faqItems: ReadonlyArray<FaqItem> = [
     answer: (
       <>
         <p>
-          I charge $75 per hour. I'll give you a clear estimate before starting so there are no
-          surprises.
+          $50/h for most jobs. $75/h for complex or lengthy work — data recovery, hardware repairs,
+          or full PC migrations. I'll confirm the rate before starting.
         </p>
         <p className={cn("text-rich-black/80 mt-2")}>
           See the{" "}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -47,7 +47,7 @@ export default function PricingPage(): React.ReactElement {
 
             <div className={cn("bg-seasalt-900/40 border-seasalt-400/60 rounded-lg border p-5")}>
               <p className={cn("text-russian-violet mb-2 text-3xl font-bold sm:text-4xl")}>
-                $50 per hour
+                $75 per hour
               </p>
               <p className={cn("text-rich-black/80 text-sm sm:text-base")}>
                 Billed fairly for the time I work. On-site visits and most remote support - remote

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -38,21 +38,29 @@ export default function PricingPage(): React.ReactElement {
           </section>
 
           <section
-            aria-label="Standard rates"
+            aria-label="Rates"
             className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-100")}
           >
-            <h2 className={cn("text-russian-violet mb-3 text-xl font-bold sm:text-2xl")}>
-              Standard rate
-            </h2>
+            <h2 className={cn("text-russian-violet mb-3 text-xl font-bold sm:text-2xl")}>Rates</h2>
 
-            <div className={cn("bg-seasalt-900/40 border-seasalt-400/60 rounded-lg border p-5")}>
-              <p className={cn("text-russian-violet mb-2 text-3xl font-bold sm:text-4xl")}>
-                $75 per hour
-              </p>
-              <p className={cn("text-rich-black/80 text-sm sm:text-base")}>
-                Billed fairly for the time I work. On-site visits and most remote support - remote
-                rates may vary.
-              </p>
+            <div className={cn("grid gap-4 sm:grid-cols-2")}>
+              <div className={cn("bg-seasalt-900/40 border-seasalt-400/60 rounded-lg border p-5")}>
+                <p className={cn("text-russian-violet mb-2 text-3xl font-bold sm:text-4xl")}>
+                  $50/h
+                </p>
+                <p className={cn("text-rich-black/80 text-sm sm:text-base")}>
+                  Most jobs — troubleshooting, setup, software, tune-ups, Wi-Fi, backups, and more.
+                </p>
+              </div>
+
+              <div className={cn("bg-seasalt-900/40 border-seasalt-400/60 rounded-lg border p-5")}>
+                <p className={cn("text-russian-violet mb-2 text-3xl font-bold sm:text-4xl")}>
+                  $75/h
+                </p>
+                <p className={cn("text-rich-black/80 text-sm sm:text-base")}>
+                  Complex or lengthy work — data recovery, hardware repairs, or full PC migrations.
+                </p>
+              </div>
             </div>
 
             <div className={cn("mt-5 space-y-3")}>
@@ -73,8 +81,8 @@ export default function PricingPage(): React.ReactElement {
               <p className={cn("text-rich-black/90 flex gap-3 text-sm sm:text-base")}>
                 <span className={cn("text-moonstone-600 mt-1 text-lg")}>✓</span>
                 <span>
-                  <strong>Bundle multiple issues into one visit</strong> to make the most of your
-                  time.
+                  <strong>Not sure which rate applies?</strong> Just ask — I'll confirm before
+                  starting.
                 </span>
               </p>
             </div>

--- a/src/features/booking/lib/booking.ts
+++ b/src/features/booking/lib/booking.ts
@@ -373,6 +373,10 @@ export function validateBookingRequest(
   );
   const slotEnd = new Date(slotStart.getTime() + durationMinutes * 60 * 1000);
 
+  if (slotStart < now) {
+    return { valid: false, error: "This time slot is in the past" };
+  }
+
   if (!isSlotFree(slotStart, slotEnd, existingBookings, calendarEvents, config.bufferMin)) {
     return { valid: false, error: "This time slot is no longer available" };
   }

--- a/tests/api/admin.contacts-export.test.ts
+++ b/tests/api/admin.contacts-export.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  isValidAdminToken: vi.fn(),
+  contactFindMany: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/auth", () => ({
+  isValidAdminToken: mocks.isValidAdminToken,
+}));
+
+vi.mock("@/shared/lib/prisma", () => ({
+  prisma: {
+    contact: { findMany: mocks.contactFindMany },
+  },
+}));
+
+import { GET } from "../../src/app/api/admin/contacts/export/route";
+
+/**
+ * Builds a minimal fake NextRequest with the given token query param.
+ * @param token - Value for the "token" query parameter, or null to omit it.
+ * @returns Fake NextRequest.
+ */
+function makeRequest(token: string | null): NextRequest {
+  return {
+    nextUrl: { searchParams: { get: (k: string) => (k === "token" ? token : null) } },
+  } as unknown as NextRequest;
+}
+
+describe("GET /api/admin/contacts/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isValidAdminToken.mockReturnValue(true);
+    mocks.contactFindMany.mockResolvedValue([]);
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    mocks.isValidAdminToken.mockReturnValue(false);
+    const res = await GET(makeRequest("bad-token"));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns 200 with correct Content-Type and Content-Disposition", async () => {
+    const res = await GET(makeRequest("secret"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/csv");
+    expect(res.headers.get("Content-Disposition")).toContain("contacts.csv");
+  });
+
+  it("includes UTF-8 BOM as the first three bytes of the response", async () => {
+    const res = await GET(makeRequest("secret"));
+    const buf = await res.arrayBuffer();
+    const bytes = new Uint8Array(buf);
+    // UTF-8 BOM: EF BB BF
+    expect(bytes[0]).toBe(0xef);
+    expect(bytes[1]).toBe(0xbb);
+    expect(bytes[2]).toBe(0xbf);
+  });
+
+  it("includes Google Contacts header columns", async () => {
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    const headerLine = text.split("\r\n")[0];
+    expect(headerLine).toContain("First Name");
+    expect(headerLine).toContain("Last Name");
+    expect(headerLine).toContain("E-mail 1 - Value");
+    expect(headerLine).toContain("Phone 1 - Value");
+    expect(headerLine).toContain("Address 1 - Formatted");
+  });
+
+  it("splits a full name into first and last name columns", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: "Alice Smith", email: "alice@example.com", phone: null, address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    const dataLine = text.split("\r\n")[1];
+    expect(dataLine).toContain('"Alice"');
+    expect(dataLine).toContain('"Smith"');
+  });
+
+  it("treats a single-word name as first name with empty last name", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: "Alice", email: null, phone: null, address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    const dataLine = text.split("\r\n")[1];
+    expect(dataLine).toMatch(/"Alice",""/);
+  });
+
+  it("handles multi-word first name correctly", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: "Mary Jane Watson", email: null, phone: null, address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    const dataLine = text.split("\r\n")[1];
+    expect(dataLine).toContain('"Mary Jane"');
+    expect(dataLine).toContain('"Watson"');
+  });
+
+  it("includes email and phone in the correct CSV columns", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: "Bob", email: "bob@example.com", phone: "+64211112222", address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    const dataLine = text.split("\r\n")[1];
+    expect(dataLine).toContain('"bob@example.com"');
+    expect(dataLine).toContain('"+64211112222"');
+  });
+
+  it("escapes double quotes inside CSV values", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: 'O"Brien', email: null, phone: null, address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    expect(text).toContain('"O""Brien"');
+  });
+
+  it("places contacts in the myContacts label group", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: "Test User", email: "test@example.com", phone: null, address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    expect(text).toContain('"* myContacts"');
+  });
+
+  it("sets primary email label when contact has an email", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: "Eve", email: "eve@example.com", phone: null, address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    expect(text).toContain('"* "');
+  });
+
+  it("leaves email label empty when contact has no email", async () => {
+    mocks.contactFindMany.mockResolvedValue([
+      { name: "No Email", email: null, phone: null, address: null },
+    ]);
+    const res = await GET(makeRequest("secret"));
+    const text = await res.text();
+    const dataLine = text.split("\r\n")[1];
+    // email label column should be empty string
+    expect(dataLine).toContain('""');
+  });
+});

--- a/tests/api/admin.preview-review-email.test.ts
+++ b/tests/api/admin.preview-review-email.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  isValidAdminToken: vi.fn(),
+  buildPastClientReviewEmailHtml: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/auth", () => ({
+  isValidAdminToken: mocks.isValidAdminToken,
+}));
+
+vi.mock("@/features/reviews/lib/email", () => ({
+  buildPastClientReviewEmailHtml: mocks.buildPastClientReviewEmailHtml,
+}));
+
+import { POST } from "../../src/app/api/admin/preview-review-email/route";
+
+/**
+ * Builds a minimal fake NextRequest that returns the given object as its JSON body.
+ * @param body - The JSON body to return from request.json().
+ * @returns Fake NextRequest.
+ */
+function makeRequest(body: object): NextRequest {
+  return { json: async () => body } as unknown as NextRequest;
+}
+
+describe("POST /api/admin/preview-review-email", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isValidAdminToken.mockReturnValue(true);
+    mocks.buildPastClientReviewEmailHtml.mockReturnValue("<html>preview</html>");
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    mocks.isValidAdminToken.mockReturnValue(false);
+    const res = await POST(makeRequest({ token: "bad", name: "Alice" }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 400 when name is absent", async () => {
+    const res = await POST(makeRequest({ token: "secret" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/name is required/i);
+  });
+
+  it("returns 400 when name is only whitespace", async () => {
+    const res = await POST(makeRequest({ token: "secret", name: "   " }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+  });
+
+  it("returns 200 with rendered html on success", async () => {
+    const res = await POST(makeRequest({ token: "secret", name: "Alice Smith" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.html).toBe("<html>preview</html>");
+  });
+
+  it("passes only the first name to the email builder", async () => {
+    await POST(makeRequest({ token: "secret", name: "Alice Smith" }));
+    expect(mocks.buildPastClientReviewEmailHtml).toHaveBeenCalledWith("Alice", "#preview");
+  });
+
+  it("uses the full value when name is a single word", async () => {
+    await POST(makeRequest({ token: "secret", name: "Bob" }));
+    expect(mocks.buildPastClientReviewEmailHtml).toHaveBeenCalledWith("Bob", "#preview");
+  });
+
+  it("returns 500 when json parsing throws", async () => {
+    const badReq = {
+      json: async () => {
+        throw new Error("parse error");
+      },
+    } as unknown as NextRequest;
+    const res = await POST(badReq);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/failed to generate preview/i);
+  });
+});

--- a/tests/api/reviews.post.test.ts
+++ b/tests/api/reviews.post.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   bookingUpdate: vi.fn(),
   reviewRequestFindFirst: vi.fn(),
   reviewRequestUpdate: vi.fn(),
+  contactFindFirst: vi.fn(),
   contactFindUnique: vi.fn(),
   revalidatePath: vi.fn(),
   sendOwnerReviewNotification: vi.fn(),
@@ -23,7 +24,7 @@ vi.mock("@/shared/lib/prisma", () => ({
       findFirst: mocks.reviewRequestFindFirst,
       update: mocks.reviewRequestUpdate,
     },
-    contact: { findUnique: mocks.contactFindUnique },
+    contact: { findFirst: mocks.contactFindFirst, findUnique: mocks.contactFindUnique },
   },
 }));
 
@@ -60,6 +61,7 @@ describe("POST /api/reviews", () => {
     });
     mocks.bookingFindFirst.mockResolvedValue(null);
     mocks.reviewRequestFindFirst.mockResolvedValue(null);
+    mocks.contactFindFirst.mockResolvedValue(null);
     mocks.contactFindUnique.mockResolvedValue(null);
     mocks.sendOwnerReviewNotification.mockResolvedValue(undefined);
   });
@@ -167,5 +169,158 @@ describe("POST /api/reviews", () => {
     await POST(req);
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/reviews");
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/review");
+  });
+
+  it("marks review as verified via reviewRequestId and reviewToken", async () => {
+    mocks.reviewRequestFindFirst.mockResolvedValue({
+      id: "rr-1",
+      reviewToken: "rr-token",
+      email: "eve@example.com",
+      phone: null,
+    });
+    mocks.reviewRequestUpdate.mockResolvedValue({});
+    mocks.reviewCreate.mockResolvedValue({
+      id: "review-rr",
+      text: "Fantastic service from start!",
+      verified: true,
+      status: "pending",
+    });
+    const req = makeRequest({
+      text: "Fantastic service from start!",
+      firstName: "Eve",
+      reviewRequestId: "rr-1",
+      reviewToken: "rr-token",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.verified).toBe(true);
+  });
+
+  it("stores contactEmail and contactPhone from body when reviewRequest lacks them", async () => {
+    mocks.reviewRequestFindFirst.mockResolvedValue({
+      id: "rr-2",
+      reviewToken: "rr-token-2",
+      email: null,
+      phone: null,
+    });
+    mocks.reviewRequestUpdate.mockResolvedValue({});
+    mocks.reviewCreate.mockResolvedValue({
+      id: "review-rr2",
+      text: "Really happy with the outcome!",
+      verified: true,
+      status: "pending",
+    });
+    const req = makeRequest({
+      text: "Really happy with the outcome!",
+      firstName: "Frank",
+      reviewRequestId: "rr-2",
+      reviewToken: "rr-token-2",
+      contactEmail: "frank@example.com",
+      contactPhone: "021 555 6666",
+    });
+    await POST(req);
+    expect(mocks.reviewRequestUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ email: "frank@example.com" }),
+      }),
+    );
+  });
+
+  it("auto-links review to contact by booking email", async () => {
+    mocks.bookingFindFirst.mockResolvedValue({
+      id: "booking-link",
+      reviewToken: "link-token",
+      email: "grace@example.com",
+    });
+    mocks.bookingUpdate.mockResolvedValue({});
+    mocks.contactFindFirst.mockResolvedValue({ id: "contact-grace" });
+    mocks.reviewCreate.mockResolvedValue({
+      id: "review-linked",
+      text: "Smooth and professional experience!",
+      verified: true,
+      status: "pending",
+    });
+    const req = makeRequest({
+      text: "Smooth and professional experience!",
+      firstName: "Grace",
+      bookingId: "booking-link",
+      reviewToken: "link-token",
+    });
+    await POST(req);
+    expect(mocks.reviewCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ contactId: "contact-grace" }),
+      }),
+    );
+  });
+
+  it("auto-links review to contact by review request email", async () => {
+    mocks.reviewRequestFindFirst.mockResolvedValue({
+      id: "rr-link",
+      reviewToken: "rr-link-token",
+      email: "henry@example.com",
+      phone: null,
+    });
+    mocks.reviewRequestUpdate.mockResolvedValue({});
+    mocks.contactFindFirst.mockResolvedValue({ id: "contact-henry" });
+    mocks.reviewCreate.mockResolvedValue({
+      id: "review-rr-linked",
+      text: "Would highly recommend this service!",
+      verified: true,
+      status: "pending",
+    });
+    const req = makeRequest({
+      text: "Would highly recommend this service!",
+      firstName: "Henry",
+      reviewRequestId: "rr-link",
+      reviewToken: "rr-link-token",
+    });
+    await POST(req);
+    expect(mocks.reviewCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ contactId: "contact-henry" }),
+      }),
+    );
+  });
+
+  it("falls back to phone lookup when review request has no email match", async () => {
+    mocks.reviewRequestFindFirst.mockResolvedValue({
+      id: "rr-phone",
+      reviewToken: "rr-phone-token",
+      email: null,
+      phone: "021 777 8888",
+    });
+    mocks.reviewRequestUpdate.mockResolvedValue({});
+    // email is null on the review request so the email-lookup branch is skipped;
+    // only the phone-lookup findFirst is called
+    mocks.contactFindFirst.mockResolvedValue({ id: "contact-phone" });
+    mocks.reviewCreate.mockResolvedValue({
+      id: "review-phone",
+      text: "Absolutely brilliant work done here!",
+      verified: true,
+      status: "pending",
+    });
+    const req = makeRequest({
+      text: "Absolutely brilliant work done here!",
+      firstName: "Iris",
+      reviewRequestId: "rr-phone",
+      reviewToken: "rr-phone-token",
+    });
+    await POST(req);
+    expect(mocks.reviewCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ contactId: "contact-phone" }),
+      }),
+    );
+  });
+
+  it("returns 500 on unexpected database error", async () => {
+    mocks.reviewCreate.mockRejectedValue(new Error("DB crash"));
+    const req = makeRequest({ text: "Great service indeed!", firstName: "Jane" });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/failed to submit review/i);
   });
 });

--- a/tests/lib/auto-maintain.test.ts
+++ b/tests/lib/auto-maintain.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi } from "vitest";
+import { autoMaintain } from "@/features/admin/lib/auto-maintain";
+import type { PrismaClient } from "@prisma/client";
+
+// autoMaintain(prisma) calls three internal phases sequentially:
+//   1. backfillContacts  — creates Contact records from Bookings/ReviewRequests
+//   2. matchReviewContacts — links unlinked Reviews to Contacts
+//   3. autoEnrich — fills missing fields and returns conflict entries
+
+/**
+ * Creates a minimal Prisma mock pre-seeded with test data for all three autoMaintain phases.
+ * @param root0 - Seed data options.
+ * @param root0.bookings - Booking records to return from findMany.
+ * @param root0.reviewRequests - ReviewRequest records to return from findMany.
+ * @param root0.contacts - Contact records to return from findMany.
+ * @param root0.reviews - Review records to return from findMany.
+ * @returns Typed Prisma mock.
+ */
+function makePrisma({
+  bookings = [] as unknown[],
+  reviewRequests = [] as unknown[],
+  contacts = [] as unknown[],
+  reviews = [] as unknown[],
+} = {}) {
+  return {
+    booking: { findMany: vi.fn().mockResolvedValue(bookings) },
+    reviewRequest: { findMany: vi.fn().mockResolvedValue(reviewRequests) },
+    contact: {
+      findMany: vi.fn().mockResolvedValue(contacts),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    review: {
+      findMany: vi.fn().mockResolvedValue(reviews),
+      update: vi.fn().mockResolvedValue({}),
+      updateMany: vi.fn().mockResolvedValue({}),
+    },
+  } as unknown as PrismaClient;
+}
+
+/**
+ * Returns the vi.fn() mock for a given model method on a Prisma mock instance.
+ * @param prisma - The Prisma mock created by makePrisma.
+ * @param model - The Prisma model name (e.g. "contact").
+ * @param method - The method name (e.g. "create").
+ * @returns The Vitest mock function.
+ */
+function m(prisma: PrismaClient, model: string, method: string) {
+  return (prisma as any)[model][method] as ReturnType<typeof vi.fn>;
+}
+
+describe("autoMaintain", () => {
+  // ─── backfillContacts ───────────────────────────────────────────────────────
+
+  it("returns empty conflicts when the database is empty", async () => {
+    const prisma = makePrisma();
+    const conflicts = await autoMaintain(prisma);
+    expect(conflicts).toEqual([]);
+    expect(m(prisma, "contact", "create")).not.toHaveBeenCalled();
+  });
+
+  it("creates a contact from a new booking email", async () => {
+    const prisma = makePrisma({
+      bookings: [{ name: "Alice Smith", email: "alice@example.com", phone: null, notes: null }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "create")).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ name: "Alice Smith", email: "alice@example.com" }),
+      }),
+    );
+  });
+
+  it("extracts address from booking notes when creating a contact", async () => {
+    const prisma = makePrisma({
+      bookings: [
+        {
+          name: "Bob",
+          email: "bob@example.com",
+          phone: null,
+          notes: "Fix printer\nAddress: 12 High St",
+        },
+      ],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "create")).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ address: "12 High St" }),
+      }),
+    );
+  });
+
+  it("skips creating a contact when the email already exists", async () => {
+    const prisma = makePrisma({
+      bookings: [{ name: "Alice", email: "alice@example.com", phone: null, notes: null }],
+      contacts: [{ id: "c1", name: "Alice", email: "alice@example.com", phone: null }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "create")).not.toHaveBeenCalled();
+  });
+
+  it("creates a contact from a review request email", async () => {
+    const prisma = makePrisma({
+      reviewRequests: [{ name: "Carol", email: "carol@example.com", phone: null }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "create")).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ email: "carol@example.com" }),
+      }),
+    );
+  });
+
+  it("creates a phone-only contact from a review request with no email", async () => {
+    const prisma = makePrisma({
+      reviewRequests: [{ name: "Dan", email: null, phone: "021 111 2222" }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "create")).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ email: null, phone: "+64211112222" }),
+      }),
+    );
+  });
+
+  it("merges a phone-only contact into the email-based contact sharing the same phone", async () => {
+    const prisma = makePrisma({
+      contacts: [
+        { id: "c-email", name: "Eve", email: "eve@example.com", phone: "+64211112222" },
+        { id: "c-phone", name: "Eve", email: null, phone: "+64211112222" },
+      ],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "review", "updateMany")).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { contactId: "c-phone" },
+        data: { contactId: "c-email" },
+      }),
+    );
+    expect(m(prisma, "contact", "delete")).toHaveBeenCalledWith({ where: { id: "c-phone" } });
+  });
+
+  it("merges booking email into an existing phone-only contact with the same phone", async () => {
+    const prisma = makePrisma({
+      bookings: [
+        { name: "Alice Smith", email: "alice@example.com", phone: "021 111 2222", notes: null },
+      ],
+      contacts: [{ id: "c-phone", name: "Alice", email: null, phone: "+64211112222" }],
+    });
+    await autoMaintain(prisma);
+    // Should update the phone-only contact with the email instead of creating a new one
+    expect(m(prisma, "contact", "update")).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "c-phone" },
+        data: expect.objectContaining({ email: "alice@example.com" }),
+      }),
+    );
+    expect(m(prisma, "contact", "create")).not.toHaveBeenCalled();
+  });
+
+  // ─── matchReviewContacts ────────────────────────────────────────────────────
+
+  it("links an unlinked review to a contact by booking email", async () => {
+    const prisma = makePrisma({
+      bookings: [{ id: "b1", name: "Alice", email: "alice@example.com", phone: null, notes: null }],
+      contacts: [
+        { id: "c1", name: "Alice", email: "alice@example.com", phone: null, address: null },
+      ],
+      reviews: [{ id: "r1", bookingId: "b1", customerRef: null }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "review", "update")).toHaveBeenCalledWith({
+      where: { id: "r1" },
+      data: { contactId: "c1" },
+    });
+  });
+
+  it("links an unlinked review to a contact by booking phone when email has no match", async () => {
+    const prisma = makePrisma({
+      bookings: [
+        { id: "b1", name: "Frank", email: "frank@example.com", phone: "021 111 2222", notes: null },
+      ],
+      contacts: [{ id: "c1", name: "Frank", email: null, phone: "+64211112222", address: null }],
+      reviews: [{ id: "r1", bookingId: "b1", customerRef: null }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "review", "update")).toHaveBeenCalledWith({
+      where: { id: "r1" },
+      data: { contactId: "c1" },
+    });
+  });
+
+  it("links an unlinked review to a contact by review request token and email", async () => {
+    const prisma = makePrisma({
+      reviewRequests: [
+        { id: "rr1", reviewToken: "tok1", name: "Grace", email: "grace@example.com", phone: null },
+      ],
+      contacts: [
+        { id: "c1", name: "Grace", email: "grace@example.com", phone: null, address: null },
+      ],
+      reviews: [{ id: "r1", bookingId: null, customerRef: "tok1" }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "review", "update")).toHaveBeenCalledWith({
+      where: { id: "r1" },
+      data: { contactId: "c1" },
+    });
+  });
+
+  it("does not update a review when no matching contact is found", async () => {
+    const prisma = makePrisma({
+      reviews: [{ id: "r1", bookingId: null, customerRef: "unknown-token" }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "review", "update")).not.toHaveBeenCalled();
+  });
+
+  // ─── autoEnrich ─────────────────────────────────────────────────────────────
+
+  it("fills a missing phone on a contact from a review request", async () => {
+    const prisma = makePrisma({
+      reviewRequests: [
+        { id: "rr1", name: "Heidi", email: "heidi@example.com", phone: "021 111 2222" },
+      ],
+      contacts: [
+        { id: "c1", name: "Heidi", email: "heidi@example.com", phone: null, address: null },
+      ],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "update")).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "c1" }, data: { phone: "+64211112222" } }),
+    );
+  });
+
+  it("fills a missing phone on a contact from a booking", async () => {
+    const prisma = makePrisma({
+      bookings: [
+        { id: "b1", name: "Ivan", email: "ivan@example.com", phone: "021 333 4444", notes: null },
+      ],
+      contacts: [{ id: "c1", name: "Ivan", email: "ivan@example.com", phone: null, address: null }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "update")).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "c1" }, data: { phone: "+64213334444" } }),
+    );
+  });
+
+  it("fills a missing address on a contact from a booking", async () => {
+    const prisma = makePrisma({
+      bookings: [
+        {
+          id: "b1",
+          name: "Jane",
+          email: "jane@example.com",
+          phone: null,
+          notes: "Address: 5 Oak Ave",
+        },
+      ],
+      contacts: [{ id: "c1", name: "Jane", email: "jane@example.com", phone: null, address: null }],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "update")).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "c1" }, data: { address: "5 Oak Ave" } }),
+    );
+  });
+
+  it("auto-fills name when source provides a full name and contact has only a first name", async () => {
+    const prisma = makePrisma({
+      reviewRequests: [{ id: "rr1", name: "Alice Smith", email: "alice@example.com", phone: null }],
+      contacts: [
+        { id: "c1", name: "Alice", email: "alice@example.com", phone: null, address: null },
+      ],
+    });
+    await autoMaintain(prisma);
+    expect(m(prisma, "contact", "update")).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "c1" }, data: { name: "Alice Smith" } }),
+    );
+  });
+
+  it("reports a name conflict when review request name differs from contact name", async () => {
+    const prisma = makePrisma({
+      reviewRequests: [{ id: "rr1", name: "Alice Jones", email: "alice@example.com", phone: null }],
+      contacts: [
+        { id: "c1", name: "Alice Smith", email: "alice@example.com", phone: null, address: null },
+      ],
+    });
+    const conflicts = await autoMaintain(prisma);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({
+      contactId: "c1",
+      source: "ReviewRequest",
+      conflictFields: expect.arrayContaining(["name"]),
+    });
+  });
+
+  it("reports a phone conflict when booking phone differs from contact phone", async () => {
+    const prisma = makePrisma({
+      bookings: [
+        { id: "b1", name: "Bob", email: "bob@example.com", phone: "021 333 4444", notes: null },
+      ],
+      contacts: [
+        { id: "c1", name: "Bob", email: "bob@example.com", phone: "+64211112222", address: null },
+      ],
+    });
+    const conflicts = await autoMaintain(prisma);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({
+      contactId: "c1",
+      source: "Booking",
+      conflictFields: expect.arrayContaining(["phone"]),
+    });
+  });
+
+  it("does not report a conflict when proposed name is a prefix of the contact full name", async () => {
+    // "Alice" proposed vs "Alice Smith" on contact → no conflict (contact is the longer name)
+    const prisma = makePrisma({
+      reviewRequests: [{ id: "rr1", name: "Alice", email: "alice@example.com", phone: null }],
+      contacts: [
+        { id: "c1", name: "Alice Smith", email: "alice@example.com", phone: null, address: null },
+      ],
+    });
+    const conflicts = await autoMaintain(prisma);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it("does not report a conflict when names match exactly", async () => {
+    const prisma = makePrisma({
+      bookings: [{ id: "b1", name: "Bob", email: "bob@example.com", phone: null, notes: null }],
+      contacts: [{ id: "c1", name: "Bob", email: "bob@example.com", phone: null, address: null }],
+    });
+    const conflicts = await autoMaintain(prisma);
+    expect(conflicts).toHaveLength(0);
+  });
+});

--- a/tests/lib/cn.test.ts
+++ b/tests/lib/cn.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "@/shared/lib/cn";
+
+describe("cn", () => {
+  it("returns empty string with no arguments", () => {
+    expect(cn()).toBe("");
+  });
+
+  it("returns a single class unchanged", () => {
+    expect(cn("foo")).toBe("foo");
+  });
+
+  it("joins multiple classes with a space", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("ignores falsy values", () => {
+    expect(cn("a", false, null, undefined, "b")).toBe("a b");
+  });
+
+  it("resolves Tailwind conflicts keeping the last class", () => {
+    expect(cn("p-4", "p-8")).toBe("p-8");
+  });
+
+  it("handles conditional object syntax", () => {
+    expect(cn({ "text-red-500": true, "text-blue-500": false })).toBe("text-red-500");
+  });
+});


### PR DESCRIPTION
## Summary

- Update pricing page and FAQ to show two-tier rates: $50/h for most jobs, $75/h for complex or lengthy work (data recovery, hardware repairs, full PC migrations)
- Add `force-dynamic` to `/booking/edit` page (was prerendering with Prisma calls at build time)
- Guard booking validation against past time slots
- Skip build step for Dependabot PRs in CI (no DB access in that context, lint and tests still run)
- Fix smoke test to load `.env.local` via dotenv-cli so the standalone server gets `MONGODB_URI` at runtime

## Test plan

- [ ] Pricing page shows two rate cards side by side
- [ ] FAQ "How much does it cost?" answer reflects new tiers
- [ ] Booking page loads and shows availability
- [ ] Dependabot CI passes (build step skipped, lint/tests run)
- [ ] Smoke test passes locally