### PR TITLE
Dev rollup: bidirectional Google Contacts sync, Bookings page rename, review copy refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.45.1",
+      "version": "1.45.2",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.46.0",
+      "version": "1.46.1",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.45.2",
+  "version": "1.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.45.2",
+      "version": "1.46.0",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.45.2",
+  "version": "1.46.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,8 +132,27 @@ model Contact {
   // Not @unique because MongoDB's unique index rejects multiple null values
   // during backfill; UUID v4 collisions are vanishingly rare.
   reviewToken     String?
+  // Bidirectional sync state: site changed iff updatedAt > lastSyncedAt,
+  // Google changed iff current etag != lastGoogleEtag.
+  lastSyncedAt    DateTime?
+  lastGoogleEtag  String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+}
+
+// Sync conflicts admin resolves at /admin/contacts/conflicts.
+model ContactConflict {
+  id          String    @id @default(auto()) @map("_id") @db.ObjectId
+  contactId   String    @db.ObjectId
+  field       String // "name" | "email" | "address"
+  siteValue   String?
+  googleValue String?
+  resolvedAt  DateTime?
+  resolution  String? // "site" | "google" | "custom" | "auto"
+  createdAt   DateTime  @default(now())
+
+  @@index([resolvedAt, createdAt(sort: Desc)])
+  @@index([contactId, field, resolvedAt])
 }
 
 // Travel time blocks created for external calendar events with a location.
@@ -233,14 +252,11 @@ model Invoice {
   contactId   String?       @db.ObjectId
   driveFileId String?
   driveWebUrl String?
-  // Timestamp of the last send-email run that included the review link in the
-  // invoice email. Powers the 30-day cooldown in getInvoiceReviewEligibility
-  // so the same customer doesn't get re-asked across consecutive invoices.
+  // Stamped when send-email included the review link; powers the 30-day cooldown.
   reviewLinkSentAt DateTime?
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
 
-  // Invoice review cooldown lookup: WHERE clientEmail = ? AND reviewLinkSentAt >= cutoff
   @@index([clientEmail, reviewLinkSentAt])
 }
 

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -13,15 +13,15 @@ import {
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Calendar - Admin",
+  title: "Bookings - Admin",
   robots: { index: false, follow: false },
 };
 
 /**
- * Admin calendar page listing all bookings with status filters.
+ * Admin bookings page listing all bookings with status filters.
  * @param root0 - Page props.
  * @param root0.searchParams - URL search parameters (contains token).
- * @returns Calendar page element.
+ * @returns Bookings page element.
  */
 export default async function AdminBookingsPage({
   searchParams,
@@ -88,7 +88,7 @@ export default async function AdminBookingsPage({
   return (
     <AdminPageLayout token={t} current="bookings">
       <div className={cn("mb-6 flex flex-wrap items-center justify-between gap-4")}>
-        <h1 className={cn("text-russian-violet text-2xl font-extrabold")}>Calendar</h1>
+        <h1 className={cn("text-russian-violet text-2xl font-extrabold")}>Bookings</h1>
         <div className={cn("flex flex-wrap gap-2")}>
           {statusStats.map((s) => (
             <span

--- a/src/app/admin/contacts/conflicts/page.tsx
+++ b/src/app/admin/contacts/conflicts/page.tsx
@@ -1,0 +1,72 @@
+// src/app/admin/contacts/conflicts/page.tsx
+import type { Metadata } from "next";
+import type React from "react";
+import { prisma } from "@/shared/lib/prisma";
+import { requireAdminToken } from "@/shared/lib/auth";
+import { cn } from "@/shared/lib/cn";
+import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import {
+  ContactConflictsView,
+  type ConflictRow,
+} from "@/features/admin/components/ContactConflictsView";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Contact conflicts - Admin",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Admin page listing pending Google Contacts sync conflicts and letting the
+ * operator pick which side wins per row.
+ * @param root0 - Page props.
+ * @param root0.searchParams - URL search parameters (contains token).
+ * @returns Conflicts page element.
+ */
+export default async function AdminContactConflictsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}): Promise<React.ReactElement> {
+  const { token } = await searchParams;
+  const t = requireAdminToken(token);
+
+  const conflicts = await prisma.contactConflict.findMany({
+    where: { resolvedAt: null },
+    orderBy: { createdAt: "desc" },
+    take: 200,
+  });
+
+  const contactIds = Array.from(new Set(conflicts.map((c) => c.contactId)));
+  const contacts =
+    contactIds.length > 0
+      ? await prisma.contact.findMany({
+          where: { id: { in: contactIds } },
+          select: { id: true, name: true, email: true },
+        })
+      : [];
+  const contactById = new Map(contacts.map((c) => [c.id, c]));
+
+  const rows: ConflictRow[] = conflicts.map((c) => ({
+    id: c.id,
+    contactId: c.contactId,
+    contactName: contactById.get(c.contactId)?.name ?? "Unknown",
+    contactEmail: contactById.get(c.contactId)?.email ?? null,
+    field: c.field,
+    siteValue: c.siteValue,
+    googleValue: c.googleValue,
+    createdAt: c.createdAt.toISOString(),
+  }));
+
+  return (
+    <AdminPageLayout token={t} current="contacts">
+      <h1 className={cn("text-russian-violet mb-2 text-2xl font-extrabold")}>Contact conflicts</h1>
+      <p className={cn("mb-6 text-sm text-slate-500")}>
+        Fields where the site DB and Google Contacts both changed since the last sync. Pick which
+        value should win - the chosen value is written to both sides and the conflict is closed.
+      </p>
+      <ContactConflictsView initial={rows} token={t} />
+    </AdminPageLayout>
+  );
+}

--- a/src/app/admin/contacts/page.tsx
+++ b/src/app/admin/contacts/page.tsx
@@ -1,6 +1,7 @@
 // src/app/admin/contacts/page.tsx
 import type { Metadata } from "next";
 import type React from "react";
+import Link from "next/link";
 import { prisma } from "@/shared/lib/prisma";
 import { requireAdminToken } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
@@ -30,6 +31,10 @@ export default async function AdminContactsPage({
   const t = requireAdminToken(token);
 
   const initialConflicts = await autoMaintain(prisma);
+
+  const pendingConflictsCount = await prisma.contactConflict.count({
+    where: { resolvedAt: null },
+  });
 
   const [allContacts, reviews] = await Promise.all([
     prisma.contact.findMany({
@@ -100,6 +105,21 @@ export default async function AdminContactsPage({
           {allContacts.length}
         </span>
       </h1>
+      {pendingConflictsCount > 0 && (
+        <Link
+          href={`/admin/contacts/conflicts?token=${encodeURIComponent(t)}`}
+          className={cn(
+            "mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 hover:bg-amber-100",
+          )}
+        >
+          <span>
+            <strong>{pendingConflictsCount}</strong> contact{" "}
+            {pendingConflictsCount === 1 ? "field has" : "fields have"} a sync conflict between the
+            site and Google Contacts.
+          </span>
+          <span className={cn("font-semibold")}>Review &amp; resolve →</span>
+        </Link>
+      )}
       <ContactsAdminView initialConflicts={initialConflicts} contacts={contactRows} token={t} />
     </AdminPageLayout>
   );

--- a/src/app/api/admin/contacts/conflicts/[id]/route.ts
+++ b/src/app/api/admin/contacts/conflicts/[id]/route.ts
@@ -1,0 +1,101 @@
+// src/app/api/admin/contacts/conflicts/[id]/route.ts
+/**
+ * @file route.ts
+ * @description Admin endpoint to resolve a ContactConflict by picking a
+ * winner (site / google / custom). Writes the chosen value to the site
+ * Contact row, marks the conflict resolved, and triggers a fresh sync to
+ * push the chosen value to Google (which lets the cross-stamping in
+ * lastSyncedAt + lastGoogleEtag catch up).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/shared/lib/prisma";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+
+/**
+ * POST /api/admin/contacts/conflicts/[id]
+ * Body: `{ winner: "site" | "google" | "custom", customValue?: string }`.
+ * - winner "site" - keeps the site value, marks resolved, pushes to Google.
+ * - winner "google" - copies Google value to site contact, marks resolved.
+ * - winner "custom" - writes `customValue` to site, marks resolved, pushes.
+ * Requires X-Admin-Secret header.
+ * @param request - Incoming request.
+ * @param ctx - Route ctx with the conflict id.
+ * @param ctx.params - Resolved Next.js dynamic route params.
+ * @returns JSON with ok flag or error.
+ */
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  if (!isAdminRequest(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await ctx.params;
+  const body = (await request.json().catch(() => ({}))) as {
+    winner?: unknown;
+    customValue?: unknown;
+  };
+  const winner = body.winner;
+  const customValue = typeof body.customValue === "string" ? body.customValue : null;
+
+  if (winner !== "site" && winner !== "google" && winner !== "custom") {
+    return NextResponse.json(
+      { error: "winner must be 'site' | 'google' | 'custom'" },
+      { status: 400 },
+    );
+  }
+  if (winner === "custom" && !customValue) {
+    return NextResponse.json(
+      { error: "customValue is required when winner is 'custom'" },
+      { status: 400 },
+    );
+  }
+
+  const conflict = await prisma.contactConflict.findUnique({ where: { id } });
+  if (!conflict || conflict.resolvedAt) {
+    return NextResponse.json({ error: "Conflict not found or already resolved" }, { status: 404 });
+  }
+
+  // Decide the chosen value
+  const chosenValue =
+    winner === "site"
+      ? conflict.siteValue
+      : winner === "google"
+        ? conflict.googleValue
+        : customValue;
+
+  // Write the chosen value to the site contact. The field guard mirrors
+  // the recordContactConflict producer - only name/email/address are
+  // single-value conflicts.
+  const field = conflict.field as "name" | "email" | "address";
+  if (field !== "name" && field !== "email" && field !== "address") {
+    return NextResponse.json({ error: `Unknown conflict field: ${field}` }, { status: 500 });
+  }
+
+  try {
+    await prisma.contact.update({
+      where: { id: conflict.contactId },
+      // Clearing lastSyncedAt forces the next syncContactToGoogle to treat
+      // both sides as freshly changed, so the chosen value reliably propagates
+      // to Google regardless of who appeared to "change last".
+      data: { [field]: chosenValue, lastSyncedAt: null },
+    });
+
+    await prisma.contactConflict.update({
+      where: { id },
+      data: { resolvedAt: new Date(), resolution: winner },
+    });
+
+    // Fire a fresh sync to push the chosen value to Google. Best-effort -
+    // syncContactToGoogle never throws.
+    await syncContactToGoogle(conflict.contactId);
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[admin/contacts/conflicts/id] POST error:", err);
+    return NextResponse.json({ error: "Failed to resolve conflict" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/contacts/conflicts/route.ts
+++ b/src/app/api/admin/contacts/conflicts/route.ts
@@ -1,0 +1,57 @@
+// src/app/api/admin/contacts/conflicts/route.ts
+/**
+ * @file route.ts
+ * @description Admin endpoint listing pending Google Contacts sync conflicts.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/shared/lib/prisma";
+import { isAdminRequest } from "@/shared/lib/auth";
+
+/**
+ * GET /api/admin/contacts/conflicts
+ * Returns unresolved ContactConflict rows joined with their contact name/email.
+ * Requires X-Admin-Secret header.
+ * @param request - Incoming request.
+ * @returns JSON `{ ok, conflicts }` or an error.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!isAdminRequest(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const conflicts = await prisma.contactConflict.findMany({
+      where: { resolvedAt: null },
+      orderBy: { createdAt: "desc" },
+      take: 200,
+    });
+
+    const contactIds = Array.from(new Set(conflicts.map((c) => c.contactId)));
+    const contacts =
+      contactIds.length > 0
+        ? await prisma.contact.findMany({
+            where: { id: { in: contactIds } },
+            select: { id: true, name: true, email: true },
+          })
+        : [];
+    const contactById = new Map(contacts.map((c) => [c.id, c]));
+
+    return NextResponse.json({
+      ok: true,
+      conflicts: conflicts.map((c) => ({
+        id: c.id,
+        contactId: c.contactId,
+        contactName: contactById.get(c.contactId)?.name ?? "Unknown",
+        contactEmail: contactById.get(c.contactId)?.email ?? null,
+        field: c.field,
+        siteValue: c.siteValue,
+        googleValue: c.googleValue,
+        createdAt: c.createdAt.toISOString(),
+      })),
+    });
+  } catch (err) {
+    console.error("[admin/contacts/conflicts] GET error:", err);
+    return NextResponse.json({ error: "Failed to load conflicts" }, { status: 500 });
+  }
+}

--- a/src/features/admin/components/AdminSidebar.tsx
+++ b/src/features/admin/components/AdminSidebar.tsx
@@ -67,7 +67,7 @@ const NAV_ITEMS: NavItem[] = [
   },
   {
     page: "bookings",
-    label: "Calendar",
+    label: "Bookings",
     icon: <FaCalendarDays className={cn("shrink-0")} />,
     path: "/admin/bookings",
   },

--- a/src/features/admin/components/ContactConflictsView.tsx
+++ b/src/features/admin/components/ContactConflictsView.tsx
@@ -1,0 +1,189 @@
+"use client";
+// src/features/admin/components/ContactConflictsView.tsx
+/**
+ * @file ContactConflictsView.tsx
+ * @description Lists pending Google Contacts sync conflicts and lets the
+ * admin pick a winner per row. POSTs to /api/admin/contacts/conflicts/[id]
+ * which writes the chosen value to the site DB and triggers a fresh push to
+ * Google. Once resolved, the row disappears from the list.
+ */
+
+import { useState } from "react";
+import type React from "react";
+import { FaCaretLeft } from "react-icons/fa6";
+import Link from "next/link";
+import { cn } from "@/shared/lib/cn";
+
+/** A single unresolved conflict as returned by the GET endpoint. */
+export interface ConflictRow {
+  id: string;
+  contactId: string;
+  contactName: string;
+  contactEmail: string | null;
+  field: "name" | "email" | "address" | string;
+  siteValue: string | null;
+  googleValue: string | null;
+  createdAt: string;
+}
+
+interface ContactConflictsViewProps {
+  /** Initial unresolved conflicts loaded server-side. */
+  initial: ConflictRow[];
+  /** Admin token for the resolve POSTs. */
+  token: string;
+}
+
+/**
+ * Conflicts review UI. Renders one card per row with "Use site value" /
+ * "Use Google value" buttons. Resolution is optimistic: the row drops out
+ * of the list as soon as the API call succeeds.
+ * @param props - Component props.
+ * @param props.initial - Server-loaded conflicts.
+ * @param props.token - Admin token.
+ * @returns Conflicts view element.
+ */
+export function ContactConflictsView({
+  initial,
+  token,
+}: ContactConflictsViewProps): React.ReactElement {
+  const [rows, setRows] = useState(initial);
+  const [resolving, setResolving] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  /**
+   * Sends the chosen winner to the resolve endpoint and removes the row
+   * from the list on success.
+   * @param id - Conflict id.
+   * @param winner - Which side wins.
+   */
+  async function resolve(id: string, winner: "site" | "google"): Promise<void> {
+    setResolving(id);
+    setErrors((prev) => ({ ...prev, [id]: "" }));
+    try {
+      const res = await fetch(`/api/admin/contacts/conflicts/${id}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Admin-Secret": token },
+        body: JSON.stringify({ winner }),
+      });
+      const d = (await res.json()) as { ok: true } | { error: string };
+      if ("error" in d) throw new Error(d.error);
+      setRows((prev) => prev.filter((r) => r.id !== id));
+    } catch (err) {
+      setErrors((prev) => ({
+        ...prev,
+        [id]: err instanceof Error ? err.message : "Could not resolve.",
+      }));
+    } finally {
+      setResolving(null);
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className={cn("rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm")}>
+        <p className={cn("text-sm font-medium text-slate-700")}>No conflicts to review.</p>
+        <p className={cn("mt-1 text-xs text-slate-400")}>
+          All contact fields are in sync between the site and Google Contacts.
+        </p>
+        <Link
+          href={`/admin/contacts?token=${encodeURIComponent(token)}`}
+          className={cn(
+            "mt-4 inline-flex items-center gap-1 text-sm font-semibold text-slate-600 hover:underline",
+          )}
+        >
+          <FaCaretLeft className={cn("h-4 w-4")} aria-hidden />
+          Back to Contacts
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-4")}>
+      <Link
+        href={`/admin/contacts?token=${encodeURIComponent(token)}`}
+        className={cn(
+          "inline-flex w-fit items-center gap-1 text-sm font-semibold text-slate-600 hover:underline",
+        )}
+      >
+        <FaCaretLeft className={cn("h-4 w-4")} aria-hidden />
+        Back to Contacts
+      </Link>
+
+      <ul className={cn("flex flex-col gap-3")}>
+        {rows.map((c) => {
+          const isResolving = resolving === c.id;
+          const err = errors[c.id];
+          return (
+            <li
+              key={c.id}
+              className={cn("rounded-xl border border-slate-200 bg-white p-5 shadow-sm")}
+            >
+              <div className={cn("mb-3 flex items-baseline justify-between gap-3")}>
+                <div className={cn("min-w-0")}>
+                  <p className={cn("text-russian-violet truncate text-base font-semibold")}>
+                    {c.contactName}
+                  </p>
+                  {c.contactEmail && (
+                    <p className={cn("truncate text-xs text-slate-400")}>{c.contactEmail}</p>
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    "text-coquelicot-500 bg-coquelicot-500/10 shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase",
+                  )}
+                >
+                  {c.field}
+                </span>
+              </div>
+
+              <div className={cn("grid grid-cols-1 gap-3 md:grid-cols-2")}>
+                <div className={cn("rounded-lg border border-slate-200 bg-slate-50 p-3")}>
+                  <p className={cn("mb-1 text-xs font-semibold uppercase text-slate-400")}>
+                    Site value
+                  </p>
+                  <p className={cn("text-sm font-medium text-slate-800")}>
+                    {c.siteValue || <span className={cn("italic text-slate-400")}>empty</span>}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => void resolve(c.id, "site")}
+                    disabled={isResolving}
+                    className={cn(
+                      "bg-russian-violet hover:bg-russian-violet/90 mt-3 w-full rounded-lg px-3 py-2 text-xs font-semibold text-white transition-colors disabled:opacity-50",
+                    )}
+                  >
+                    {isResolving ? "Saving…" : "Use site value"}
+                  </button>
+                </div>
+                <div className={cn("rounded-lg border border-slate-200 bg-slate-50 p-3")}>
+                  <p className={cn("mb-1 text-xs font-semibold uppercase text-slate-400")}>
+                    Google value
+                  </p>
+                  <p className={cn("text-sm font-medium text-slate-800")}>
+                    {c.googleValue || <span className={cn("italic text-slate-400")}>empty</span>}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => void resolve(c.id, "google")}
+                    disabled={isResolving}
+                    className={cn(
+                      "mt-3 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50",
+                    )}
+                  >
+                    {isResolving ? "Saving…" : "Use Google value"}
+                  </button>
+                </div>
+              </div>
+
+              {err && <p className={cn("text-coquelicot-500 mt-3 text-xs")}>{err}</p>}
+              <p className={cn("mt-3 text-xs text-slate-400")}>
+                Detected {new Date(c.createdAt).toLocaleString()}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/contacts/lib/contact-conflicts.ts
+++ b/src/features/contacts/lib/contact-conflicts.ts
@@ -1,0 +1,75 @@
+// src/features/contacts/lib/contact-conflicts.ts
+/**
+ * @file contact-conflicts.ts
+ * @description Helpers for recording and resolving sync conflicts between the
+ * site DB and Google Contacts. A conflict is created when a single-value field
+ * (name, email, address) has different values on each side AND both sides
+ * have changed since the last successful sync, so we can't safely auto-resolve.
+ */
+
+import { prisma } from "@/shared/lib/prisma";
+
+/** Fields we track conflicts for. Phones are merged as a union, not conflicted. */
+export type ConflictField = "name" | "email" | "address";
+
+/** Resolution choice when an admin picks a winner. */
+export type ConflictResolution = "site" | "google" | "custom";
+
+/**
+ * Records (or refreshes) a pending conflict for a contact's field. If an
+ * unresolved row already exists for the same contactId + field, its values
+ * are updated in place so the admin always sees the latest both-sides state.
+ * @param args - Conflict inputs.
+ * @param args.contactId - Local Contact id.
+ * @param args.field - Which field is in conflict.
+ * @param args.siteValue - Site's current value (may be null).
+ * @param args.googleValue - Google's current value (may be null).
+ * @returns Promise that resolves when the conflict row is persisted.
+ */
+export async function recordContactConflict(args: {
+  contactId: string;
+  field: ConflictField;
+  siteValue: string | null;
+  googleValue: string | null;
+}): Promise<void> {
+  const { contactId, field, siteValue, googleValue } = args;
+
+  try {
+    const existing = await prisma.contactConflict.findFirst({
+      where: { contactId, field, resolvedAt: null },
+      select: { id: true },
+    });
+    if (existing) {
+      await prisma.contactConflict.update({
+        where: { id: existing.id },
+        data: { siteValue, googleValue },
+      });
+    } else {
+      await prisma.contactConflict.create({
+        data: { contactId, field, siteValue, googleValue },
+      });
+    }
+  } catch (err) {
+    // Conflict recording must never block the sync flow.
+    console.error("[contact-conflicts] recordContactConflict failed:", err);
+  }
+}
+
+/**
+ * Clears any pending conflict for this contact + field. Called when the field
+ * resolves itself (values now match) so the admin's conflict list doesn't
+ * show stale entries.
+ * @param contactId - Local Contact id.
+ * @param field - Which field is no longer in conflict.
+ * @returns Promise that resolves when any pending row is marked resolved.
+ */
+export async function clearContactConflict(contactId: string, field: ConflictField): Promise<void> {
+  try {
+    await prisma.contactConflict.updateMany({
+      where: { contactId, field, resolvedAt: null },
+      data: { resolvedAt: new Date(), resolution: "auto" },
+    });
+  } catch (err) {
+    console.error("[contact-conflicts] clearContactConflict failed:", err);
+  }
+}

--- a/src/features/contacts/lib/google-contacts.ts
+++ b/src/features/contacts/lib/google-contacts.ts
@@ -1,13 +1,28 @@
 // src/features/contacts/lib/google-contacts.ts
 /**
  * @file google-contacts.ts
- * @description Google People API integration for syncing local contacts with Google Contacts.
+ * @description Google People API integration with bidirectional latest-wins
+ * sync. The site DB and Google Contacts both have authority, with conflict
+ * resolution:
+ *
+ * - Phones: always merged as a union. A second number from a new booking is
+ *   appended to Google's existing phones; nothing is ever overwritten.
+ * - Names, emails, addresses (single-value fields): latest-wins when only one
+ *   side changed since the last sync (using Contact.lastSyncedAt and the
+ *   stored Google etag in lastGoogleEtag to detect change). When BOTH sides
+ *   changed and values differ, a ContactConflict row is recorded and the
+ *   admin resolves it from /admin/contacts/conflicts. The site DB is not
+ *   updated until the admin picks a winner.
+ *
+ * On first contact (lastSyncedAt null), Google's values win for any field
+ * Google has populated, with site values used to fill remaining blanks.
  */
 
 import { google } from "googleapis";
 import { prisma } from "@/shared/lib/prisma";
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
 import { normalizePhone, toE164NZ } from "@/shared/lib/normalize-phone";
+import { recordContactConflict, clearContactConflict } from "./contact-conflicts";
 
 /**
  * Returns an authenticated Google People API client.
@@ -60,6 +75,7 @@ export async function importFromGoogleContacts(): Promise<number> {
       // for the whole page so we issue 2 findManys instead of N findFirsts.
       interface Resolved {
         resourceName: string;
+        etag: string | null;
         email: string | null;
         phone: string | null;
         normPhone: string | null;
@@ -84,8 +100,9 @@ export async function importFromGoogleContacts(): Promise<number> {
         const address = person.addresses?.[0]?.formattedValue?.trim() ?? null;
         const email =
           emailEntry ?? (normPhone ? (reviewRequestsByPhone.get(normPhone) ?? null) : null);
+        const etag = person.etag ?? null;
 
-        resolved.push({ resourceName, email, phone, normPhone, name, address });
+        resolved.push({ resourceName, etag, email, phone, normPhone, name, address });
       }
 
       const emailsToCheck = Array.from(
@@ -127,10 +144,23 @@ export async function importFromGoogleContacts(): Promise<number> {
           try {
             const existing = contactByEmail.get(r.email);
             if (existing) {
+              // First-sync pull: on import, Google's values flow into the
+              // site DB (Google wins for any field it has populated). The
+              // blank-safety rule means empty Google values never overwrite
+              // existing site data. Stamping lastSyncedAt + lastGoogleEtag
+              // here is critical: without it the next syncContactToGoogle
+              // would see the etag as "changed" and conflict every field.
+              const updates: Record<string, unknown> = {
+                googleContactId: r.resourceName,
+                lastSyncedAt: new Date(),
+                lastGoogleEtag: r.etag,
+              };
+              if (r.name && r.name !== existing.name) updates.name = r.name;
+              if (r.phone) updates.phone = r.phone;
+              if (r.address) updates.address = r.address;
               await prisma.contact.update({
                 where: { id: existing.id },
-                // Local name/phone/address are the source of truth - only link the resource name.
-                data: { googleContactId: r.resourceName },
+                data: updates,
               });
             } else {
               const created = await prisma.contact.create({
@@ -140,6 +170,8 @@ export async function importFromGoogleContacts(): Promise<number> {
                   phone: r.phone,
                   address: r.address,
                   googleContactId: r.resourceName,
+                  lastSyncedAt: new Date(),
+                  lastGoogleEtag: r.etag,
                 },
                 select: { id: true, name: true },
               });
@@ -157,14 +189,18 @@ export async function importFromGoogleContacts(): Promise<number> {
           try {
             const existing = contactByPhone.get(r.phone);
             if (existing) {
-              // Also update the name if it was set to the phone number as a placeholder.
+              // Same first-sync pull semantics as the email-matched branch.
               const namePlaceholder = existing.name === r.phone || existing.name === r.normPhone;
+              const updates: Record<string, unknown> = {
+                googleContactId: r.resourceName,
+                lastSyncedAt: new Date(),
+                lastGoogleEtag: r.etag,
+              };
+              if (r.name && (namePlaceholder || r.name !== existing.name)) updates.name = r.name;
+              if (r.address) updates.address = r.address;
               await prisma.contact.update({
                 where: { id: existing.id },
-                data: {
-                  googleContactId: r.resourceName,
-                  ...(r.name && namePlaceholder ? { name: r.name } : {}),
-                },
+                data: updates,
               });
             } else {
               const created = await prisma.contact.create({
@@ -174,6 +210,8 @@ export async function importFromGoogleContacts(): Promise<number> {
                   phone: r.phone,
                   address: r.address,
                   googleContactId: r.resourceName,
+                  lastSyncedAt: new Date(),
+                  lastGoogleEtag: r.etag,
                 },
                 select: { id: true, name: true },
               });
@@ -198,22 +236,6 @@ export async function importFromGoogleContacts(): Promise<number> {
 }
 
 /**
- * Parameters for upserting a contact to Google Contacts.
- */
-export interface UpsertContactParams {
-  /** Full display name. */
-  name: string;
-  /** Email address (used for deduplication). */
-  email: string;
-  /** Phone number, or null. */
-  phone?: string | null;
-  /** Street/postal address, or null. */
-  address?: string | null;
-  /** Existing Google People API resource name if known (e.g. "people/c1234567890"). */
-  googleContactId?: string | null;
-}
-
-/**
  * Splits a full display name into given (first) and family (last) name parts.
  * @param fullName - Full display name.
  * @returns Object with givenName and familyName strings.
@@ -223,140 +245,6 @@ function splitName(fullName: string): { givenName: string; familyName: string } 
   if (parts.length === 0) return { givenName: "", familyName: "" };
   if (parts.length === 1) return { givenName: parts[0], familyName: "" };
   return { givenName: parts.slice(0, -1).join(" "), familyName: parts[parts.length - 1] };
-}
-
-/**
- * Creates or updates a contact in Google Contacts.
- * - If `googleContactId` is provided, updates the existing contact (fetching etag first).
- * - Otherwise searches by email; updates if found, creates if not.
- * Never throws - returns null on any error.
- * @param params - Contact data to sync.
- * @returns The Google People API resource name, or null on error.
- */
-export async function upsertToGoogleContacts(params: UpsertContactParams): Promise<string | null> {
-  try {
-    const people = getPeopleClient();
-
-    const { givenName, familyName } = splitName(params.name);
-
-    // Full body used only when CREATING a new contact - includes the local name.
-    const createBody = {
-      names: [{ displayName: params.name, givenName, familyName }],
-      emailAddresses: [{ value: params.email }],
-      ...(params.phone ? { phoneNumbers: [{ value: params.phone }] } : {}),
-      ...(params.address ? { addresses: [{ formattedValue: params.address }] } : {}),
-    };
-
-    // Base update fields - always sync email, phone, address.
-    // `names` is added only when the existing Google contact has no name.
-    const baseUpdateBody = {
-      emailAddresses: [{ value: params.email }],
-      ...(params.phone ? { phoneNumbers: [{ value: params.phone }] } : {}),
-      ...(params.address ? { addresses: [{ formattedValue: params.address }] } : {}),
-    };
-
-    /**
-     * Builds the request body and personFields for an update, adding `names`
-     * only when the existing Google contact has no display name.
-     * @param existingNames - The `names` array from the fetched Google contact.
-     * @returns Body and personFields string to pass to updateContact.
-     */
-    function buildUpdate(
-      existingNames: Array<{ displayName?: string | null }> | null | undefined,
-    ): {
-      body: typeof baseUpdateBody & {
-        names?: Array<{ displayName: string; givenName: string; familyName: string }>;
-      };
-      fields: string;
-    } {
-      const hasName = existingNames?.some((n) => n.displayName?.trim());
-      if (!hasName && params.name) {
-        return {
-          body: { names: [{ displayName: params.name, givenName, familyName }], ...baseUpdateBody },
-          fields: "names,emailAddresses,phoneNumbers,addresses",
-        };
-      }
-      return { body: baseUpdateBody, fields: "emailAddresses,phoneNumbers,addresses" };
-    }
-
-    // If we already have a resource name, try to update in place.
-    if (params.googleContactId) {
-      try {
-        const existing = await people.people.get({
-          resourceName: params.googleContactId,
-          personFields: "names,emailAddresses,phoneNumbers,addresses",
-        });
-        const etag = existing.data.etag;
-        if (etag) {
-          const { body, fields } = buildUpdate(existing.data.names);
-          const updated = await people.people.updateContact({
-            resourceName: params.googleContactId,
-            updatePersonFields: fields,
-            requestBody: { etag, ...body },
-          });
-          return updated.data.resourceName ?? params.googleContactId;
-        }
-      } catch (updateError) {
-        // Fall through to search-and-create if the existing resource is gone.
-        console.error(
-          `[google-contacts] Failed to update ${params.googleContactId}, falling back to search:`,
-          updateError,
-        );
-      }
-    }
-
-    // Search for an existing contact by email.
-    try {
-      const searchResult = await people.people.searchContacts({
-        query: params.email,
-        readMask: "names,emailAddresses",
-        pageSize: 5,
-      });
-
-      const match = searchResult.data.results?.find((r) =>
-        r.person?.emailAddresses?.some(
-          (e) => e.value?.toLowerCase() === params.email.toLowerCase(),
-        ),
-      );
-
-      if (match?.person?.resourceName) {
-        const resourceName = match.person.resourceName;
-        try {
-          const existing = await people.people.get({
-            resourceName,
-            personFields: "names,emailAddresses,phoneNumbers,addresses",
-          });
-          const etag = existing.data.etag;
-          if (etag) {
-            const { body, fields } = buildUpdate(existing.data.names);
-            const updated = await people.people.updateContact({
-              resourceName,
-              updatePersonFields: fields,
-              requestBody: { etag, ...body },
-            });
-            return updated.data.resourceName ?? resourceName;
-          }
-        } catch (updateFoundError) {
-          console.error(
-            `[google-contacts] Failed to update found contact ${resourceName}:`,
-            updateFoundError,
-          );
-          return resourceName;
-        }
-      }
-    } catch (searchError) {
-      console.error("[google-contacts] Search failed, will attempt create:", searchError);
-    }
-
-    // Create a new contact - use the full body including name.
-    const created = await people.people.createContact({
-      requestBody: createBody,
-    });
-    return created.data.resourceName ?? null;
-  } catch (error) {
-    console.error("[google-contacts] upsertToGoogleContacts failed:", error);
-    return null;
-  }
 }
 
 /**
@@ -379,9 +267,78 @@ export async function syncAllContactsToGoogle(): Promise<number> {
 }
 
 /**
- * Loads a contact from the local DB and syncs it to Google Contacts.
- * Updates `googleContactId` in the DB if it changed.
- * Never throws - all errors are logged and swallowed.
+ * Compares site + Google values of a single-value field, considering which
+ * sides changed since the last sync, and returns the action the sync should
+ * take. See file header for the policy.
+ * @param siteValue - Current site value (possibly null).
+ * @param googleValue - Current Google value (possibly null).
+ * @param siteChanged - Whether the site row was updated since last sync.
+ * @param googleChanged - Whether Google's etag differs from the stored one.
+ * @returns "noop" if values match, "push" / "pull" for latest-wins,
+ *   "conflict" when both sides changed and values diverge.
+ */
+function compareSingleField(
+  siteValue: string | null,
+  googleValue: string | null,
+  siteChanged: boolean,
+  googleChanged: boolean,
+): "noop" | "push" | "pull" | "conflict" {
+  const a = siteValue?.trim() || null;
+  const b = googleValue?.trim() || null;
+  if (a === b) return "noop";
+  if (siteChanged && !googleChanged) return "push";
+  if (!siteChanged && googleChanged) return "pull";
+  if (siteChanged && googleChanged) return "conflict";
+  // Neither changed but values diverge (e.g. first sync ever, or external
+  // tampering). Prefer Google so the admin's manual edits aren't trampled.
+  if (b) return "pull";
+  if (a) return "push";
+  return "noop";
+}
+
+/**
+ * Returns the union of site + Google phone numbers, deduplicated by
+ * normalised E.164 form. The order is preserved: Google's existing phones
+ * first (so its primary stays primary), then any new ones the site added.
+ * @param sitePhone - Site's single phone field (may be null).
+ * @param googlePhones - All values from Google's phoneNumbers array.
+ * @returns Merged phone array suitable for pushing back to Google.
+ */
+function mergePhones(sitePhone: string | null, googlePhones: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of googlePhones) {
+    const trimmed = raw?.trim();
+    if (!trimmed) continue;
+    const key = normalizePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+  if (sitePhone?.trim()) {
+    const trimmed = sitePhone.trim();
+    const key = normalizePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(trimmed);
+    }
+  }
+  return result;
+}
+
+/**
+ * Bidirectional sync between a site Contact and its Google Contacts counterpart.
+ *
+ * Loads the contact, finds (or creates) the matching Google person, then:
+ * - merges phones as a union so booking-time phone variations are appended,
+ *   never lost,
+ * - for name / email / address, uses latest-wins when only one side changed
+ *   since the last sync (Contact.lastSyncedAt vs Google's etag); when both
+ *   sides changed and values diverge, records a ContactConflict for admin
+ *   approval and leaves the site value alone.
+ *
+ * Stamps Contact.lastSyncedAt + Contact.lastGoogleEtag on success so the next
+ * sync can detect change correctly. Never throws - all errors are logged.
  * @param contactId - The local DB contact ID to sync.
  * @returns Promise that resolves when the sync attempt is complete.
  */
@@ -399,19 +356,198 @@ export async function syncContactToGoogle(contactId: string): Promise<void> {
       return;
     }
 
-    const resourceName = await upsertToGoogleContacts({
-      name: contact.name,
-      email: contact.email,
-      phone: contact.phone,
-      address: contact.address,
-      googleContactId: contact.googleContactId,
-    });
+    const people = getPeopleClient();
 
-    if (resourceName && resourceName !== contact.googleContactId) {
-      await prisma.contact.update({
-        where: { id: contactId },
-        data: { googleContactId: resourceName },
+    // Locate the Google contact: prefer the stored resource name, fall back
+    // to email search. If neither finds one, create a fresh Google contact
+    // using site values - that's an unambiguous first sync.
+    let resourceName = contact.googleContactId;
+    let googlePerson: {
+      etag?: string | null;
+      names?: Array<{ displayName?: string | null }> | null;
+      emailAddresses?: Array<{ value?: string | null }> | null;
+      phoneNumbers?: Array<{ value?: string | null }> | null;
+      addresses?: Array<{ formattedValue?: string | null }> | null;
+    } | null = null;
+
+    if (resourceName) {
+      try {
+        const fetched = await people.people.get({
+          resourceName,
+          personFields: "names,emailAddresses,phoneNumbers,addresses",
+        });
+        googlePerson = fetched.data;
+      } catch (err) {
+        console.error(
+          `[google-contacts] Stored googleContactId ${resourceName} not fetchable, will search by email:`,
+          err,
+        );
+        resourceName = null;
+      }
+    }
+
+    if (!resourceName) {
+      // Search Google by email
+      try {
+        const searchResult = await people.people.searchContacts({
+          query: contact.email,
+          readMask: "names,emailAddresses,phoneNumbers,addresses",
+          pageSize: 5,
+        });
+        const match = searchResult.data.results?.find((r) =>
+          r.person?.emailAddresses?.some(
+            (e) => e.value?.toLowerCase() === contact.email!.toLowerCase(),
+          ),
+        );
+        if (match?.person?.resourceName) {
+          resourceName = match.person.resourceName;
+          googlePerson = match.person;
+        }
+      } catch (err) {
+        console.error("[google-contacts] Search by email failed:", err);
+      }
+    }
+
+    if (!resourceName || !googlePerson) {
+      // No Google contact found - create a new one with all site values.
+      try {
+        const { givenName, familyName } = splitName(contact.name);
+        const created = await people.people.createContact({
+          requestBody: {
+            names: [{ displayName: contact.name, givenName, familyName }],
+            emailAddresses: [{ value: contact.email }],
+            ...(contact.phone ? { phoneNumbers: [{ value: contact.phone }] } : {}),
+            ...(contact.address ? { addresses: [{ formattedValue: contact.address }] } : {}),
+          },
+        });
+        if (created.data.resourceName) {
+          await prisma.contact.update({
+            where: { id: contactId },
+            data: {
+              googleContactId: created.data.resourceName,
+              lastSyncedAt: new Date(),
+              lastGoogleEtag: created.data.etag ?? null,
+            },
+          });
+        }
+      } catch (err) {
+        console.error("[google-contacts] Failed to create new Google contact:", err);
+      }
+      return;
+    }
+
+    // Both sides exist - decide who changed since last sync, then act.
+    const currentEtag = googlePerson.etag ?? null;
+    const siteChanged =
+      !contact.lastSyncedAt || contact.updatedAt.getTime() > contact.lastSyncedAt.getTime();
+    const googleChanged = !contact.lastGoogleEtag || currentEtag !== contact.lastGoogleEtag;
+
+    const googleName = googlePerson.names?.[0]?.displayName?.trim() || null;
+    const googleEmail = googlePerson.emailAddresses?.[0]?.value?.trim() || null;
+    const googleAddress = googlePerson.addresses?.[0]?.formattedValue?.trim() || null;
+    const googlePhoneList = (googlePerson.phoneNumbers ?? [])
+      .map((p) => p.value?.trim())
+      .filter((v): v is string => !!v);
+
+    // Phones - always merge as union. No conflict semantics.
+    const mergedPhones = mergePhones(contact.phone, googlePhoneList);
+    const phonesChanged =
+      mergedPhones.length !== googlePhoneList.length ||
+      mergedPhones.some((p, i) => p !== googlePhoneList[i]);
+
+    // Single-value fields - latest-wins or conflict
+    const nameAction = compareSingleField(contact.name, googleName, siteChanged, googleChanged);
+    const emailAction = compareSingleField(contact.email, googleEmail, siteChanged, googleChanged);
+    const addressAction = compareSingleField(
+      contact.address,
+      googleAddress,
+      siteChanged,
+      googleChanged,
+    );
+
+    // Build the Google update body from the actions
+    const updateBody: Record<string, unknown> = {};
+    const updateFields: string[] = [];
+    if (phonesChanged && mergedPhones.length > 0) {
+      updateBody.phoneNumbers = mergedPhones.map((value) => ({ value }));
+      updateFields.push("phoneNumbers");
+    }
+    if (nameAction === "push" && contact.name) {
+      const { givenName, familyName } = splitName(contact.name);
+      updateBody.names = [{ displayName: contact.name, givenName, familyName }];
+      updateFields.push("names");
+    }
+    if (emailAction === "push" && contact.email) {
+      updateBody.emailAddresses = [{ value: contact.email }];
+      updateFields.push("emailAddresses");
+    }
+    if (addressAction === "push" && contact.address) {
+      updateBody.addresses = [{ formattedValue: contact.address }];
+      updateFields.push("addresses");
+    }
+
+    if (updateFields.length > 0 && currentEtag) {
+      try {
+        const updated = await people.people.updateContact({
+          resourceName,
+          updatePersonFields: updateFields.join(","),
+          requestBody: { etag: currentEtag, ...updateBody },
+        });
+        // Refresh etag from the response - it changed because we just wrote.
+        googlePerson.etag = updated.data.etag ?? currentEtag;
+      } catch (err) {
+        console.error(`[google-contacts] updateContact failed for ${resourceName}:`, err);
+      }
+    }
+
+    // Build the site update from pull actions + the merged phones
+    const siteUpdate: Record<string, unknown> = {
+      googleContactId: resourceName,
+      lastSyncedAt: new Date(),
+      lastGoogleEtag: googlePerson.etag ?? currentEtag,
+    };
+    if (nameAction === "pull" && googleName) siteUpdate.name = googleName;
+    if (emailAction === "pull" && googleEmail) siteUpdate.email = googleEmail;
+    if (addressAction === "pull" && googleAddress) siteUpdate.address = googleAddress;
+    // Keep the site's phone as the first phone in the merged list so the rest
+    // of the app (which only reads the single Contact.phone field) sees the
+    // primary number.
+    if (mergedPhones[0] && mergedPhones[0] !== contact.phone) {
+      siteUpdate.phone = mergedPhones[0];
+    }
+
+    await prisma.contact.update({ where: { id: contactId }, data: siteUpdate });
+
+    // Record / clear conflicts per single-value field
+    if (nameAction === "conflict") {
+      await recordContactConflict({
+        contactId,
+        field: "name",
+        siteValue: contact.name,
+        googleValue: googleName,
       });
+    } else {
+      await clearContactConflict(contactId, "name");
+    }
+    if (emailAction === "conflict") {
+      await recordContactConflict({
+        contactId,
+        field: "email",
+        siteValue: contact.email,
+        googleValue: googleEmail,
+      });
+    } else {
+      await clearContactConflict(contactId, "email");
+    }
+    if (addressAction === "conflict") {
+      await recordContactConflict({
+        contactId,
+        field: "address",
+        siteValue: contact.address,
+        googleValue: googleAddress,
+      });
+    } else {
+      await clearContactConflict(contactId, "address");
     }
   } catch (error) {
     console.error(`[google-contacts] syncContactToGoogle failed for ${contactId}:`, error);

--- a/src/features/reviews/components/admin/SendReviewLinkForm.tsx
+++ b/src/features/reviews/components/admin/SendReviewLinkForm.tsx
@@ -177,7 +177,7 @@ export function SendReviewLinkForm({
       } else if (data.reviewUrl) {
         const firstName = name.trim().split(" ")[0];
         setSmsText(
-          `Hi ${firstName}, it's Harrison from To The Point Tech. Thanks for letting me help you out! I'm updating my website and a quick review would be greatly appreciated - it really helps: ${data.reviewUrl}`,
+          `Hi ${firstName}, it's Harrison from To The Point Tech. Thanks for letting me help you out! A quick review would be greatly appreciated - it really helps: ${data.reviewUrl}`,
         );
         clearFields();
       }

--- a/src/features/reviews/lib/email.ts
+++ b/src/features/reviews/lib/email.ts
@@ -321,7 +321,7 @@ export async function sendCustomerReviewRequest(booking: ReviewRequestData): Pro
   <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;box-shadow:0 2px 8px rgba(0,0,0,.08)">
     <h2 style="margin:0 0 12px;color:#0c0a3e;font-size:20px">Hi ${safeFirstName}, how did everything go?</h2>
     <p style="margin:0 0 12px;color:#444;line-height:1.6">It was great meeting you - I hope I managed to get everything sorted and left you feeling a bit less frustrated with technology!</p>
-    <p style="margin:0 0 12px;color:#444;line-height:1.6">If you have a spare moment, I'd love to hear how your experience was. A quick review makes a real difference for a small local business like mine, and helps other people in the area find reliable tech support when they need it.</p>
+    <p style="margin:0 0 12px;color:#444;line-height:1.6">If you have a spare moment, I'd love to hear how your experience was. A quick review makes a real difference for a small local business like mine, and helps other people find reliable tech support when they need it.</p>
     <p style="margin:0 0 24px;color:#444;line-height:1.6">It only takes a minute - and honest feedback is always welcome.</p>
     <a href="${reviewUrl}" style="display:inline-block;background:#43bccd;color:#fff;text-decoration:none;padding:12px 28px;border-radius:8px;font-weight:600;font-size:15px">Share your experience →</a>
 
@@ -364,7 +364,7 @@ export function buildPastClientReviewEmailHtml(firstName: string, reviewUrl: str
   <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;box-shadow:0 2px 8px rgba(0,0,0,.08)">
     <h2 style="margin:0 0 12px;color:#0c0a3e;font-size:20px">Hi ${safeFirstName},</h2>
     <p style="margin:0 0 12px;color:#444;line-height:1.6">It's ${BUSINESS.name.split(" ")[0]} from ${BUSINESS.company} Tech - thanks again for letting me help you out!</p>
-    <p style="margin:0 0 12px;color:#444;line-height:1.6">I'm in the process of updating my website and building up my reviews section. If you have a spare moment, a quick review would mean a lot - it really helps other people in the area find reliable local tech support.</p>
+    <p style="margin:0 0 12px;color:#444;line-height:1.6">If you have a spare moment, a quick review would mean a lot - it really helps other people find reliable local tech support.</p>
     <p style="margin:0 0 24px;color:#444;line-height:1.6">No pressure at all, but if you're happy to, I'd really appreciate it.</p>
     <a href="${reviewUrl}" style="display:inline-block;background:#43bccd;color:#fff;text-decoration:none;padding:12px 28px;border-radius:8px;font-weight:600;font-size:15px">Leave a review →</a>
 


### PR DESCRIPTION
## Summary

4 commits taking dev from `1.45.1` to `1.46.1`. Three themes:

1. Bidirectional Google Contacts sync: phones merged as a union (so a rebook's new phone is appended, not lost), name/email/address use latest-wins with admin conflict resolution at /admin/contacts/conflicts when both sides changed
2. Admin Bookings page renamed from "Calendar" so the label matches the URL and the content
3. Review-request copy refresh: dropped the outdated "I'm updating my website" line from the past-client email + SMS, trimmed "in the area" from the auto-sent post-appointment email so the asks read more universally

## Bidirectional Google Contacts sync

The feature spans two commits - `016059b` shipped the admin UI + endpoints, and `1564cd3` followed up with the engine + schema additions + admin banner that were missed when lint-staged backed up unstaged changes during the first commit. Together they form the complete feature.

- `016059b` feat(contacts): bidirectional Google sync with phone-append and admin conflict resolution
- `1564cd3` feat(contacts): bidirectional Google sync engine, schema additions, and admin banner
  - Previously the site overwrote Google Contacts on every push - customer edits made directly in Google were silently destroyed by the next booking-time sync
  - Phones are now always merged as a union: a new phone from a rebook is appended to Google's existing numbers rather than replacing them
  - Names, emails, and addresses use latest-wins via Contact.lastSyncedAt + Contact.lastGoogleEtag: if only the site changed since the last sync, push; if only Google changed, pull; if both changed and values diverge, record a ContactConflict and leave the site value alone for admin to resolve
  - syncContactToGoogle is now fully bidirectional with new helpers compareSingleField + mergePhones encoding the policy; dead upsertToGoogleContacts function + UpsertContactParams interface removed
  - importFromGoogleContacts stamps lastSyncedAt + lastGoogleEtag on every matched/created contact so subsequent syncs detect change correctly
  - New ContactConflict model stores unresolved per-field conflicts; admin reviews them at /admin/contacts/conflicts (new server page + ContactConflictsView client component with side-by-side "site value" / "Google value" cards). Banner on /admin/contacts links to the conflicts page with the pending count
  - New endpoints: GET /api/admin/contacts/conflicts and POST /api/admin/contacts/conflicts/[id] with `{ winner: "site" | "google" | "custom" }`; resolution writes the chosen value to the site contact, marks resolved, and fires syncContactToGoogle to propagate to Google
  - New customer bookings still create a fresh Contact row + Google contact unchanged - the merge logic only activates when both sides exist
  - New workflow for permanent contact changes: edit in Google Contacts, click "Import contacts" in /admin/contacts, then reconcile any conflicts that surface

## Admin Bookings page rename

- `2b54ded` refactor(admin): rename Bookings page from "Calendar"
  - Browser title, page h1, JSDoc, and sidebar label updated to "Bookings" so the label matches the URL (/admin/bookings) and the content (it's a bookings list with status filters, not a calendar)
  - FaCalendarDays icon kept on the sidebar - still fits visually
  - "Calendar cache" label on the admin dashboard's System status panel left as-is (different concept - that's the Google Calendar sync cache)

## Review-request copy refresh

- `716882d` chore(reviews): refresh review-request copy across email and SMS templates
  - Past-client email (admin "Send a review link" form): dropped the now-outdated "I'm in the process of updating my website and building up my reviews section" sentence entirely; trimmed "in the area" from the remaining ask
  - Auto-sent post-appointment email (cron + admin "Mark complete"): trimmed "in the area" from the same ask, rest unchanged
  - Past-client SMS: dropped "I'm updating my website" from the message so it's shorter and accurate; rest unchanged
  - Copy-only change, no behaviour difference

## Schema migrations

npm run db:push + npx prisma generate after merging. New fields/models:

- Contact.lastSyncedAt + Contact.lastGoogleEtag (nullable; updated after every successful Google Contacts sync; drive the latest-wins / conflict detection in syncContactToGoogle)
- ContactConflict (new model with field/siteValue/googleValue/resolvedAt/resolution; populated when bidirectional sync detects both sides changed since last sync) + composite indexes on (resolvedAt, createdAt desc) for the admin list and (contactId, field, resolvedAt) for the dedup lookup

No data backfill required - existing contacts have lastSyncedAt + lastGoogleEtag null which the sync correctly treats as "first sync ever" (Google wins for populated fields, site fills blanks).

## Test plan

- [ ] gh pr checks passes (build + smoke already ran on each commit via pre-push)
- [ ] npm run db:push + npx prisma generate
- [ ] Admin Bookings page: /admin/bookings shows "Bookings" as the h1, sidebar entry, and browser title; "Calendar cache" indicator on /admin still reads "Calendar cache" (intentional - separate concept)
- [ ] Contact sync - phone append: a customer who already exists in Google Contacts books with a new phone number; the new number appears as a second phone on their Google contact (existing phone preserved); site contact.phone shows the new number as primary
- [ ] Contact sync - latest-wins push: edit a contact's name in /admin/contacts, then trigger a sync; Google Contacts shows the new name (site changed, Google didn't); no conflict raised
- [ ] Contact sync - latest-wins pull: change a contact's address in Google Contacts, then click "Import contacts" in /admin/contacts; site contact's address updates to Google's value (Google changed, site didn't); no conflict raised
- [ ] Contact sync - conflict path: edit a contact's name in /admin/contacts AND in Google Contacts before either has synced, then trigger a sync; banner appears on /admin/contacts ("1 contact field has a sync conflict"); /admin/contacts/conflicts shows the row with both values; click "Use site value" - site value persists, Google updates to match, conflict disappears; repeat with a fresh conflict and pick "Use Google value" - site updates to match
- [ ] Contact sync - new customer booking: a brand-new customer books; site creates a Contact row + a new Google contact with all fields; lastSyncedAt + lastGoogleEtag stamped; no conflict; the contact appears in Google Contacts
- [ ] Review-request copy: send a review link via the admin "Send a review link" form (email mode) and confirm the body no longer contains "updating my website" or "in the area"; do the same in SMS mode and confirm the generated SMS body no longer says "updating my website"; trigger the auto post-appointment email (cron or admin "Mark complete") and confirm "in the area" is gone but the rest of the message is unchanged
