### PR TITLE
style: replace em dashes with plain hyphens

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,15 +137,15 @@ model TravelBlock {
   sourceEventId    String
   calendarEmail    String
   summary          String?   // Google Calendar event title (e.g. "Dentist", "Mario Movie")
-  eventStartAt     DateTime  // Source event start — used to detect time changes
-  eventEndAt       DateTime  // Source event end — used to detect time changes
+  eventStartAt     DateTime  // Source event start - used to detect time changes
+  eventEndAt       DateTime  // Source event end - used to detect time changes
   rawTravelMinutes     Int?    // Raw travel-to time from Distance Matrix API
   roundedMinutes       Int?    // Rounded travel-to value used for block window
   rawTravelBackMinutes Int?    // Raw return-trip travel time
   roundedBackMinutes   Int?    // Rounded return-trip value used for block window
   beforeEventId        String? // Synthetic CalendarEventCache ID blocking travel-to
   afterEventId         String? // Synthetic CalendarEventCache ID blocking travel-back
-  transportMode        String? // "transit" | "driving" | "walking" | "bicycling" — null treated as "transit"
+  transportMode        String? // "transit" | "driving" | "walking" | "bicycling" - null treated as "transit"
   customOrigin         String? // Manual override for travel-to origin address
   detectedOrigin       String? // Auto-detected origin from preceding event or home address
   createdAt        DateTime  @default(now())

--- a/scripts/reauth-google.ts
+++ b/scripts/reauth-google.ts
@@ -101,7 +101,7 @@ async function authorise(
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
 console.log("\n=== Google OAuth Re-authorisation (dev + prod) ===");
-console.log("You will authorise twice — once for dev, once for prod.");
+console.log("You will authorise twice - once for dev, once for prod.");
 console.log("Make sure both redirect URIs are registered in Google Cloud Console.\n");
 
 (async () => {

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -46,7 +46,7 @@ const PAGES: PageSpec[] = [
   {
     path: "/booking/cancel",
     name: "Booking Cancel (no token)",
-    // Client fires cancel API immediately — no-token 400 is expected
+    // Client fires cancel API immediately - no-token 400 is expected
     ignoreErrors: ["Missing cancel token", "Could not cancel"],
   },
   { path: "/booking/success", name: "Booking Success (no token)" },
@@ -65,7 +65,7 @@ const PAGES: PageSpec[] = [
 /** Warn (but don't fail) when TTFB exceeds this on a local production server. */
 const TTFB_WARN_MS = 1_500;
 
-/** Fail when TTFB exceeds this — something is clearly broken. */
+/** Fail when TTFB exceeds this - something is clearly broken. */
 const TTFB_FAIL_MS = 10_000;
 
 /**
@@ -104,7 +104,7 @@ function runBuild(): void {
 
 /**
  * Copies static assets and native modules into the standalone output directory.
- * Next.js standalone only bundles server JS — static files, public assets, and
+ * Next.js standalone only bundles server JS - static files, public assets, and
  * platform-specific native binaries (e.g. sharp) must be copied manually.
  */
 function copyStandaloneAssets(): void {
@@ -258,7 +258,7 @@ async function checkPage(browser: Browser, baseUrl: string, spec: PageSpec): Pro
  * @returns Formatted string.
  */
 function fmtMs(ms: number | null): string {
-  if (ms === null) return "  —  ";
+  if (ms === null) return "  -  ";
   const s = `${ms}ms`.padStart(7);
   return ms > TTFB_WARN_MS ? `${s} ⚠` : s;
 }
@@ -337,7 +337,7 @@ function printTable(results: PageResult[]): void {
       const result = await checkPage(browser, baseUrl, spec);
       results.push(result);
       const icon = result.status === "pass" ? "✓" : "✗";
-      process.stdout.write(`\r  ${icon} ${spec.path.padEnd(40)} ${result.ttfbMs ?? "—"}ms TTFB\n`);
+      process.stdout.write(`\r  ${icon} ${spec.path.padEnd(40)} ${result.ttfbMs ?? "-"}ms TTFB\n`);
     }
 
     printTable(results);
@@ -356,7 +356,7 @@ function printTable(results: PageResult[]): void {
   } finally {
     await browser?.close();
     if (server?.pid) {
-      // On Windows, SIGTERM doesn't propagate to child processes — use taskkill to
+      // On Windows, SIGTERM doesn't propagate to child processes - use taskkill to
       // kill the whole process tree so the Prisma DLL is released before npm can update it.
       try {
         execSync(`taskkill //F //T //PID ${server.pid}`, { stdio: "ignore" });

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -14,7 +14,7 @@ import {
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Calendar — Admin",
+  title: "Calendar - Admin",
   robots: { index: false, follow: false },
 };
 

--- a/src/app/admin/contacts/page.tsx
+++ b/src/app/admin/contacts/page.tsx
@@ -12,7 +12,7 @@ import { autoMaintain } from "@/features/admin/lib/auto-maintain";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Contacts — Admin",
+  title: "Contacts - Admin",
   robots: { index: false, follow: false },
 };
 

--- a/src/app/admin/reviews/page.tsx
+++ b/src/app/admin/reviews/page.tsx
@@ -14,7 +14,7 @@ import { SendReviewLinkForm } from "@/features/reviews/components/admin/SendRevi
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Reviews — Admin",
+  title: "Reviews - Admin",
   robots: { index: false, follow: false },
 };
 

--- a/src/app/admin/travel/page.tsx
+++ b/src/app/admin/travel/page.tsx
@@ -15,7 +15,7 @@ import { RecalculateButton } from "@/features/admin/components/RecalculateButton
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Travel — Admin",
+  title: "Travel - Admin",
   robots: { index: false, follow: false },
 };
 

--- a/src/app/api/admin/contacts/[id]/route.ts
+++ b/src/app/api/admin/contacts/[id]/route.ts
@@ -72,7 +72,7 @@ export async function PATCH(
     select: { id: true, name: true, email: true, phone: true, address: true },
   });
 
-  // Best-effort Google Contacts sync — never fail the request if it errors.
+  // Best-effort Google Contacts sync - never fail the request if it errors.
   try {
     await syncContactToGoogle(id);
   } catch (syncError) {

--- a/src/app/api/admin/contacts/[id]/sync-google/route.ts
+++ b/src/app/api/admin/contacts/[id]/sync-google/route.ts
@@ -11,7 +11,7 @@ import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
 /**
  * POST /api/admin/contacts/[id]/sync-google
  * Syncs the specified contact to Google Contacts.
- * Never throws — all errors are captured and returned as { ok: false, error }.
+ * Never throws - all errors are captured and returned as { ok: false, error }.
  * Requires X-Admin-Secret header.
  * @param request - Incoming request.
  * @param params - Route segment params wrapper.

--- a/src/app/api/admin/contacts/backfill/route.ts
+++ b/src/app/api/admin/contacts/backfill/route.ts
@@ -27,7 +27,7 @@ function parseNotes(notes: string | null): { phone: string | null; address: stri
  * POST /api/admin/contacts/backfill
  * Scans all Bookings and ReviewRequests, and upserts a Contact for each unique email.
  * For each email, the most recent Booking or ReviewRequest is used as the source of truth.
- * Existing contacts are never overwritten — admin edits take precedence.
+ * Existing contacts are never overwritten - admin edits take precedence.
  * Requires X-Admin-Secret header.
  * @param request - Incoming request.
  * @returns JSON with upserted count.
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   >();
   const mergedByPhone = new Map<string, { name: string; email: null; phone: string }>();
 
-  // 1. Bookings (sorted ascending — most recent wins the Map)
+  // 1. Bookings (sorted ascending - most recent wins the Map)
   const bookings = await prisma.booking.findMany({
     orderBy: { createdAt: "asc" },
     select: { name: true, email: true, notes: true },
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     mergedByEmail.set(b.email.toLowerCase(), { name: b.name, email: b.email, phone, address });
   }
 
-  // 2. ReviewRequests — email-based and phone-only (sorted ascending — most recent wins)
+  // 2. ReviewRequests - email-based and phone-only (sorted ascending - most recent wins)
   const reviewRequests = await prisma.reviewRequest.findMany({
     orderBy: { createdAt: "asc" },
     select: { name: true, email: true, phone: true },

--- a/src/app/api/admin/contacts/enrich-from-reviews/route.ts
+++ b/src/app/api/admin/contacts/enrich-from-reviews/route.ts
@@ -139,7 +139,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (!contact || seenRev.has(contact.id)) continue;
     seenRev.add(contact.id);
 
-    // If the review has no last name, don't flag a name conflict — the reviewer's
+    // If the review has no last name, don't flag a name conflict - the reviewer's
     // choice of display name (first name only) is not a suggestion to drop the
     // contact's last name.
     if (!review.lastName) continue;

--- a/src/app/api/admin/contacts/export/route.ts
+++ b/src/app/api/admin/contacts/export/route.ts
@@ -102,7 +102,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       csvCell(""), // Birthday
       csvCell(""), // Notes
       csvCell(""), // Photo
-      csvCell("* myContacts"), // Labels — places contact in the My Contacts group
+      csvCell("* myContacts"), // Labels - places contact in the My Contacts group
       csvCell(c.email ? "* " : ""), // E-mail 1 - Label (* = primary)
       csvCell(c.email), // E-mail 1 - Value
       csvCell(""), // Phone 1 - Label

--- a/src/app/api/admin/contacts/resolve-conflict/route.ts
+++ b/src/app/api/admin/contacts/resolve-conflict/route.ts
@@ -15,7 +15,7 @@ interface ResolveBody {
   contactId: string;
   /** Source record ID to write back to. */
   sourceId: string;
-  /** Source type — determines which table to update. */
+  /** Source type - determines which table to update. */
   source: "ReviewRequest" | "Booking" | "Review";
   /** Fields and their chosen values. */
   name?: string;
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         await prisma.booking.update({ where: { id: sourceId }, data: bookingUpdate });
       }
     } else if (source === "Review") {
-      // Reviews store name as firstName/lastName — only name conflicts arise from Reviews.
+      // Reviews store name as firstName/lastName - only name conflicts arise from Reviews.
       if (name !== undefined) {
         const parts = name.trim().split(/\s+/);
         const firstName = parts.slice(0, -1).join(" ") || parts[0] || null;

--- a/src/app/api/admin/review-requests/route.ts
+++ b/src/app/api/admin/review-requests/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
 
     /**
-     * Upserts a Contact for a given email — best effort, never blocks the response.
+     * Upserts a Contact for a given email - best effort, never blocks the response.
      * @param contactEmail - Normalised email address.
      * @param contactName - Contact name from the ReviewRequest.
      */

--- a/src/app/api/admin/reviews/match-contacts/route.ts
+++ b/src/app/api/admin/reviews/match-contacts/route.ts
@@ -94,7 +94,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           if (phone) contactId = contactIdByPhone.get(phone);
         }
       } else if (review.customerRef) {
-        // customerRef is a reviewToken UUID — look it up via ReviewRequest
+        // customerRef is a reviewToken UUID - look it up via ReviewRequest
         const email = rrEmailByToken.get(review.customerRef);
         if (email) contactId = contactIdByEmail.get(email);
         if (!contactId) {

--- a/src/app/api/admin/send-review-link/route.ts
+++ b/src/app/api/admin/send-review-link/route.ts
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       },
     });
 
-    // Upsert a Contact record — best effort, never blocks.
+    // Upsert a Contact record - best effort, never blocks.
     if (mode === "email" && reviewRequest.email) {
       try {
         const exists = await prisma.contact.findFirst({ where: { email: reviewRequest.email } });

--- a/src/app/api/booking/contact-lookup/route.ts
+++ b/src/app/api/booking/contact-lookup/route.ts
@@ -10,7 +10,7 @@ import { prisma } from "@/shared/lib/prisma";
 /**
  * GET /api/booking/contact-lookup?email=<email>
  * Returns name, phone, and address for a known contact email.
- * Returns 404 (ok: false) if not found — never exposes other contact fields.
+ * Returns 404 (ok: false) if not found - never exposes other contact fields.
  * @param request - Incoming request.
  * @returns JSON with contact fields or not-found response.
  */

--- a/src/app/api/booking/request/route.ts
+++ b/src/app/api/booking/request/route.ts
@@ -260,7 +260,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           });
         }
         const contact = existing;
-        // Best-effort sync to Google Contacts — never fail the booking if it errors.
+        // Best-effort sync to Google Contacts - never fail the booking if it errors.
         await syncContactToGoogle(contact.id);
       } catch (contactError) {
         console.error("[booking/request] Failed to upsert contact:", contactError);

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -104,7 +104,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         verified = true;
         bookingId = booking.id;
         customerRef = booking.reviewToken;
-        // Auto-link to Contact by booking email — best effort, never fails the submission.
+        // Auto-link to Contact by booking email - best effort, never fails the submission.
         try {
           const contact = await prisma.contact.findFirst({
             where: { email: booking.email.toLowerCase() },

--- a/src/app/booking/cancel/page.tsx
+++ b/src/app/booking/cancel/page.tsx
@@ -1,7 +1,7 @@
 // src/app/booking/cancel/page.tsx
 /**
  * @file page.tsx
- * @description Booking cancel page. Statically rendered shell — token is read
+ * @description Booking cancel page. Statically rendered shell - token is read
  * client-side via useSearchParams, so this page has no server-side dependencies.
  */
 

--- a/src/app/booking/edit/page.tsx
+++ b/src/app/booking/edit/page.tsx
@@ -181,7 +181,7 @@ export default async function EditBookingPage({
   const nzHour = getNZHour(booking.startAt);
   const matchedSlot = TIME_OF_DAY_OPTIONS.find((t) => t.startHour === nzHour);
   const timeOfDay: TimeOfDay = (matchedSlot?.value ?? "10am") as TimeOfDay;
-  // Minutes are timezone-independent — preserve the sub-slot offset
+  // Minutes are timezone-independent - preserve the sub-slot offset
   const startMinute = (booking.startAt.getUTCMinutes() as StartMinute) ?? 0;
 
   const { userNotes, meetingType, address, phone } = parseBookingNotes(booking.notes);

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -17,7 +17,7 @@ const MESSAGES = [
   "Something broke. Which is ironic, given that fixing broken things is literally my job.",
   "The website has done the digital equivalent of tripping over nothing.",
   "An error occurred. No, turning your screen off and on won't help. But it won't hurt either.",
-  "Something went wrong — and unlike your printer, it's not out of paper.",
+  "Something went wrong - and unlike your printer, it's not out of paper.",
   "Well, this is embarrassing. The website is having a moment.",
   "The code gremlins struck again. I'll sort them out.",
   "This error is more unexpected than a Windows update at 8am.",

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -69,7 +69,7 @@ const faqItems: ReadonlyArray<FaqItem> = [
     answer: (
       <>
         <p>
-          $50/h for most jobs. $75/h for complex or lengthy work — data recovery, hardware repairs,
+          $50/h for most jobs. $75/h for complex or lengthy work - data recovery, hardware repairs,
           or full PC migrations. I'll confirm the rate before starting.
         </p>
         <p className={cn("text-rich-black/80 mt-2")}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,11 +24,11 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://tothepoint.co.nz";
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: {
-    default: "To The Point Tech — Local IT & Computer Support Auckland",
+    default: "To The Point Tech - Local IT & Computer Support Auckland",
     template: "%s | To The Point Tech",
   },
   description:
-    "Local IT & computer support in Auckland. Same-day, evening & weekend appointments available. No jargon — clear fixes for computers, Wi-Fi, phones, printers, and more.",
+    "Local IT & computer support in Auckland. Same-day, evening & weekend appointments available. No jargon - clear fixes for computers, Wi-Fi, phones, printers, and more.",
   applicationName: "To The Point Tech",
   authors: [{ name: "Harrison Raynes" }],
   alternates: {
@@ -141,7 +141,7 @@ export default function RootLayout({
     url: siteUrl,
     image: `${siteUrl}/og-1200x630.jpg`,
     description:
-      "Local IT & computer support in Auckland. Same-day, evening & weekend appointments. No jargon — clear fixes for computers, Wi-Fi, phones, printers, and more.",
+      "Local IT & computer support in Auckland. Same-day, evening & weekend appointments. No jargon - clear fixes for computers, Wi-Fi, phones, printers, and more.",
     telephone: "+64-21-297-1237",
     email: "harrison@tothepoint.co.nz",
     founder: { "@type": "Person", name: "Harrison Raynes" },

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -20,7 +20,7 @@ const MESSAGES = [
   "Page not found. It's probably hiding in the same place as your TV remote.",
   "This page crashed harder than a Windows update at the worst time.",
   "Last seen heading toward the recycle bin.",
-  "This page has gone the way of Internet Explorer — fondly remembered by no one.",
+  "This page has gone the way of Internet Explorer - fondly remembered by no one.",
   "Like Bluetooth headphones at 2%, this page has quietly given up.",
   "This URL is about as useful as a printer at 3am.",
   "This page has as many bars as your phone in the kitchen.",

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -49,7 +49,7 @@ export default function PricingPage(): React.ReactElement {
                   $50/h
                 </p>
                 <p className={cn("text-rich-black/80 text-sm sm:text-base")}>
-                  Most jobs — troubleshooting, setup, software, tune-ups, Wi-Fi, backups, and more.
+                  Most jobs - troubleshooting, setup, software, tune-ups, Wi-Fi, backups, and more.
                 </p>
               </div>
 
@@ -58,7 +58,7 @@ export default function PricingPage(): React.ReactElement {
                   $75/h
                 </p>
                 <p className={cn("text-rich-black/80 text-sm sm:text-base")}>
-                  Complex or lengthy work — data recovery, hardware repairs, or full PC migrations.
+                  Complex or lengthy work - data recovery, hardware repairs, or full PC migrations.
                 </p>
               </div>
             </div>
@@ -81,7 +81,7 @@ export default function PricingPage(): React.ReactElement {
               <p className={cn("text-rich-black/90 flex gap-3 text-sm sm:text-base")}>
                 <span className={cn("text-moonstone-600 mt-1 text-lg")}>✓</span>
                 <span>
-                  <strong>Not sure which rate applies?</strong> Just ask — I'll confirm before
+                  <strong>Not sure which rate applies?</strong> Just ask - I'll confirm before
                   starting.
                 </span>
               </p>

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/shared/components/Button";
 import { cn } from "@/shared/lib/cn";
 import { prisma } from "@/shared/lib/prisma";
 
-// This page reads searchParams so it is always dynamic — revalidate has no effect.
+// This page reads searchParams so it is always dynamic - revalidate has no effect.
 export const dynamic = "force-dynamic";
 
 /**
@@ -56,7 +56,7 @@ export default async function ReviewPage({
         where: { reviewToken: token },
         select: { id: true, name: true, email: true, phone: true, reviewSubmittedAt: true },
       }),
-      // Fetch speculatively — only used if the token maps to an already-reviewed source
+      // Fetch speculatively - only used if the token maps to an already-reviewed source
       prisma.review.findFirst({
         where: { customerRef: token },
         select: { id: true, text: true, firstName: true, lastName: true, isAnonymous: true },

--- a/src/features/admin/components/ContactAdminList.tsx
+++ b/src/features/admin/components/ContactAdminList.tsx
@@ -668,7 +668,7 @@ export function ContactAdminList({
         </a>
       </div>
 
-      {/* New contacts — added in the last 7 days */}
+      {/* New contacts - added in the last 7 days */}
       {newContacts.length > 0 && (
         <div className={cn("flex flex-col gap-3")}>
           <h3
@@ -691,7 +691,7 @@ export function ContactAdminList({
         </div>
       )}
 
-      {/* Unsynced contacts — shown prominently */}
+      {/* Unsynced contacts - shown prominently */}
       {unsynced.length > 0 ? (
         <div className={cn("flex flex-col gap-3")}>
           <h3 className={cn("text-russian-violet text-xs font-semibold uppercase tracking-wide")}>
@@ -705,7 +705,7 @@ export function ContactAdminList({
         <p className={cn("text-sm text-slate-400")}>All contacts are synced to Google.</p>
       )}
 
-      {/* Synced contacts — collapsible */}
+      {/* Synced contacts - collapsible */}
       {synced.length > 0 && (
         <div className={cn("flex flex-col gap-3")}>
           <button

--- a/src/features/admin/components/ContactsAdminView.tsx
+++ b/src/features/admin/components/ContactsAdminView.tsx
@@ -52,14 +52,14 @@ export function ContactsAdminView({
       };
       if (data.ok) {
         setSyncResult(
-          `Done — ${data.importedCount ?? 0} imported from Google, ${data.syncedCount ?? 0} pushed to Google.`,
+          `Done - ${data.importedCount ?? 0} imported from Google, ${data.syncedCount ?? 0} pushed to Google.`,
         );
         router.refresh();
       } else {
         setSyncResult(`Error: ${data.error ?? "unknown"}`);
       }
     } catch {
-      setSyncResult("Network error — try again.");
+      setSyncResult("Network error - try again.");
     } finally {
       setSyncing(false);
     }
@@ -141,7 +141,7 @@ export function ContactsAdminView({
                             "text-xs font-medium uppercase tracking-wide text-slate-400",
                           )}
                         >
-                          Name — pick one
+                          Name - pick one
                         </p>
                         <div className={cn("flex flex-wrap gap-2")}>
                           <button
@@ -174,7 +174,7 @@ export function ContactsAdminView({
                             "text-xs font-medium uppercase tracking-wide text-slate-400",
                           )}
                         >
-                          Phone — pick one
+                          Phone - pick one
                         </p>
                         <div className={cn("flex flex-wrap gap-2")}>
                           <button
@@ -185,7 +185,7 @@ export function ContactsAdminView({
                               "hover:border-russian-violet hover:text-russian-violet rounded border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-700 transition-colors",
                             )}
                           >
-                            {conflict.contactPhone ?? "—"}
+                            {conflict.contactPhone ?? "-"}
                           </button>
                           <button
                             onClick={() =>

--- a/src/features/admin/components/DashboardQuickActions.tsx
+++ b/src/features/admin/components/DashboardQuickActions.tsx
@@ -22,7 +22,7 @@ export interface PastBookingRow {
   id: string;
   /** Customer name */
   name: string;
-  /** Customer email — null for phone-only bookings */
+  /** Customer email - null for phone-only bookings */
   email: string | null;
   /** Start time as ISO string */
   startAt: string;
@@ -159,7 +159,7 @@ export function DashboardQuickActions({
             )}
           </h2>
           <p className={cn("mt-0.5 text-xs text-slate-400")}>
-            Past confirmed bookings — mark complete and send review
+            Past confirmed bookings - mark complete and send review
           </p>
         </div>
 

--- a/src/features/admin/components/RecalculateButton.tsx
+++ b/src/features/admin/components/RecalculateButton.tsx
@@ -30,13 +30,13 @@ export function RecalculateButton({ token }: RecalculateButtonProps): React.Reac
       });
       const data = (await res.json()) as { ok: boolean; cachedCount?: number; error?: string };
       if (data.ok) {
-        setResult(`Done — ${data.cachedCount ?? 0} events cached.`);
+        setResult(`Done - ${data.cachedCount ?? 0} events cached.`);
         router.refresh();
       } else {
         setResult(`Error: ${data.error ?? "unknown"}`);
       }
     } catch {
-      setResult("Network error — try again.");
+      setResult("Network error - try again.");
     } finally {
       setRecalculating(false);
     }

--- a/src/features/admin/components/TravelBlockAdminList.tsx
+++ b/src/features/admin/components/TravelBlockAdminList.tsx
@@ -245,7 +245,7 @@ export function TravelBlockAdminList({
                 {(b.rawTravelMinutes === null || b.rawTravelBackMinutes === null) &&
                   b.transportMode !== null && (
                     <p className={cn("mt-1 text-xs text-amber-500")}>
-                      Mode changed — recalculate to update travel times
+                      Mode changed - recalculate to update travel times
                     </p>
                   )}
               </div>
@@ -338,7 +338,7 @@ export function TravelBlockAdminList({
                 {(b.rawTravelMinutes === null || b.rawTravelBackMinutes === null) &&
                   b.customOrigin !== null && (
                     <p className={cn("mt-1 text-xs text-amber-500")}>
-                      Origin changed — recalculate to update travel times
+                      Origin changed - recalculate to update travel times
                     </p>
                   )}
               </div>

--- a/src/features/admin/lib/auto-maintain.ts
+++ b/src/features/admin/lib/auto-maintain.ts
@@ -28,7 +28,7 @@ export async function autoMaintain(prisma: PrismaClient): Promise<ConflictEntry[
  * Creates a Contact for every unique email found in Booking or ReviewRequest records
  * that does not already have a corresponding Contact.
  * Also merges phone-only contacts into their email-based counterpart when both share
- * the same phone number. Existing contacts are never overwritten otherwise —
+ * the same phone number. Existing contacts are never overwritten otherwise -
  * admin edits are the source of truth.
  * @param prisma - Prisma client instance.
  */
@@ -85,7 +85,7 @@ async function backfillContacts(prisma: PrismaClient): Promise<void> {
   const existingPhones = new Set(
     existing.filter((c) => c.phone).map((c) => normalizePhone(toE164NZ(c.phone!) || c.phone!)),
   );
-  // Remaining phone-only contacts (post-merge) — used to merge-on-create below
+  // Remaining phone-only contacts (post-merge) - used to merge-on-create below
   const phoneOnlyByNorm = new Map<string, (typeof existing)[number]>();
   for (const c of existing) {
     if (!c.email && c.phone) {
@@ -100,7 +100,7 @@ async function backfillContacts(prisma: PrismaClient): Promise<void> {
   >();
   const toCreateByPhone = new Map<string, { name: string; email: null; phone: string }>();
 
-  // Bookings sorted asc — most recent overwrites earlier entries in the Map
+  // Bookings sorted asc - most recent overwrites earlier entries in the Map
   for (const b of bookings) {
     const email = b.email.toLowerCase();
     if (existingEmails.has(email)) continue;
@@ -108,7 +108,7 @@ async function backfillContacts(prisma: PrismaClient): Promise<void> {
     toCreateByEmail.set(email, { name: b.name, email, phone: b.phone ?? null, address });
   }
 
-  // ReviewRequests sorted asc — email-based update existing map, phone-only go in separate map
+  // ReviewRequests sorted asc - email-based update existing map, phone-only go in separate map
   for (const rr of reviewRequests) {
     if (rr.email) {
       const email = rr.email.toLowerCase();
@@ -315,7 +315,7 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
   const nameUpdates = new Map<string, string>();
   const addressUpdates = new Map<string, string>();
 
-  // ReviewRequests — newest first per contact: fill phone, detect conflicts
+  // ReviewRequests - newest first per contact: fill phone, detect conflicts
   for (const rr of reviewRequests) {
     const contact = findContact(rr.email, rr.phone);
     if (!contact) continue;
@@ -347,7 +347,7 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
       const proposedName = proposedNameRR;
       const contactNameLower = contact.name.toLowerCase();
       const proposedNameLower = proposedName.toLowerCase();
-      // Only flag a name conflict when the proposed name is genuinely different —
+      // Only flag a name conflict when the proposed name is genuinely different -
       // not when it is simply the contact's first name without the last name.
       if (
         proposedName &&
@@ -377,7 +377,7 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
     }
   }
 
-  // Bookings — newest first per contact: fill phone + address, detect conflicts
+  // Bookings - newest first per contact: fill phone + address, detect conflicts
   for (const booking of bookings) {
     const contact = findContact(booking.email, booking.phone);
     if (!contact) continue;
@@ -415,7 +415,7 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
       const proposedName = proposedNameBooking;
       const contactNameLower = contact.name.toLowerCase();
       const proposedNameLower = proposedName.toLowerCase();
-      // Only flag a name conflict when the proposed name is genuinely different —
+      // Only flag a name conflict when the proposed name is genuinely different -
       // not when it is simply the contact's first name without the last name.
       if (
         proposedName &&

--- a/src/features/booking/components/AddressAutocomplete.tsx
+++ b/src/features/booking/components/AddressAutocomplete.tsx
@@ -69,7 +69,7 @@ export default function AddressAutocomplete({
 
     const apiKey = process.env.GOOGLE_MAPS_API_KEY;
     if (!apiKey) {
-      console.warn("GOOGLE_MAPS_API_KEY not set — address autocomplete disabled.");
+      console.warn("GOOGLE_MAPS_API_KEY not set - address autocomplete disabled.");
       const timer = setTimeout(() => setApiKeyMissing(true), 0);
       return () => clearTimeout(timer);
     }
@@ -195,7 +195,7 @@ export default function AddressAutocomplete({
           <span className={cn("mt-0.5")}>⚠️</span>
           <span>
             Address autocomplete unavailable. Please type your full address manually. (Failed to
-            load Google Maps — check Application restrictions in Google Cloud Console)
+            load Google Maps - check Application restrictions in Google Cloud Console)
           </span>
         </p>
       )}

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -114,7 +114,7 @@ export default function BookingForm({
         setContactHint(`Pre-filled from your previous booking: ${filled.join(", ")}.`);
       }
     } catch {
-      // Silently ignore — pre-fill is best-effort
+      // Silently ignore - pre-fill is best-effort
     }
   }
 
@@ -463,7 +463,7 @@ export default function BookingForm({
                   })}
                 </div>
 
-                {/* Sub-slot picker — shown once an hour is selected */}
+                {/* Sub-slot picker - shown once an hour is selected */}
                 {selectedTime &&
                   (() => {
                     const activeWindow = selectedDay.timeWindows.find(

--- a/src/features/booking/lib/booking.ts
+++ b/src/features/booking/lib/booking.ts
@@ -135,7 +135,7 @@ function isSlotFree(
 
   // Check calendar events.
   // Travel blocks (synthetic entries) already represent padding, so no additional
-  // buffer is applied to them — only real calendar events get the bufferMin gap.
+  // buffer is applied to them - only real calendar events get the bufferMin gap.
   for (const event of calendarEvents) {
     const isTravelBlock =
       event.id.startsWith("travel-before:") || event.id.startsWith("travel-after:");

--- a/src/features/calendar/lib/calendar-cache.ts
+++ b/src/features/calendar/lib/calendar-cache.ts
@@ -188,7 +188,7 @@ export async function refreshCalendarCache(): Promise<RefreshResult> {
     const eventStart = new Date(event.start);
     const eventEnd = new Date(event.end);
 
-    // Synthetic cache IDs — never written to Google Calendar
+    // Synthetic cache IDs - never written to Google Calendar
     const beforeId = `travel-before:${event.id}`;
     const afterId = `travel-after:${event.id}`;
 
@@ -220,7 +220,7 @@ export async function refreshCalendarCache(): Promise<RefreshResult> {
       const originChanged = effectiveOrigin !== existingEffectiveOrigin;
 
       if (eventTimesMatch && !originChanged) {
-        // null means the direction was never successfully calculated — treat as needing retry
+        // null means the direction was never successfully calculated - treat as needing retry
         const toOk =
           existing.rawTravelMinutes !== null &&
           Math.ceil(existing.rawTravelMinutes / 15) * 15 === (existing.roundedMinutes ?? -1);
@@ -233,7 +233,7 @@ export async function refreshCalendarCache(): Promise<RefreshResult> {
           if (isDev) console.log(`[travel] Skipping "${event.summary}" - unchanged`);
           needsRebuild = false;
         } else {
-          // Rounding formula changed or a direction was never calculated — reuse what we have
+          // Rounding formula changed or a direction was never calculated - reuse what we have
           reuseRawToMinutes = existing.rawTravelMinutes;
           reuseRawBackMinutes = existing.rawTravelBackMinutes;
           if (isDev)

--- a/src/features/calendar/lib/google-calendar.ts
+++ b/src/features/calendar/lib/google-calendar.ts
@@ -242,7 +242,7 @@ export async function fetchAllCalendarEvents(
 
   if (errorCount === calendarIds.length) {
     throw new Error(
-      `Failed to fetch events from all ${calendarIds.length} calendars — check API credentials`,
+      `Failed to fetch events from all ${calendarIds.length} calendars - check API credentials`,
     );
   }
 

--- a/src/features/calendar/lib/travel-time.ts
+++ b/src/features/calendar/lib/travel-time.ts
@@ -76,7 +76,7 @@ export async function calculateTravelMinutes(
   }
 
   const mode: TransportMode = options?.mode ?? "transit";
-  // Only apply the schedule-horizon proxy for transit — driving/walking/cycling don't need it
+  // Only apply the schedule-horizon proxy for transit - driving/walking/cycling don't need it
   const effectiveDeparture =
     mode === "transit" ? toReliableDeparture(departureTime, new Date()) : departureTime;
 

--- a/src/features/contacts/lib/google-contacts.ts
+++ b/src/features/contacts/lib/google-contacts.ts
@@ -81,7 +81,7 @@ export async function importFromGoogleContacts(): Promise<number> {
             if (existing) {
               await prisma.contact.update({
                 where: { id: existing.id },
-                // Local name/phone/address are the source of truth — only link the resource name.
+                // Local name/phone/address are the source of truth - only link the resource name.
                 data: { googleContactId: resourceName },
               });
             } else {
@@ -94,7 +94,7 @@ export async function importFromGoogleContacts(): Promise<number> {
             console.error(`[google-contacts] Failed to import contact ${email}:`, upsertError);
           }
         } else if (normPhone) {
-          // No email anywhere — create a phone-only contact or link to an existing one.
+          // No email anywhere - create a phone-only contact or link to an existing one.
           try {
             const existing = await prisma.contact.findFirst({
               where: { phone },
@@ -171,7 +171,7 @@ function splitName(fullName: string): { givenName: string; familyName: string } 
  * Creates or updates a contact in Google Contacts.
  * - If `googleContactId` is provided, updates the existing contact (fetching etag first).
  * - Otherwise searches by email; updates if found, creates if not.
- * Never throws — returns null on any error.
+ * Never throws - returns null on any error.
  * @param params - Contact data to sync.
  * @returns The Google People API resource name, or null on error.
  */
@@ -181,7 +181,7 @@ export async function upsertToGoogleContacts(params: UpsertContactParams): Promi
 
     const { givenName, familyName } = splitName(params.name);
 
-    // Full body used only when CREATING a new contact — includes the local name.
+    // Full body used only when CREATING a new contact - includes the local name.
     const createBody = {
       names: [{ displayName: params.name, givenName, familyName }],
       emailAddresses: [{ value: params.email }],
@@ -189,7 +189,7 @@ export async function upsertToGoogleContacts(params: UpsertContactParams): Promi
       ...(params.address ? { addresses: [{ formattedValue: params.address }] } : {}),
     };
 
-    // Base update fields — always sync email, phone, address.
+    // Base update fields - always sync email, phone, address.
     // `names` is added only when the existing Google contact has no name.
     const baseUpdateBody = {
       emailAddresses: [{ value: params.email }],
@@ -290,7 +290,7 @@ export async function upsertToGoogleContacts(params: UpsertContactParams): Promi
       console.error("[google-contacts] Search failed, will attempt create:", searchError);
     }
 
-    // Create a new contact — use the full body including name.
+    // Create a new contact - use the full body including name.
     const created = await people.people.createContact({
       requestBody: createBody,
     });
@@ -323,7 +323,7 @@ export async function syncAllContactsToGoogle(): Promise<number> {
 /**
  * Loads a contact from the local DB and syncs it to Google Contacts.
  * Updates `googleContactId` in the DB if it changed.
- * Never throws — all errors are logged and swallowed.
+ * Never throws - all errors are logged and swallowed.
  * @param contactId - The local DB contact ID to sync.
  * @returns Promise that resolves when the sync attempt is complete.
  */
@@ -337,7 +337,7 @@ export async function syncContactToGoogle(contactId: string): Promise<void> {
       return;
     }
     if (!contact.email) {
-      // Phone-only contacts have no email — they are imported FROM Google, not pushed to it.
+      // Phone-only contacts have no email - they are imported FROM Google, not pushed to it.
       return;
     }
 

--- a/src/features/reviews/components/admin/SendReviewLinkForm.tsx
+++ b/src/features/reviews/components/admin/SendReviewLinkForm.tsx
@@ -229,7 +229,7 @@ export function SendReviewLinkForm({
 
       {open && (
         <div className={cn("mt-4 flex flex-col gap-3")}>
-          {/* Contact picker — only shown when there are suggestions */}
+          {/* Contact picker - only shown when there are suggestions */}
           {contactSuggestions.length > 0 && (
             <div className={cn("flex flex-col gap-1")}>
               <label className={cn("text-xs font-medium text-slate-500")}>
@@ -254,7 +254,7 @@ export function SendReviewLinkForm({
                   "focus:ring-russian-violet/30 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-1",
                 )}
               >
-                <option value="">— select to pre-fill —</option>
+                <option value="">- select to pre-fill -</option>
                 {contactSuggestions
                   .filter((c) => {
                     const q = contactSearch.toLowerCase();
@@ -344,7 +344,7 @@ export function SendReviewLinkForm({
           {mode === "email" && previewHtml && (
             <div className={cn("flex flex-col gap-3")}>
               <p className={cn("text-xs font-semibold uppercase tracking-wide text-slate-500")}>
-                Preview — sending to {email}
+                Preview - sending to {email}
               </p>
               <iframe
                 srcDoc={previewHtml}

--- a/src/features/reviews/lib/email.ts
+++ b/src/features/reviews/lib/email.ts
@@ -6,7 +6,7 @@
 
 import { Resend } from "resend";
 
-// Lazy singleton — created on first use so module import never throws in test environments.
+// Lazy singleton - created on first use so module import never throws in test environments.
 let _resend: Resend | null = null;
 /**
  * Returns the shared Resend client, initialising it on first call.

--- a/tests/api/admin.contacts-enrich.test.ts
+++ b/tests/api/admin.contacts-enrich.test.ts
@@ -196,7 +196,7 @@ describe("POST /api/admin/contacts/enrich-from-reviews", () => {
   it("uses only the most recent ReviewRequest per contact (first in desc order)", async () => {
     mocks.contactFindMany.mockResolvedValue([CONTACT]);
     mocks.reviewRequestFindMany.mockResolvedValue([
-      // Most recent first — this one should win
+      // Most recent first - this one should win
       { id: "rr-new", name: "Alice S.", email: "alice@example.com", phone: null },
       { id: "rr-old", name: "A. Smith", email: "alice@example.com", phone: null },
     ]);
@@ -250,7 +250,7 @@ describe("POST /api/admin/contacts/enrich-from-reviews", () => {
     mocks.contactFindMany.mockResolvedValue([CONTACT]);
     mocks.reviewRequestFindMany.mockResolvedValue([]);
     mocks.reviewFindMany.mockResolvedValue([
-      // Reviewer chose to display only their first name — don't suggest dropping "Smith"
+      // Reviewer chose to display only their first name - don't suggest dropping "Smith"
       { id: "rev-1", firstName: "Alice", lastName: null, customerRef: "alice@example.com" },
     ]);
     const res = await POST(makeRequest());

--- a/tests/api/admin.reviews-id.test.ts
+++ b/tests/api/admin.reviews-id.test.ts
@@ -65,7 +65,7 @@ function makeDeleteRequest(token: string): NextRequest {
 
 const PARAMS = { params: Promise.resolve({ id: "review-123" }) };
 
-/** Default review stub with no source info — auto-link does nothing. */
+/** Default review stub with no source info - auto-link does nothing. */
 const NO_SOURCE_REVIEW = {
   bookingId: null,
   customerRef: null,
@@ -253,7 +253,7 @@ describe("PATCH /api/admin/reviews/[id]", () => {
   });
 });
 
-describe("PATCH /api/admin/reviews/[id] — contactId link flow", () => {
+describe("PATCH /api/admin/reviews/[id] - contactId link flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.isAdminRequest.mockReturnValue(true);

--- a/tests/api/admin.reviews-match-contacts.test.ts
+++ b/tests/api/admin.reviews-match-contacts.test.ts
@@ -43,7 +43,7 @@ import { POST } from "../../src/app/api/admin/reviews/match-contacts/route";
 
 const FAKE_REQ = {} as unknown as NextRequest;
 
-// customerRef is a reviewToken UUID — must be looked up via ReviewRequest
+// customerRef is a reviewToken UUID - must be looked up via ReviewRequest
 const TOKEN_BOB = "token-bob-uuid";
 
 const UNMATCHED_REVIEWS = [

--- a/tests/api/cron.test.ts
+++ b/tests/api/cron.test.ts
@@ -51,7 +51,7 @@ describe("GET /api/cron/send-review-emails", () => {
 
   it("returns ok:true with zero sent when no bookings are due", async () => {
     mocks.isCronAuthorized.mockReturnValue(true);
-    // No bookings to email — early exit, dedup queries are never called
+    // No bookings to email - early exit, dedup queries are never called
     mocks.bookingFindMany.mockResolvedValueOnce([]);
 
     const res = await GET(FAKE_REQ);

--- a/tests/lib/auto-maintain.test.ts
+++ b/tests/lib/auto-maintain.test.ts
@@ -3,9 +3,9 @@ import { autoMaintain } from "@/features/admin/lib/auto-maintain";
 import type { PrismaClient } from "@prisma/client";
 
 // autoMaintain(prisma) calls three internal phases sequentially:
-//   1. backfillContacts  — creates Contact records from Bookings/ReviewRequests
-//   2. matchReviewContacts — links unlinked Reviews to Contacts
-//   3. autoEnrich — fills missing fields and returns conflict entries
+//   1. backfillContacts  - creates Contact records from Bookings/ReviewRequests
+//   2. matchReviewContacts - links unlinked Reviews to Contacts
+//   3. autoEnrich - fills missing fields and returns conflict entries
 
 /**
  * Creates a minimal Prisma mock pre-seeded with test data for all three autoMaintain phases.

--- a/tests/lib/calendar-cache.test.ts
+++ b/tests/lib/calendar-cache.test.ts
@@ -261,7 +261,7 @@ describe("refreshCalendarCache", () => {
       { mode: "transit" },
     );
 
-    // Cache entries written with synthetic IDs — no Google Calendar writes
+    // Cache entries written with synthetic IDs - no Google Calendar writes
     expect(mocks.calendarEventCacheUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
@@ -480,7 +480,7 @@ describe("refreshCalendarCache", () => {
 
   it("falls back to home when no preceding event is within 4 hours", async () => {
     const farPastEnd = new Date(Date.now() + 1 * 60 * 60 * 1000).toISOString(); // 1h from now
-    // Target starts 6 hours after preceding event ends — outside the 4-hour window
+    // Target starts 6 hours after preceding event ends - outside the 4-hour window
     const futureStart = new Date(Date.now() + 7 * 60 * 60 * 1000).toISOString();
     const futureEnd = new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString();
 

--- a/tests/lib/email.test.ts
+++ b/tests/lib/email.test.ts
@@ -7,7 +7,7 @@ const mockSend = vi.hoisted(() =>
 );
 
 // Mock Resend before importing email.ts so the lazy singleton picks up the mock.
-// Must use a regular function (not an arrow function) — arrow functions cannot be
+// Must use a regular function (not an arrow function) - arrow functions cannot be
 // used as constructors with `new`.
 vi.mock("resend", () => ({
   Resend: vi.fn().mockImplementation(function () {

--- a/tests/lib/google-contacts.test.ts
+++ b/tests/lib/google-contacts.test.ts
@@ -148,7 +148,7 @@ describe("importFromGoogleContacts", () => {
       },
     });
     await importFromGoogleContacts();
-    // Must update only googleContactId — never name/phone/address
+    // Must update only googleContactId - never name/phone/address
     expect(mocks.contactUpdate).toHaveBeenCalledWith({
       where: { id: "existing-1" },
       data: { googleContactId: "people/1" },
@@ -390,7 +390,7 @@ describe("upsertToGoogleContacts", () => {
         requestBody: expect.objectContaining({ etag: "etag-abc" }),
       }),
     );
-    // names must NOT be sent — existing Google name is preserved
+    // names must NOT be sent - existing Google name is preserved
     const call = mocks.updateContact.mock.calls[0][0] as { requestBody: Record<string, unknown> };
     expect(call.requestBody).not.toHaveProperty("names");
     expect(mocks.searchContacts).not.toHaveBeenCalled();
@@ -429,7 +429,7 @@ describe("upsertToGoogleContacts", () => {
     expect(result).toBe("people/created-1");
   });
 
-  it("updates a contact found by search (has existing name — name not replaced)", async () => {
+  it("updates a contact found by search (has existing name - name not replaced)", async () => {
     mocks.searchContacts.mockResolvedValue({
       data: {
         results: [
@@ -457,7 +457,7 @@ describe("upsertToGoogleContacts", () => {
         updatePersonFields: "emailAddresses,phoneNumbers,addresses",
       }),
     );
-    // names must NOT be sent — existing Google name is preserved
+    // names must NOT be sent - existing Google name is preserved
     const call = mocks.updateContact.mock.calls[0][0] as { requestBody: Record<string, unknown> };
     expect(call.requestBody).not.toHaveProperty("names");
     expect(mocks.createContact).not.toHaveBeenCalled();

--- a/tests/lib/travel-time.test.ts
+++ b/tests/lib/travel-time.test.ts
@@ -122,7 +122,7 @@ describe("calculateTravelMinutes", () => {
     });
 
     // now = Saturday 23:30 UTC; departure is a Sunday far in the future at 00:15 UTC.
-    // candidate = tomorrow (Sunday) at 00:15 UTC, which is only 45 min from now —
+    // candidate = tomorrow (Sunday) at 00:15 UTC, which is only 45 min from now -
     // within the 1 h safety margin → must be bumped an extra week.
     const fakeNow = new Date("2026-03-28T23:30:00Z"); // Saturday
     vi.setSystemTime(fakeNow);
@@ -156,7 +156,7 @@ describe("calculateTravelMinutes", () => {
     const fakeNow = new Date("2026-03-27T10:00:00Z"); // Friday UTC
     vi.setSystemTime(fakeNow);
 
-    // Event on Tuesday 2026-04-14 at 12:00 UTC — 18 days away, beyond 7-day horizon
+    // Event on Tuesday 2026-04-14 at 12:00 UTC - 18 days away, beyond 7-day horizon
     const farDeparture = new Date("2026-04-14T12:00:00Z"); // Tuesday UTC
     await calculateTravelMinutes("home", "dest", farDeparture);
 


### PR DESCRIPTION
## Summary

- Replace all em dash characters (—) with plain hyphens (-) across 51 source files, covering comments, UI copy, and inline strings

## Test plan

- [ ] No em dashes remain in src/, tests/, scripts/, or prisma/