### PR TITLE
Dev rollup: comment audit + drop US spelling from phone util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.49.2",
+  "version": "1.49.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.49.2",
+      "version": "1.49.3",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.49.1",
+  "version": "1.49.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.49.1",
+      "version": "1.49.2",
       "hasInstallScript": true,
       "dependencies": {
         "@vercel/analytics": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.49.2",
+  "version": "1.49.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.49.1",
+  "version": "1.49.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/build-icons/generators.ts
+++ b/scripts/build-icons/generators.ts
@@ -40,8 +40,8 @@ const canvas = createRequire(import.meta.url)("canvas") as typeof import("canvas
 /**
  * Render a single favicon variant from an SVG logo buffer.
  *
- * - `opaque: false` → resize logo to fill the canvas (transparent passthrough).
- * - `opaque: true` → composite logo onto a coloured background at `logoScale`.
+ * - `opaque: false` > resize logo to fill the canvas (transparent passthrough).
+ * - `opaque: true` > composite logo onto a coloured background at `logoScale`.
  * @param logoSvg - SVG source buffer (light or dark colour variant).
  * @param size - Output square size in pixels.
  * @param opaque - Whether to render on an opaque background.

--- a/scripts/export-poster-screenshot.ts
+++ b/scripts/export-poster-screenshot.ts
@@ -46,21 +46,21 @@ interface PageConfig {
   cropMarks: boolean;
   /** Output file name. */
   filename: string;
-  /** URL suffix appended to the base poster URL (e.g. "?mode=print" → /poster?mode=print). */
+  /** URL suffix appended to the base poster URL (e.g. "?mode=print" > /poster?mode=print). */
   urlSuffix?: string;
 }
 
 /* ---------- Constants ---------- */
 
 /**
- * A5 CSS viewport at 300 DPI (148 mm × 210 mm → 1748 px × 2480 px).
+ * A5 CSS viewport at 300 DPI (148 mm × 210 mm > 1748 px × 2480 px).
  * Combined with {@link DEVICE_SCALE_FACTOR} the captured screenshot is
  * 1748×SCALE × 2480×SCALE px, equivalent to 300×SCALE DPI.
  */
 const A5_VIEWPORT = { width: 1748, height: 2480 } as const;
 
 /**
- * Puppeteer device scale factor (CSS pixel → physical pixel multiplier).
+ * Puppeteer device scale factor (CSS pixel > physical pixel multiplier).
  * 1 = 300 DPI (captures 1748 × 2480 px as-is).
  * 2 = 600 DPI effective (3496 × 4960 px screenshot).
  */
@@ -79,7 +79,7 @@ const A5_DIGITAL_CONFIG: PageConfig = {
 /** Configuration for print variant (A5 + 3mm bleed). */
 const A5_PRINT_CONFIG: PageConfig = {
   label: "Print (A5 + 3mm bleed)",
-  // 3 mm bleed at 300 DPI ≈ 35.43 px per side → 1748 + 2×35.43 ≈ 1818.86
+  // 3 mm bleed at 300 DPI ≈ 35.43 px per side > 1748 + 2×35.43 ≈ 1818.86
   // and 2480 + 2×35.43 ≈ 2550.86, which we round up to whole pixels: 1819×2551.
   viewport: { width: 1819, height: 2551 },
   pdfSize: { width: 436.53, height: 612.28 },

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -5,8 +5,8 @@
  * public page with Puppeteer to collect console errors and navigation timing.
  *
  * Usage:
- *   npx tsx scripts/smoke-test.ts              # build → start → test
- *   npx tsx scripts/smoke-test.ts --skip-build # start → test (reuse existing .next)
+ *   npx tsx scripts/smoke-test.ts              # build > start > test
+ *   npx tsx scripts/smoke-test.ts --skip-build # start > test (reuse existing .next)
  *   npx tsx scripts/smoke-test.ts --port=3001
  *
  * Exit codes:

--- a/src/app/admin/business/page.tsx
+++ b/src/app/admin/business/page.tsx
@@ -37,7 +37,7 @@ const SCOPE_PARAM = "fy";
 
 /**
  * Resolves the displayed scope from a search-param value.
- * "all" → the all-time scope (no date filter).
+ * "all" > the all-time scope (no date filter).
  * Otherwise tries to match an FY key (e.g. "2025-26") against the listed FYs.
  * Falls back to the current FY when the param is missing or doesn't match.
  * @param raw - Raw `?fy=` query value (undefined, "all", or an FY key).

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,7 +6,7 @@ import { prisma } from "@/shared/lib/prisma";
 import { requireAdminToken } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { DashboardQuickActions } from "@/features/admin/components/DashboardQuickActions";
-import { toE164NZ } from "@/shared/lib/normalize-phone";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { cn } from "@/shared/lib/cn";
 import { formatDateShort, formatDateTimeShort } from "@/shared/lib/date-format";
 import { formatNZD } from "@/features/business/lib/business";

--- a/src/app/admin/reviews/page.tsx
+++ b/src/app/admin/reviews/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import type React from "react";
 import { prisma } from "@/shared/lib/prisma";
 import { requireAdminToken } from "@/shared/lib/auth";
-import { toE164NZ } from "@/shared/lib/normalize-phone";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { cn } from "@/shared/lib/cn";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { ReviewApprovalList } from "@/features/reviews/components/admin/ReviewApprovalList";

--- a/src/app/api/admin/bookings/[id]/route.ts
+++ b/src/app/api/admin/bookings/[id]/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { deleteBookingEvent } from "@/features/calendar/lib/google-calendar";
-import { toE164NZ } from "@/shared/lib/normalize-phone";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
 
 interface PatchPayload {

--- a/src/app/api/admin/contacts/[id]/route.ts
+++ b/src/app/api/admin/contacts/[id]/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
-import { toE164NZ, normalizePhone, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, normalisePhone, isValidPhone } from "@/shared/lib/normalise-phone";
 
 interface ContactPatchBody {
   name?: string;
@@ -56,7 +56,7 @@ export async function PATCH(
       }
     }
   }
-  if (body.phone !== undefined && body.phone.trim() && !isValidPhone(normalizePhone(body.phone))) {
+  if (body.phone !== undefined && body.phone.trim() && !isValidPhone(normalisePhone(body.phone))) {
     return NextResponse.json({ error: "Please enter a valid phone number." }, { status: 400 });
   }
 

--- a/src/app/api/admin/contacts/backfill/route.ts
+++ b/src/app/api/admin/contacts/backfill/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ, normalizePhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, normalisePhone } from "@/shared/lib/normalise-phone";
 
 /**
  * Parse phone and address from structured booking notes.
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       });
     } else if (rr.phone) {
       const phone = toE164NZ(rr.phone) || rr.phone;
-      const normPhone = normalizePhone(phone);
+      const normPhone = normalisePhone(phone);
       if (normPhone && !mergedByPhone.has(normPhone)) {
         mergedByPhone.set(normPhone, { name: rr.name, email: null, phone });
       }

--- a/src/app/api/admin/contacts/backfill/route.ts
+++ b/src/app/api/admin/contacts/backfill/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Build a unified map of email → contact data from all sources.
+  // Build a unified map of email > contact data from all sources.
   // Sources are processed oldest-first so the most recent entry wins.
 
   const mergedByEmail = new Map<

--- a/src/app/api/admin/contacts/enrich-from-reviews/route.ts
+++ b/src/app/api/admin/contacts/enrich-from-reviews/route.ts
@@ -9,7 +9,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ, normalizePhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, normalisePhone } from "@/shared/lib/normalise-phone";
 
 export interface ConflictEntry {
   contactId: string;
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const contactByPhone = new Map<string, (typeof allContacts)[0]>();
   for (const c of allContacts) {
     if (c.phone) {
-      const norm = normalizePhone(toE164NZ(c.phone) || c.phone);
+      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
       if (norm && !contactByPhone.has(norm)) contactByPhone.set(norm, c);
     }
   }
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   for (const rr of reviewRequests) {
     let contact = rr.email ? contactByEmail.get(rr.email.toLowerCase()) : undefined;
     if (!contact && rr.phone) {
-      const normPhone = normalizePhone(toE164NZ(rr.phone) || rr.phone);
+      const normPhone = normalisePhone(toE164NZ(rr.phone) || rr.phone);
       if (normPhone) contact = contactByPhone.get(normPhone);
     }
     if (!contact || seenRR.has(contact.id)) continue;
@@ -86,8 +86,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const proposedName = rr.name.trim();
     const proposedPhoneRaw = rr.phone?.trim() ?? null;
-    const proposedPhone = proposedPhoneRaw ? normalizePhone(proposedPhoneRaw) : null;
-    const existingPhone = contact.phone ? normalizePhone(contact.phone) : null;
+    const proposedPhone = proposedPhoneRaw ? normalisePhone(proposedPhoneRaw) : null;
+    const existingPhone = contact.phone ? normalisePhone(contact.phone) : null;
 
     // Auto-fill name when contact has only a first name and source provides full name.
     if (

--- a/src/app/api/admin/contacts/enrich-from-reviews/route.ts
+++ b/src/app/api/admin/contacts/enrich-from-reviews/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // One entry per source type per contact (most-recent wins)
   const seenRR = new Set<string>();
   const seenRev = new Set<string>();
-  // contactId → enriched value
+  // contactId > enriched value
   const phoneEnrichments = new Map<string, string>();
   const nameEnrichments = new Map<string, string>();
 

--- a/src/app/api/admin/contacts/resolve-conflict/route.ts
+++ b/src/app/api/admin/contacts/resolve-conflict/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ } from "@/shared/lib/normalize-phone";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
 
 interface ResolveBody {
   /** Local contact ID to update. */

--- a/src/app/api/admin/review-requests/[id]/route.ts
+++ b/src/app/api/admin/review-requests/[id]/route.ts
@@ -7,7 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
 
 /**
  * PATCH /api/admin/review-requests/[id]

--- a/src/app/api/admin/review-requests/route.ts
+++ b/src/app/api/admin/review-requests/route.ts
@@ -7,7 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
 
 /**
  * POST /api/admin/review-requests

--- a/src/app/api/admin/reviews/[id]/route.ts
+++ b/src/app/api/admin/reviews/[id]/route.ts
@@ -14,10 +14,10 @@ import { revalidateReviewPaths } from "@/features/reviews/lib/revalidate";
  * PATCH /api/admin/reviews/[id]
  * Approves or revokes a review, or updates the linked contactId.
  * Authenticated via X-Admin-Secret header.
- * - When body contains { action: "approve" | "revoke" } → moderation flow.
+ * - When body contains { action: "approve" | "revoke" } > moderation flow.
  *   On approve, automatically upserts a Contact record from the review's booking/review-request
  *   and links review.contactId. This is best-effort; failure does not block the approval.
- * - When body contains { contactId: string | null } → contact-link flow.
+ * - When body contains { contactId: string | null } > contact-link flow.
  * @param request - Incoming request.
  * @param params - Route segment params wrapper.
  * @param params.params - Promise resolving to the route segment containing the review ID.

--- a/src/app/api/admin/reviews/match-contacts/route.ts
+++ b/src/app/api/admin/reviews/match-contacts/route.ts
@@ -7,7 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ, normalizePhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, normalisePhone } from "@/shared/lib/normalise-phone";
 
 /**
  * POST /api/admin/reviews/match-contacts
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const bookingPhoneById = new Map<string, string>();
     for (const b of bookings) {
       if (b.phone) {
-        const norm = normalizePhone(toE164NZ(b.phone) || b.phone);
+        const norm = normalisePhone(toE164NZ(b.phone) || b.phone);
         if (norm) bookingPhoneById.set(b.id, norm);
       }
     }
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     for (const rr of rrRows) {
       if (rr.email) rrEmailByToken.set(rr.reviewToken, rr.email.toLowerCase());
       if (rr.phone) {
-        const norm = normalizePhone(toE164NZ(rr.phone) || rr.phone);
+        const norm = normalisePhone(toE164NZ(rr.phone) || rr.phone);
         if (norm) rrPhoneByToken.set(rr.reviewToken, norm);
       }
     }
@@ -81,7 +81,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const contactIdByPhone = new Map<string, string>();
     for (const c of contacts) {
       if (c.phone) {
-        const norm = normalizePhone(c.phone);
+        const norm = normalisePhone(c.phone);
         if (norm && !contactIdByPhone.has(norm)) contactIdByPhone.set(norm, c.id);
       }
     }

--- a/src/app/api/admin/send-review-link/route.ts
+++ b/src/app/api/admin/send-review-link/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { sendPastClientReviewRequest } from "@/features/reviews/lib/email";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
 
 /**
  * POST /api/admin/send-review-link

--- a/src/app/api/booking/edit/route.ts
+++ b/src/app/api/booking/edit/route.ts
@@ -24,7 +24,7 @@ import {
   fetchAllCalendarEvents,
 } from "@/features/calendar/lib/google-calendar";
 import { Prisma } from "@prisma/client";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import {
   sendCustomerBookingConfirmation,

--- a/src/app/api/booking/hold/route.ts
+++ b/src/app/api/booking/hold/route.ts
@@ -12,7 +12,7 @@ import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
 import { createBookingEvent } from "@/features/calendar/lib/google-calendar";
 import { randomUUID } from "crypto";
 import { Prisma } from "@prisma/client";
-import { toE164NZ } from "@/shared/lib/normalize-phone";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 
 const HOLD_EXPIRATION_MINUTES = 15;

--- a/src/app/api/booking/hold/route.ts
+++ b/src/app/api/booking/hold/route.ts
@@ -15,7 +15,6 @@ import { Prisma } from "@prisma/client";
 import { toE164NZ } from "@/shared/lib/normalize-phone";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 
-// Hold expiration time in minutes
 const HOLD_EXPIRATION_MINUTES = 15;
 
 /**
@@ -65,11 +64,9 @@ export async function POST(request: NextRequest): Promise<NextResponse<CreateBoo
   if (limited) return limited as NextResponse<CreateBookingResponse>;
 
   try {
-    // Parse and validate request body
     const body = (await request.json()) as CreateBookingRequest;
     const { name, email, phone, notes, dateKey, slotStart, slotEnd, meetingType, address } = body;
 
-    // Basic validation
     if (!name?.trim()) {
       return NextResponse.json({ ok: false, error: "Name is required." }, { status: 400 });
     }

--- a/src/app/api/booking/request/route.ts
+++ b/src/app/api/booking/request/route.ts
@@ -29,7 +29,7 @@ import {
 import { randomUUID } from "crypto";
 import { Prisma } from "@prisma/client";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 
 interface BookingRequestPayload {

--- a/src/app/api/business/invoices/import-drive/route.ts
+++ b/src/app/api/business/invoices/import-drive/route.ts
@@ -54,7 +54,7 @@ function decodePdfString(s: string): string {
     }
     // Byte 92 ('\') decodes to 'y' (92+29=121). When the PDF escape handler captures
     // '\' + next_byte, both pass through decode and produce spurious 'y' between
-    // uppercase letters (e.g. "HyELP" → "HELP", "DUyE" → "DUE").
+    // uppercase letters (e.g. "HyELP" > "HELP", "DUyE" > "DUE").
     return out.replace(/([A-Z])y([A-Z])/g, "$1$2");
   }
   return s;

--- a/src/app/api/business/invoices/sync-drive/route.ts
+++ b/src/app/api/business/invoices/sync-drive/route.ts
@@ -16,7 +16,7 @@ function extractCandidates(filename: string): string[] {
   if (!m) return [];
   const raw = m[1]; // e.g. "TTP-202627-0006" or "TTP-0001"
   const candidates = [raw];
-  // Normalise 6-digit year like "202627" → 4-digit "2627"
+  // Normalise 6-digit year like "202627" > 4-digit "2627"
   const yearMatch = raw.match(/^([A-Z]+-)(\d{6})(-.+)$/i);
   if (yearMatch) candidates.push(`${yearMatch[1]}${yearMatch[2].slice(-4)}${yearMatch[3]}`);
   return candidates;

--- a/src/app/api/business/parse-job/route.ts
+++ b/src/app/api/business/parse-job/route.ts
@@ -74,7 +74,7 @@ function calcSessionMins(input: string): number | null {
     let dur = end - start;
     if (dur <= 0) {
       // Prefer the smallest positive result that fits a reasonable session (≤ 16h).
-      // +12h handles unmarked am/pm crossing noon (e.g. "11:25-1:20" → 115 min).
+      // +12h handles unmarked am/pm crossing noon (e.g. "11:25-1:20" > 115 min).
       // +24h is the fallback for overnight runs.
       const withNoon = dur + 12 * 60;
       dur = withNoon > 0 && withNoon <= 16 * 60 ? withNoon : dur + 24 * 60;

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { prisma as prismaClient } from "@/shared/lib/prisma";
 import { sendOwnerReviewNotification } from "@/features/reviews/lib/email";
-import { normalizePhone } from "@/shared/lib/normalize-phone";
+import { normalisePhone } from "@/shared/lib/normalise-phone";
 import { reviewTextError } from "@/features/reviews/lib/validation";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 
@@ -159,7 +159,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         }
         // Store any contact details the customer provided (only fill blanks, never overwrite)
         const contactEmail = body.contactEmail?.trim().toLowerCase() || null;
-        const contactPhone = body.contactPhone ? normalizePhone(body.contactPhone) : null;
+        const contactPhone = body.contactPhone ? normalisePhone(body.contactPhone) : null;
         await prisma.reviewRequest.update({
           where: { id: reviewRequest.id },
           data: {

--- a/src/features/admin/components/ContactAdminList.tsx
+++ b/src/features/admin/components/ContactAdminList.tsx
@@ -13,7 +13,7 @@ import { useState, useEffect } from "react";
 import { cn } from "@/shared/lib/cn";
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
 import { formatReviewerName } from "@/features/reviews/lib/formatting";
-import { normalizePhone, isValidPhone } from "@/shared/lib/normalize-phone";
+import { normalisePhone, isValidPhone } from "@/shared/lib/normalise-phone";
 import { formatDateShort } from "@/shared/lib/date-format";
 
 export interface ContactRow {
@@ -524,7 +524,7 @@ export function ContactAdminList({
       setEditError("Please enter a valid email address.");
       return;
     }
-    if (editPhone.trim() && !isValidPhone(normalizePhone(editPhone))) {
+    if (editPhone.trim() && !isValidPhone(normalisePhone(editPhone))) {
       setEditError("Please enter a valid phone number.");
       return;
     }
@@ -625,7 +625,7 @@ export function ContactAdminList({
    * Validates the phone field when the input loses focus.
    */
   function handlePhoneBlur(): void {
-    if (editPhone.trim() && !isValidPhone(normalizePhone(editPhone))) {
+    if (editPhone.trim() && !isValidPhone(normalisePhone(editPhone))) {
       setPhoneBlurError("Please enter a valid phone number.");
     }
   }

--- a/src/features/admin/components/TravelBlockAdminList.tsx
+++ b/src/features/admin/components/TravelBlockAdminList.tsx
@@ -45,7 +45,7 @@ const MODES: { value: TransportMode; label: string; icon: string }[] = [
  * Formats a minutes value for display.
  * @param raw - Raw minutes from API, or null.
  * @param rounded - Rounded minutes used for blocking, or null.
- * @returns Formatted string like "21 min → 30 min blocked".
+ * @returns Formatted string like "21 min > 30 min blocked".
  */
 function formatMinutes(raw: number | null, rounded: number | null): string {
   if (raw === null) return "\u2013";

--- a/src/features/admin/lib/auto-maintain.ts
+++ b/src/features/admin/lib/auto-maintain.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PrismaClient } from "@prisma/client";
-import { toE164NZ, normalizePhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, normalisePhone } from "@/shared/lib/normalise-phone";
 import type { ConflictEntry } from "@/app/api/admin/contacts/enrich-from-reviews/route";
 
 /**
@@ -56,7 +56,7 @@ async function backfillContacts(prisma: PrismaClient): Promise<void> {
   >();
   for (const c of allContacts) {
     if (!c.phone) continue;
-    const norm = normalizePhone(toE164NZ(c.phone) || c.phone);
+    const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
     if (!norm) continue;
     if (!phoneBuckets.has(norm)) phoneBuckets.set(norm, { withEmail: null, phoneOnly: [] });
     const bucket = phoneBuckets.get(norm)!;
@@ -83,13 +83,13 @@ async function backfillContacts(prisma: PrismaClient): Promise<void> {
     existing.filter((c) => c.email).map((c) => c.email!.toLowerCase()),
   );
   const existingPhones = new Set(
-    existing.filter((c) => c.phone).map((c) => normalizePhone(toE164NZ(c.phone!) || c.phone!)),
+    existing.filter((c) => c.phone).map((c) => normalisePhone(toE164NZ(c.phone!) || c.phone!)),
   );
   // Remaining phone-only contacts (post-merge) - used to merge-on-create below
   const phoneOnlyByNorm = new Map<string, (typeof existing)[number]>();
   for (const c of existing) {
     if (!c.email && c.phone) {
-      const norm = normalizePhone(toE164NZ(c.phone) || c.phone);
+      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
       if (norm) phoneOnlyByNorm.set(norm, c);
     }
   }
@@ -122,7 +122,7 @@ async function backfillContacts(prisma: PrismaClient): Promise<void> {
       });
     } else if (rr.phone) {
       const phone = toE164NZ(rr.phone) || rr.phone;
-      const normPhone = normalizePhone(phone);
+      const normPhone = normalisePhone(phone);
       if (!normPhone || existingPhones.has(normPhone)) continue;
       if (!toCreateByPhone.has(normPhone)) {
         toCreateByPhone.set(normPhone, { name: rr.name, email: null, phone });
@@ -137,7 +137,7 @@ async function backfillContacts(prisma: PrismaClient): Promise<void> {
       // If a phone-only contact already has this phone, merge email into it rather than
       // creating a duplicate contact.
       if (d.phone) {
-        const norm = normalizePhone(toE164NZ(d.phone) || d.phone);
+        const norm = normalisePhone(toE164NZ(d.phone) || d.phone);
         const phoneOnlyMatch = norm ? phoneOnlyByNorm.get(norm) : undefined;
         if (phoneOnlyMatch) {
           const updates: { email: string; name?: string; address?: string } = { email: d.email };
@@ -201,7 +201,7 @@ async function matchReviewContacts(prisma: PrismaClient): Promise<void> {
   const bookingPhoneById = new Map<string, string>();
   for (const b of bookingRows) {
     if (b.phone) {
-      const norm = normalizePhone(toE164NZ(b.phone) || b.phone);
+      const norm = normalisePhone(toE164NZ(b.phone) || b.phone);
       if (norm) bookingPhoneById.set(b.id, norm);
     }
   }
@@ -212,7 +212,7 @@ async function matchReviewContacts(prisma: PrismaClient): Promise<void> {
   const contactIdByPhone = new Map<string, string>();
   for (const c of contacts) {
     if (c.phone) {
-      const norm = normalizePhone(toE164NZ(c.phone) || c.phone);
+      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
       if (norm && !contactIdByPhone.has(norm)) contactIdByPhone.set(norm, c.id);
     }
   }
@@ -222,7 +222,7 @@ async function matchReviewContacts(prisma: PrismaClient): Promise<void> {
   for (const rr of rrRows) {
     if (rr.email) emailByToken.set(rr.reviewToken, rr.email.toLowerCase());
     if (rr.phone) {
-      const norm = normalizePhone(toE164NZ(rr.phone) || rr.phone);
+      const norm = normalisePhone(toE164NZ(rr.phone) || rr.phone);
       if (norm) phoneByToken.set(rr.reviewToken, norm);
     }
   }
@@ -282,7 +282,7 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
   const contactByPhone = new Map<string, (typeof contacts)[0]>();
   for (const c of contacts) {
     if (c.phone) {
-      const norm = normalizePhone(toE164NZ(c.phone) || c.phone);
+      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
       if (norm && !contactByPhone.has(norm)) contactByPhone.set(norm, c);
     }
   }
@@ -302,7 +302,7 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
       if (c) return c;
     }
     if (phone) {
-      const norm = normalizePhone(toE164NZ(phone) || phone);
+      const norm = normalisePhone(toE164NZ(phone) || phone);
       if (norm) return contactByPhone.get(norm);
     }
     return undefined;
@@ -325,8 +325,8 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
     if (!contact) continue;
 
     const proposedPhoneRaw = rr.phone?.trim() ?? null;
-    const proposedPhone = proposedPhoneRaw ? normalizePhone(proposedPhoneRaw) : null;
-    const existingPhone = contact.phone ? normalizePhone(contact.phone) : null;
+    const proposedPhone = proposedPhoneRaw ? normalisePhone(proposedPhoneRaw) : null;
+    const existingPhone = contact.phone ? normalisePhone(contact.phone) : null;
 
     if (proposedPhone && !existingPhone && !phoneFilled.has(contact.id)) {
       phoneFilled.add(contact.id);
@@ -387,8 +387,8 @@ async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
     if (!contact) continue;
 
     const proposedPhoneRaw = booking.phone?.trim() ?? null;
-    const proposedPhone = proposedPhoneRaw ? normalizePhone(proposedPhoneRaw) : null;
-    const existingPhone = contact.phone ? normalizePhone(contact.phone) : null;
+    const proposedPhone = proposedPhoneRaw ? normalisePhone(proposedPhoneRaw) : null;
+    const existingPhone = contact.phone ? normalisePhone(contact.phone) : null;
     const address = booking.notes?.match(/Address:\s*(.+)/i)?.[1]?.trim() ?? null;
 
     if (proposedPhone && !existingPhone && !phoneFilled.has(contact.id)) {

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -22,7 +22,7 @@ import {
   type StartMinute,
   type JobDuration,
 } from "@/features/booking/lib/booking";
-import { normalizePhone, isValidPhone } from "@/shared/lib/normalize-phone";
+import { normalisePhone, isValidPhone } from "@/shared/lib/normalise-phone";
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
 
 export interface BookingFormInitialValues {
@@ -279,7 +279,7 @@ export default function BookingForm({
     // Phone is optional, but if present must be valid. Re-run validation here
     // in case the user typed without blurring (phoneError only sets on blur).
     if (phone.trim()) {
-      const phoneOk = isValidPhone(normalizePhone(phone));
+      const phoneOk = isValidPhone(normalisePhone(phone));
       if (!phoneOk) {
         setPhoneError("Please enter a valid phone number.");
         setError("Please fix the phone number, or leave it blank.");
@@ -715,7 +715,7 @@ export default function BookingForm({
               setPhoneError(null);
             }}
             onBlur={() => {
-              if (phone.trim() && !isValidPhone(normalizePhone(phone))) {
+              if (phone.trim() && !isValidPhone(normalisePhone(phone))) {
                 setPhoneError("Please enter a valid phone number.");
               }
             }}

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -195,7 +195,6 @@ export default function BookingForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount
 
-  // Split days into weekdays and weekends
   const weekdays = availableDays.filter((d) => !d.isWeekend);
   const weekends = availableDays.filter((d) => d.isWeekend);
 
@@ -238,7 +237,7 @@ export default function BookingForm({
   }
 
   /**
-   * Format a sub-slot time label, e.g. startHour=14, minute=15 → "2:15pm"
+   * Format a sub-slot time label, e.g. startHour=14, minute=15 > "2:15pm".
    * @param startHour - The hour in 24h format (e.g. 14 for 2pm)
    * @param minute - Minutes past the hour (0, 15, 30, or 45)
    * @returns Formatted time string (e.g. "2:15pm")
@@ -311,7 +310,7 @@ export default function BookingForm({
     // Soft geocode check for typed-but-not-picked addresses. First failure
     // sets addressOverrideAcked so the customer can click Submit again to
     // proceed. Network/API outages don't block submission - the booking
-    // still goes through and I can clarify if needed.
+    // still goes through and is clarified out-of-band if needed.
     if (meetingType === "in-person" && !addressVerified && !addressOverrideAcked) {
       try {
         const verifyRes = await fetch("/api/pricing/travel-time", {

--- a/src/features/booking/lib/booking.ts
+++ b/src/features/booking/lib/booking.ts
@@ -123,7 +123,6 @@ function isSlotFree(
   calendarEvents: Array<{ id: string; start: string; end: string }>,
   bufferMin: number,
 ): boolean {
-  // Check database bookings
   for (const booking of existingBookings) {
     const bookingStart = new Date(booking.startAt.getTime() - booking.bufferBeforeMin * 60 * 1000);
     const bookingEnd = new Date(booking.endAt.getTime() + booking.bufferAfterMin * 60 * 1000);
@@ -190,7 +189,6 @@ export function buildAvailableDays(
     const isToday = i === 0;
     const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
 
-    // Format labels
     const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
     const shortDayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
     const monthNames = [
@@ -290,7 +288,6 @@ export function buildAvailableDays(
       });
     }
 
-    // Check if day has any available slots
     const hasAnySlots = timeWindows.some((w) => w.availableShort || w.availableLong);
 
     // Hide today when nothing is bookable (e.g. past same-day cutoff).
@@ -366,7 +363,6 @@ export function validateBookingRequest(
   // Get dynamic UTC offset for this date (handles NZDT/NZST)
   const utcOffset = getPacificAucklandOffset(year, month, day);
 
-  // Check if slot is actually available for this duration
   const durationMinutes = duration === "short" ? 60 : 120;
   const slotStart = new Date(
     Date.UTC(year, month - 1, day, slot.startHour - utcOffset, startMinute, 0),

--- a/src/features/business/components/CalculatorView.tsx
+++ b/src/features/business/components/CalculatorView.tsx
@@ -515,7 +515,6 @@ export function CalculatorView({ token }: { token: string }): React.ReactElement
     if (d.ok) {
       setIncomeToast("Income entry saved.");
       setTimeout(() => setIncomeToast(null), 3000);
-      // Reset
       setDurationOverride(null);
       setTasks([]);
       setParts([]);

--- a/src/features/business/components/PromosView.tsx
+++ b/src/features/business/components/PromosView.tsx
@@ -27,7 +27,7 @@ interface FormState {
 }
 
 /**
- * ISO timestamp -> "YYYY-MM-DD" (local date parts) for <input type="date">.
+ * ISO timestamp > "YYYY-MM-DD" (local date parts) for <input type="date">.
  * @param iso - ISO 8601 timestamp.
  * @returns Date-input string, or empty for invalid input.
  */
@@ -45,7 +45,7 @@ function toDateInput(iso: string): string {
 }
 
 /**
- * YYYY-MM-DD -> ISO timestamp at local-midnight (start of day).
+ * YYYY-MM-DD > ISO timestamp at local-midnight (start of day).
  * @param date - YYYY-MM-DD string.
  * @returns ISO timestamp.
  */
@@ -54,7 +54,7 @@ function startOfDayISO(date: string): string {
 }
 
 /**
- * YYYY-MM-DD -> ISO timestamp at start of next day (so end is inclusive).
+ * YYYY-MM-DD > ISO timestamp at start of next day (so end is inclusive).
  * @param date - YYYY-MM-DD string.
  * @returns ISO timestamp.
  */
@@ -65,7 +65,7 @@ function endOfDayISO(date: string): string {
 }
 
 /**
- * `endAt` ISO -> inclusive YYYY-MM-DD (subtracts the day we added on save).
+ * `endAt` ISO > inclusive YYYY-MM-DD (subtracts the day we added on save).
  * @param iso - ISO 8601 timestamp.
  * @returns Date-input string.
  */

--- a/src/features/business/lib/google-drive.ts
+++ b/src/features/business/lib/google-drive.ts
@@ -35,7 +35,7 @@ async function getOrCreateFolder(parentId: string, name: string): Promise<string
 
 /**
  * Converts a year code to the Drive folder name format used by the Apps Script.
- * "202627" → "2026-27" (6-digit, current format); "2627" → "2026-27" (4-digit, legacy fallback).
+ * "202627" > "2026-27" (6-digit, current format); "2627" > "2026-27" (4-digit, legacy fallback).
  * @param yearCode - Compact fiscal year code string
  * @returns Human-readable folder name like "2026-27"
  */

--- a/src/features/business/lib/invoice-pdf.ts
+++ b/src/features/business/lib/invoice-pdf.ts
@@ -385,7 +385,7 @@ function drawLineItemsTable(ctx: PdfCtx, invoice: Invoice, y: number): number {
  * @returns Y coordinate below the Total row.
  */
 function drawTotalsBlock(ctx: PdfCtx, invoice: Invoice, y: number): number {
-  // Label area widened (0.4 → 0.6 of CONTENT_W) so long promo titles fit.
+  // Label area widened (0.4 > 0.6 of CONTENT_W) so long promo titles fit.
   const totalsLabelX = MARGIN + CONTENT_W * 0.4;
   const totalsValueX = MARGIN + CONTENT_W;
 
@@ -594,7 +594,7 @@ export async function generateInvoicePdf(invoice: Invoice): Promise<Buffer> {
 }
 
 /**
- * Extracts the fiscal year code from an invoice number (e.g. "TTP-2627-0042" -> "2627").
+ * Extracts the fiscal year code from an invoice number (e.g. "TTP-2627-0042" > "2627").
  * Falls back to deriving the current fiscal year if the number doesn't match.
  * @param invoiceNumber - Invoice number string.
  * @returns Two-digit fiscal year code (e.g. "2627").

--- a/src/features/business/lib/sheets-sync.ts
+++ b/src/features/business/lib/sheets-sync.ts
@@ -1,7 +1,7 @@
 // src/features/business/lib/sheets-sync.ts
 /**
  * @file sheets-sync.ts
- * @description Site → Google Sheet write-back. Hidden Sync ID at column Z
+ * @description Site > Google Sheet write-back. Hidden Sync ID at column Z
  * carries a UUID so edits/deletes can find rows. Failures are non-fatal.
  */
 
@@ -11,10 +11,10 @@ import { getDriveClient } from "@/features/business/lib/google-drive";
 import { formatDateSlash } from "@/shared/lib/date-format";
 import { getFinancialYear } from "@/features/business/lib/financial-year";
 
-/** Cache: FY key (e.g. "2025-26") → spreadsheet file ID. */
+/** Cache: FY key (e.g. "2025-26") > spreadsheet file ID. */
 const fySheetCache = new Map<string, string>();
 
-/** Cache: spreadsheet file ID → Set of tab names that have already had Sync ID setup applied. */
+/** Cache: spreadsheet file ID > Set of tab names that have already had Sync ID setup applied. */
 const setupCache = new Map<string, Set<string>>();
 
 /** Column Z (0-indexed 25) is where the Sync ID lives, well clear of any data column. */

--- a/src/features/calendar/lib/google-calendar.ts
+++ b/src/features/calendar/lib/google-calendar.ts
@@ -210,7 +210,7 @@ export async function fetchAllCalendarEvents(
         } else if (event.start?.date && event.end?.date && !isPersonal) {
           // All-day event from a non-personal calendar - block the full NZ day(s).
           // All-day events use date strings ("YYYY-MM-DD"); end.date is exclusive.
-          // Convert NZ calendar midnight → UTC so slot checking works correctly.
+          // Convert NZ calendar midnight > UTC so slot checking works correctly.
           const startDateStr = event.start.date;
           const endDateStr = event.end.date;
           const [sYear, sMonth, sDay] = startDateStr.split("-").map(Number);

--- a/src/features/contacts/lib/google-contacts.ts
+++ b/src/features/contacts/lib/google-contacts.ts
@@ -43,7 +43,7 @@ export async function importFromGoogleContacts(): Promise<number> {
   try {
     const people = getPeopleClient();
 
-    // Build phone → email map from ReviewRequest history so phone-only Google
+    // Build phone > email map from ReviewRequest history so phone-only Google
     // contacts can be matched to a known email and imported.
     const reviewRequestsByPhone = new Map<string, string>();
     const rrRows = await prisma.reviewRequest.findMany({

--- a/src/features/contacts/lib/google-contacts.ts
+++ b/src/features/contacts/lib/google-contacts.ts
@@ -21,7 +21,7 @@
 import { google } from "googleapis";
 import { prisma } from "@/shared/lib/prisma";
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
-import { normalizePhone, toE164NZ } from "@/shared/lib/normalize-phone";
+import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
 import { recordContactConflict, clearContactConflict } from "./contact-conflicts";
 
 /**
@@ -53,7 +53,7 @@ export async function importFromGoogleContacts(): Promise<number> {
     });
     for (const rr of rrRows) {
       if (!rr.phone || !rr.email) continue;
-      const norm = normalizePhone(toE164NZ(rr.phone) || rr.phone);
+      const norm = normalisePhone(toE164NZ(rr.phone) || rr.phone);
       if (norm && !reviewRequestsByPhone.has(norm)) reviewRequestsByPhone.set(norm, rr.email);
     }
 
@@ -91,7 +91,7 @@ export async function importFromGoogleContacts(): Promise<number> {
         const emailEntry = person.emailAddresses?.[0]?.value?.trim().toLowerCase() ?? null;
         const rawPhone = person.phoneNumbers?.[0]?.value?.trim() ?? null;
         const phone = rawPhone ? toE164NZ(rawPhone) || rawPhone : null;
-        const normPhone = rawPhone ? normalizePhone(toE164NZ(rawPhone) || rawPhone) : null;
+        const normPhone = rawPhone ? normalisePhone(toE164NZ(rawPhone) || rawPhone) : null;
         const name =
           person.names?.[0]?.displayName?.trim() ??
           person.names?.[0]?.givenName?.trim() ??
@@ -310,14 +310,14 @@ function mergePhones(sitePhone: string | null, googlePhones: string[]): string[]
   for (const raw of googlePhones) {
     const trimmed = raw?.trim();
     if (!trimmed) continue;
-    const key = normalizePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
+    const key = normalisePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
     if (seen.has(key)) continue;
     seen.add(key);
     result.push(trimmed);
   }
   if (sitePhone?.trim()) {
     const trimmed = sitePhone.trim();
-    const key = normalizePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
+    const key = normalisePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
     if (!seen.has(key)) {
       seen.add(key);
       result.push(trimmed);

--- a/src/features/reviews/components/ReviewForm.tsx
+++ b/src/features/reviews/components/ReviewForm.tsx
@@ -64,10 +64,9 @@ export default function ReviewFormProtected({
   const isEditing = !!existingReview;
   const isVerified = !!((bookingId || reviewRequestId) && token);
 
-  // Derive initial name display mode from existing review or booking name
   /**
-   * Returns the initial name display mode based on existing review data or booking name.
-   * @returns The name display mode: "anonymous", "full", or "first".
+   * Initial name-display mode: keep existing anonymity if editing, otherwise show the name.
+   * @returns "anonymous" or "name".
    */
   function initialNameDisplay(): NameDisplay {
     if (existingReview) {

--- a/src/features/reviews/components/ReviewForm.tsx
+++ b/src/features/reviews/components/ReviewForm.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/components/Button";
 import { useId, useState } from "react";
 import { useRouter } from "next/navigation";
-import { formatNZPhone, normalizePhone, isValidPhone } from "@/shared/lib/normalize-phone";
+import { formatNZPhone, normalisePhone, isValidPhone } from "@/shared/lib/normalise-phone";
 
 type NameDisplay = "name" | "anonymous";
 
@@ -87,7 +87,7 @@ export default function ReviewFormProtected({
   const [contactEmail, setContactEmail] = useState(prefillEmail ?? "");
   // Store raw phone digits internally; display formatted
   const [phoneInput, setPhoneInput] = useState(
-    prefillPhone ? formatNZPhone(normalizePhone(prefillPhone)) : "",
+    prefillPhone ? formatNZPhone(normalisePhone(prefillPhone)) : "",
   );
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -100,7 +100,7 @@ export default function ReviewFormProtected({
   const remaining = textMax - textCount;
   const isAnonymous = nameDisplay === "anonymous";
 
-  const phoneNormalized = normalizePhone(phoneInput);
+  const phoneNormalized = normalisePhone(phoneInput);
   const phoneInvalid = !!phoneInput.trim() && !isValidPhone(phoneNormalized);
 
   const NAME_OPTIONS: { value: NameDisplay; label: string }[] = [

--- a/src/features/reviews/components/admin/ReviewLinkHistoryTable.tsx
+++ b/src/features/reviews/components/admin/ReviewLinkHistoryTable.tsx
@@ -10,7 +10,7 @@ import type React from "react";
 import { FaCheck } from "react-icons/fa6";
 import { cn } from "@/shared/lib/cn";
 import { CopyLinkButton } from "./CopyLinkButton";
-import { toE164NZ, formatNZPhone, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, formatNZPhone, isValidPhone } from "@/shared/lib/normalise-phone";
 import { formatDateShort } from "@/shared/lib/date-format";
 
 /**

--- a/src/features/reviews/components/admin/SendReviewLinkForm.tsx
+++ b/src/features/reviews/components/admin/SendReviewLinkForm.tsx
@@ -339,7 +339,7 @@ export function SendReviewLinkForm({
             ))}
           </div>
 
-          {/* Email mode: form → preview → confirm send */}
+          {/* Email mode: form > preview > confirm send */}
           {mode === "email" && !previewHtml && (
             <form onSubmit={handlePreview} className={cn("flex flex-col gap-3")}>
               <div className={cn("flex flex-col gap-2")}>

--- a/src/features/reviews/components/admin/SendReviewLinkForm.tsx
+++ b/src/features/reviews/components/admin/SendReviewLinkForm.tsx
@@ -8,7 +8,7 @@
 import { useState, useRef } from "react";
 import { cn } from "@/shared/lib/cn";
 import { CopyLinkButton } from "./CopyLinkButton";
-import { toE164NZ, formatNZPhone, isValidPhone } from "@/shared/lib/normalize-phone";
+import { toE164NZ, formatNZPhone, isValidPhone } from "@/shared/lib/normalise-phone";
 import type React from "react";
 import { FaCaretLeft } from "react-icons/fa6";
 

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -14,11 +14,10 @@ export type ButtonVariant = "primary" | "secondary" | "tertiary" | "ghost";
 export type ButtonSize = "sm" | "md" | "lg";
 
 /**
- * Button props when rendering as a Next.js Link (href present)
+ * Button props when rendering as a Next.js Link (href present).
  */
 interface ButtonAsLink {
   href: string;
-  // Next.js Link props
   prefetch?: boolean;
   scroll?: boolean;
   replace?: boolean;
@@ -27,7 +26,6 @@ interface ButtonAsLink {
    * Use for file downloads so the browser handles them directly without the router.
    */
   download?: string;
-  // Button-specific props
   variant?: ButtonVariant;
   size?: ButtonSize;
   fullWidth?: boolean;
@@ -38,27 +36,23 @@ interface ButtonAsLink {
   disabled?: boolean;
   className?: string;
   children: React.ReactNode;
-  // Accessibility
   "aria-current"?: "page" | "step" | "location" | "date" | "time" | "true" | "false";
   "aria-label"?: string;
 }
 
 /**
- * Button props when rendering as a native button element (no href)
+ * Button props when rendering as a native button element (no href).
  */
 interface ButtonAsButton {
-  href?: never; // explicitly exclude href
-  // Native button props
+  href?: never;
   type?: "button" | "submit" | "reset";
   disabled?: boolean;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  // Button-specific props
   variant?: ButtonVariant;
   size?: ButtonSize;
   fullWidth?: boolean;
   className?: string;
   children: React.ReactNode;
-  // Accessibility
   "aria-label"?: string;
   "aria-disabled"?: boolean;
 }
@@ -66,9 +60,9 @@ interface ButtonAsButton {
 export type ButtonProps = ButtonAsLink | ButtonAsButton;
 
 /**
- * Get variant-specific classes
- * @param variant - Button variant type
- * @returns Tailwind class string for the variant
+ * Tailwind classes for the given variant.
+ * @param variant - Button variant.
+ * @returns Class string.
  */
 function getVariantClasses(variant: ButtonVariant): string {
   switch (variant) {
@@ -98,9 +92,9 @@ function getVariantClasses(variant: ButtonVariant): string {
 }
 
 /**
- * Get size-specific classes
- * @param size - Button size type
- * @returns Tailwind class string for the size
+ * Tailwind classes for the given size.
+ * @param size - Button size.
+ * @returns Class string.
  */
 function getSizeClasses(size: ButtonSize): string {
   switch (size) {
@@ -132,7 +126,6 @@ export function Button(props: ButtonProps): React.ReactElement {
     ...rest
   } = props;
 
-  // Base classes shared by all buttons
   const baseClasses = cn(
     "inline-flex items-center justify-center gap-2",
     "rounded-lg font-bold",
@@ -144,7 +137,6 @@ export function Button(props: ButtonProps): React.ReactElement {
     className,
   );
 
-  // Discriminate based on href presence
   if ("href" in props && props.href) {
     const {
       href,
@@ -177,15 +169,14 @@ export function Button(props: ButtonProps): React.ReactElement {
         className={baseClasses}
         aria-current={ariaCurrent}
         aria-label={ariaLabel}
-        // Note: disabled is applied via className (opacity/cursor)
-        // Link will still navigate - use conditional rendering if truly disabled
+        // `disabled` here is visual only (opacity/cursor) - Link still navigates.
+        // Use conditional rendering when the link should be truly inert.
       >
         {children}
       </Link>
     );
   }
 
-  // Render as button
   const {
     type = "button",
     onClick,

--- a/src/shared/components/NavBar.tsx
+++ b/src/shared/components/NavBar.tsx
@@ -39,7 +39,7 @@ const DEEP_MIN_SCROLL_DELTA = 1;
 const TOP_HIDE_SCROLL_DISTANCE = 72;
 const MID_HIDE_SCROLL_DISTANCE = 120;
 const DEEP_HIDE_SCROLL_DISTANCE = 170;
-const FULL_HIDE_TRANSLATE = "120%"; // Vertical translate percentage when navbar is fully hidden
+const FULL_HIDE_TRANSLATE = "120%";
 const TOP_IDLE_HIDE_DELAY_MS = 900;
 const MID_IDLE_HIDE_DELAY_MS = 1200;
 const DEEP_IDLE_HIDE_DELAY_MS = 2300;
@@ -118,10 +118,8 @@ export function NavBar(): React.ReactElement | null {
   const headerRef = useRef<HTMLElement | null>(null);
 
   /**
-   * Set hidden state only when it changes.
+   * Set hidden state only when it changes (avoids redundant renders).
    * @param nextHidden - Target hidden state.
-   * @param reason - Why this transition happened.
-   * @param details - Optional context for debug logs.
    */
   const setHiddenSafely = useCallback((nextHidden: boolean): void => {
     setIsHidden((previous) => (previous === nextHidden ? previous : nextHidden));

--- a/src/shared/components/PageLayout.tsx
+++ b/src/shared/components/PageLayout.tsx
@@ -16,24 +16,21 @@ export const SOFT_CARD = cn(
   "border-seasalt-400/80 bg-seasalt-900/60 rounded-xl border p-3 text-sm sm:p-4 sm:text-base",
 );
 
-/**
- * Props for PageShell component
- */
+/** Props for PageShell. */
 export interface PageShellProps {
-  /** Child elements to render */
+  /** Child elements to render. */
   children: React.ReactNode;
 }
 
 /**
- * Main page shell with backdrop image
- * @param props - Component props
- * @param props.children - Page content
- * @returns Page shell element
+ * Main page shell with fixed backdrop image.
+ * @param props - Component props.
+ * @param props.children - Page content.
+ * @returns Page shell element.
  */
 export function PageShell({ children }: PageShellProps): React.ReactElement {
   return (
     <main className={cn("relative min-h-[calc(100dvh-4rem)] overflow-hidden")}>
-      {/* Backdrop */}
       <div className={cn("pointer-events-none fixed inset-0 -z-10 overflow-hidden")}>
         <Image
           src="/source/backdrop-blur.webp"
@@ -50,25 +47,23 @@ export function PageShell({ children }: PageShellProps): React.ReactElement {
   );
 }
 
-/**
- * Props for FrostedSection component
- */
+/** Props for FrostedSection. */
 export interface FrostedSectionProps {
-  /** Child elements to render */
+  /** Child elements to render. */
   children: React.ReactNode;
-  /** Maximum width constraint. Default scales with viewport: stays at 1440px on 1080p screens, grows to ~1920px on 1440p, caps at 2240px on 4K. */
+  /** Max width override. Default scales with viewport: 1440px on 1080p, ~1920px on 1440p, capped at 2240px on 4K. */
   maxWidth?: string;
-  /** Additional CSS classes */
+  /** Additional CSS classes. */
   className?: string;
 }
 
 /**
- * Frosted glass content section
- * @param props - Component props
- * @param props.children - Section content
- * @param props.maxWidth - Optional max width override
- * @param props.className - Optional additional classes
- * @returns Frosted section element
+ * Frosted glass content section.
+ * @param props - Component props.
+ * @param props.children - Section content.
+ * @param props.maxWidth - Optional max width override.
+ * @param props.className - Optional additional classes.
+ * @returns Frosted section element.
  */
 export function FrostedSection({
   children,

--- a/src/shared/lib/cn.ts
+++ b/src/shared/lib/cn.ts
@@ -8,9 +8,9 @@ import clsx, { ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 /**
- * Utility function to merge class names using clsx and tailwind-merge.
- * @param inputs - Class names to be merged.
- * @returns Merged class names as a single string.
+ * Merge class names with Tailwind conflict resolution (later classes win).
+ * @param inputs - Class values to merge.
+ * @returns Merged class string.
  */
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));

--- a/src/shared/lib/normalise-phone.ts
+++ b/src/shared/lib/normalise-phone.ts
@@ -1,16 +1,16 @@
-// src/shared/lib/normalize-phone.ts
+// src/shared/lib/normalise-phone.ts
 /**
- * @file normalize-phone.ts
- * @description Shared phone number normalization and validation utilities.
+ * @file normalise-phone.ts
+ * @description Shared phone number normalisation and validation utilities.
  */
 
 /**
  * Strip all non-digit characters except a leading '+'.
  * e.g. "021 123-456" > "021123456", "+64 21 123 456" > "+6421123456"
  * @param raw - Raw phone input string.
- * @returns Normalized phone string, or empty string if input is blank.
+ * @returns Normalised phone string, or empty string if input is blank.
  */
-export function normalizePhone(raw: string): string {
+export function normalisePhone(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return "";
   const prefix = trimmed.startsWith("+") ? "+" : "";
@@ -64,15 +64,15 @@ export function formatNZPhone(raw: string): string {
  *   "09 123 4567"   > "+6491234567"   (landline)
  *   "+64 21 123 1234" > "+64211231234" (already E.164)
  *   "+61 400 000 000" > "+61400000000" (non-NZ: left as-is)
- * Non-NZ numbers (no leading 0, no NZ mobile prefix, no +) are returned normalized.
+ * Non-NZ numbers (no leading 0, no NZ mobile prefix, no +) are returned normalised.
  * @param raw - Raw phone input string.
- * @returns E.164-normalized phone string, or empty string if input is blank.
+ * @returns E.164-normalised phone string, or empty string if input is blank.
  */
 export function toE164NZ(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return "";
   // Already has a + country code prefix - just strip formatting
-  if (trimmed.startsWith("+")) return normalizePhone(trimmed);
+  if (trimmed.startsWith("+")) return normalisePhone(trimmed);
   const digits = trimmed.replace(/\D/g, "");
   if (!digits) return "";
   // NZ domestic (leading 0): 021xxx, 09xxx, 04xxx etc.
@@ -87,13 +87,13 @@ export function toE164NZ(raw: string): string {
 }
 
 /**
- * Returns true when a normalized phone string looks like a valid phone number.
- * Requires 7–15 digits (E.164 max). The leading '+' is ignored for the count.
- * @param normalized - Already-normalized phone string (from normalizePhone).
+ * Returns true when a normalised phone string looks like a valid phone number.
+ * Requires 7-15 digits (E.164 max). The leading '+' is ignored for the count.
+ * @param normalised - Already-normalised phone string (from normalisePhone).
  * @returns Whether the phone number is valid.
  */
-export function isValidPhone(normalized: string): boolean {
-  if (!normalized) return true; // empty is fine - field is optional
-  const digits = normalized.replace(/\D/g, "");
+export function isValidPhone(normalised: string): boolean {
+  if (!normalised) return true; // empty is fine - field is optional
+  const digits = normalised.replace(/\D/g, "");
   return digits.length >= 7 && digits.length <= 15;
 }

--- a/src/shared/lib/normalize-phone.ts
+++ b/src/shared/lib/normalize-phone.ts
@@ -5,8 +5,8 @@
  */
 
 /**
- * Strips all non-digit characters except a leading '+'.
- * e.g. "021 123-456" → "021123456", "+64 21 123 456" → "+6421123456"
+ * Strip all non-digit characters except a leading '+'.
+ * e.g. "021 123-456" > "021123456", "+64 21 123 456" > "+6421123456"
  * @param raw - Raw phone input string.
  * @returns Normalized phone string, or empty string if input is blank.
  */
@@ -59,11 +59,11 @@ export function formatNZPhone(raw: string): string {
 /**
  * Converts a NZ phone number to E.164 format (+64...).
  * Handles all common NZ inputs:
- *   "021 123 1234"  → "+64211231234"
- *   "21 123 1234"   → "+64211231234"  (no leading 0)
- *   "09 123 4567"   → "+6491234567"   (landline)
- *   "+64 21 123 1234" → "+64211231234" (already E.164)
- *   "+61 400 000 000" → "+61400000000" (non-NZ: left as-is)
+ *   "021 123 1234"  > "+64211231234"
+ *   "21 123 1234"   > "+64211231234"  (no leading 0)
+ *   "09 123 4567"   > "+6491234567"   (landline)
+ *   "+64 21 123 1234" > "+64211231234" (already E.164)
+ *   "+61 400 000 000" > "+61400000000" (non-NZ: left as-is)
  * Non-NZ numbers (no leading 0, no NZ mobile prefix, no +) are returned normalized.
  * @param raw - Raw phone input string.
  * @returns E.164-normalized phone string, or empty string if input is blank.

--- a/src/shared/lib/prisma.ts
+++ b/src/shared/lib/prisma.ts
@@ -5,6 +5,7 @@
  */
 import { PrismaClient } from "@prisma/client";
 
+// Cache the Prisma client on globalThis so hot-reload in dev doesn't leak connections.
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
 export const prisma =

--- a/src/shared/lib/timezone-utils.ts
+++ b/src/shared/lib/timezone-utils.ts
@@ -5,18 +5,17 @@
  */
 
 /**
- * Get the UTC offset for Pacific/Auckland timezone on a specific date.
- * Automatically handles NZDT (UTC+13, Sep–Apr) and NZST (UTC+12, Apr–Sep).
- * @param year - Full year (e.g., 2026)
- * @param month - Month as 1-12 (not 0-indexed)
- * @param day - Day of month
- * @returns UTC offset in hours (13 during NZDT, 12 during NZST)
+ * UTC offset (hours) for Pacific/Auckland on a given date.
+ * Handles NZDT (UTC+13, Sep-Apr) and NZST (UTC+12, Apr-Sep) automatically.
+ * @param year - Full year.
+ * @param month - Month 1-12 (not 0-indexed).
+ * @param day - Day of month.
+ * @returns Offset in hours (12 or 13).
  */
 export function getPacificAucklandOffset(year: number, month: number, day: number): number {
-  // Create a date at midnight UTC on the target day
+  // Take the NZ wall-clock hour at UTC midnight; since UTC is at hour 0,
+  // that hour equals the offset directly. This sidesteps Intl DST APIs.
   const utcMidnight = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
-
-  // See what hour it is in NZ when it's midnight UTC
   const nzHour = parseInt(
     utcMidnight.toLocaleString("en-US", {
       timeZone: "Pacific/Auckland",
@@ -25,7 +24,5 @@ export function getPacificAucklandOffset(year: number, month: number, day: numbe
     }),
     10,
   );
-
-  // The NZ hour IS the offset (since UTC is at hour 0)
   return nzHour;
 }

--- a/src/shared/lib/useOnVisible.ts
+++ b/src/shared/lib/useOnVisible.ts
@@ -1,20 +1,19 @@
 // src/shared/lib/useOnVisible.ts
 /**
  * @file useOnVisible.ts
- * @description React hook that tracks whether a DOM element is visible in the
- * viewport (via IntersectionObserver) or has received focus, triggering a
- * one-time visibility flag used to defer expensive resource loading.
+ * @description Hook that latches true once an element first becomes visible or
+ * focused, used to defer loading heavy third-party scripts.
  */
 
 import { useEffect, useState } from "react";
 
 /**
- * Hook that returns true when the given element becomes visible in the viewport
- * or receives focus. It disconnects the observer after the first visible event.
- * @param ref - React ref pointing to the element to observe.
- * @param ref.current - The DOM element to observe (or null if not yet mounted).
- * @param options - Optional IntersectionObserver configuration.
- * @returns True once the element has entered the viewport or received focus.
+ * Latch `true` once the element first enters the viewport or receives focus,
+ * then disconnect. Used to defer loading heavy third-party scripts.
+ * @param ref - Ref to the element to observe.
+ * @param ref.current - DOM element (or null while unmounted).
+ * @param options - IntersectionObserver options.
+ * @returns Whether the element has been visible at least once.
  */
 export default function useOnVisible<T extends Element | null = Element>(
   ref: { current: T | null },
@@ -23,8 +22,8 @@ export default function useOnVisible<T extends Element | null = Element>(
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    // If IntersectionObserver is not available (older browsers / test env),
-    // consider the element visible so the script can load when needed.
+    // No IntersectionObserver (old browsers, test env): fall back to "always visible"
+    // so the script still loads rather than silently never firing.
     if (typeof IntersectionObserver === "undefined") {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setVisible(true);
@@ -49,12 +48,12 @@ export default function useOnVisible<T extends Element | null = Element>(
 
       observer.observe(el);
     } catch {
-      // In case the environment throws, fallback to visible.
+      // Defensive fallback if the constructor throws in some exotic env.
       setVisible(true);
     }
 
     /**
-     * Sets the element as visible and disconnects the observer on focus.
+     * Focus fallback: keyboard users may tab to the element before it scrolls in.
      */
     const onFocus = (): void => {
       setVisible(true);


### PR DESCRIPTION
## Summary

Dev rollup, `1.49.1` > `1.49.3`. Two themes:

1. Repo-wide comment audit (style only, no behaviour change)
2. Rename `normalize-phone` to `normalise-phone` to drop the US spelling

---

### 1. Comment audit

`72f48d5`

Read every `.ts/.tsx` file under `src/`, plus `scripts/` and root configs. Sweep covered:

- **Arrows in comments and JSDoc**: convert `->` and unicode `→` to `>`.
- **Voice**: switch to imperative/neutral. Drop first-person ("I cache the client...") and third-person ("Harrison can clarify...") narration. Mid-audit memory update locked this in: see `feedback_first_person_comments.md`, `feedback_comment_style.md`.
- **What-not-why markers removed**: `// Reset`, `// Parse and validate request body`, `// Format labels`, `// Check database bookings`, `// Render as button`, etc.
- **JSDoc trims**: tightened restating one-line summaries on small helpers. Kept long JSDoc where it documents real edge cases (e.g. `getInvoiceReviewEligibility`, `buildInvoiceEmail`, `lookupDriveDistance`).
- **Stale `@param` fixes**: `setHiddenSafely` in NavBar (4 params documented, function takes 1); `initialNameDisplay` in ReviewForm (return values didn't match the type union).
- **`@file` blocks**: kept (project convention).
- **AI prompts** in `parse-job.ts` and `estimate-duration/route.ts` left untouched (out of scope per memory).

33 files changed, 97 insertions, 126 deletions.

### 2. Phone util rename

`debcaf7`

Only authored identifier in the repo with a US spelling. Renamed to drop it, matching the spelling rule established in the audit.

- File: `src/shared/lib/normalize-phone.ts` > `normalise-phone.ts` (git-tracked rename, 78% similarity).
- Export: `normalizePhone()` > `normalisePhone()`.
- JSDoc prose updated to match ("Normalised", "normalisation").
- 22 import sites updated in the same commit.
- Other exports (`formatNZPhone`, `toE164NZ`, `isValidPhone`) unchanged.

25 files changed, 73 insertions, 73 deletions.

---

## Schema

No schema changes.

## Deploy

No deploy steps. Build + smoke tests pass on `dev`.

## Test plan

- [ ] gh pr checks green
- [ ] Spot-check a couple of files that had the rename to confirm `normalisePhone` resolves at runtime (Vercel preview deploy)
- [ ] Skim a sample of audited files in the diff to confirm no behavioural code touched