### PR TITLE
feat(analytics): Google tag (GA4 + Ads) with booking + phone conversions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,17 @@ NEXT_PUBLIC_SITE_URL="https://example.com"
 NEXT_PUBLIC_BUSINESS_GST_NUMBER=""
 NEXT_PUBLIC_BUSINESS_BANK_ACCOUNT=""
 
+# --- Analytics / Google Ads (NEXT_PUBLIC_*, inlined into the client at build) ---
+# GA4 measurement ID (G-XXXXXXX). Optional; enables Google Analytics.
+NEXT_PUBLIC_GA4_ID=""
+# Google Ads tag ID (AW-XXXXXXX). Enables Ads conversion tracking + remarketing.
+NEXT_PUBLIC_GOOGLE_ADS_ID=""
+# Conversion label for a completed booking - the part after the slash in the Ads
+# "send_to" value (AW-XXXXXXX/<label>). Fired once on /booking/success.
+NEXT_PUBLIC_GOOGLE_ADS_BOOKING_LABEL=""
+# Conversion label for a phone-link tap. Optional; fired on any tel: click.
+NEXT_PUBLIC_GOOGLE_ADS_CALL_LABEL=""
+
 # --- Auth ---
 # Admin password the operator types into /admin/login (also the HMAC signing
 # key for the session cookie + the X-Admin-Secret header for scripts/cron-like

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.96.2",
+  "version": "1.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.96.2",
+      "version": "1.97.0",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.96.2",
+  "version": "1.97.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/booking/success/BookingConversion.tsx
+++ b/src/app/booking/success/BookingConversion.tsx
@@ -1,0 +1,26 @@
+"use client";
+// src/app/booking/success/BookingConversion.tsx
+/**
+ * @file BookingConversion.tsx
+ * @description Reports a completed booking to Google Ads on the success page.
+ */
+
+import { useEffect } from "react";
+
+const ADS_ID = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;
+const BOOKING_LABEL = process.env.NEXT_PUBLIC_GOOGLE_ADS_BOOKING_LABEL;
+
+/**
+ * Fires the Ads booking conversion once on mount. This page renders only after
+ * a booking is confirmed, so the event maps one-to-one to a real lead. Renders
+ * no markup, and no-ops until the Ads ID + label are configured.
+ * @returns Null - this component has no markup.
+ */
+export function BookingConversion(): null {
+  useEffect(() => {
+    if (!ADS_ID || !BOOKING_LABEL || typeof window.gtag !== "function") return;
+    window.gtag("event", "conversion", { send_to: `${ADS_ID}/${BOOKING_LABEL}` });
+  }, []);
+
+  return null;
+}

--- a/src/app/booking/success/page.tsx
+++ b/src/app/booking/success/page.tsx
@@ -11,6 +11,7 @@ import { FaCircleCheck, FaHouse, FaPenToSquare, FaTag } from "react-icons/fa6";
 import { cancellationCopy } from "@/features/business/lib/pricing-policy";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
 import { prisma } from "@/shared/lib/prisma";
+import { BookingConversion } from "./BookingConversion";
 
 const CARD = "border-seasalt-400/60 bg-seasalt-800 rounded-xl border p-5 shadow-sm sm:p-6";
 
@@ -58,6 +59,7 @@ export default async function BookingSuccessPage({
 
   return (
     <main className={cn("relative min-h-dvh overflow-hidden")}>
+      <BookingConversion />
       {/* Backdrop */}
       <div className={cn("pointer-events-none absolute inset-0 -z-10 overflow-hidden")}>
         <picture>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { Exo } from "next/font/google";
 import "./globals.css";
+import { GoogleTag } from "@/shared/components/GoogleTag";
 import { NavBar } from "@/shared/components/NavBar";
 import { PromoBanner } from "@/shared/components/PromoBanner";
 import { getSiteUrl } from "@/shared/lib/site-url";
@@ -399,6 +400,7 @@ export default async function RootLayout({
 
         <Analytics />
         <SpeedInsights />
+        <GoogleTag />
         <script
           id="ld-business"
           type="application/ld+json"

--- a/src/shared/components/GoogleTag.tsx
+++ b/src/shared/components/GoogleTag.tsx
@@ -1,0 +1,69 @@
+"use client";
+// src/shared/components/GoogleTag.tsx
+/**
+ * @file GoogleTag.tsx
+ * @description Loads gtag.js for GA4 + Google Ads and reports tel: link taps.
+ */
+
+import Script from "next/script";
+import { useEffect } from "react";
+import type React from "react";
+
+const GA4_ID = process.env.NEXT_PUBLIC_GA4_ID;
+const ADS_ID = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;
+const CALL_LABEL = process.env.NEXT_PUBLIC_GOOGLE_ADS_CALL_LABEL;
+
+// gtag.js loads once from any configured target; the per-target config calls
+// register GA4 and Ads separately. Ads seeds the loader URL when present.
+const loaderId = ADS_ID ?? GA4_ID;
+
+/**
+ * Injects the Google tag and reports phone-link taps as conversions. Renders
+ * nothing when no measurement IDs are set, so the site runs untracked in dev
+ * or before the Ads/GA4 IDs are configured.
+ * @returns The gtag script tags, or null when unconfigured.
+ */
+export function GoogleTag(): React.ReactElement | null {
+  // One delegated listener covers every tel: link (raw anchors and the Button
+  // component alike), so individual links never need their own handler.
+  useEffect(() => {
+    if (!loaderId) return;
+    /**
+     * Reports a tel: link tap to GA4, and to Ads when a call label is set.
+     * @param event - The bubbled document click.
+     */
+    const onClick = (event: MouseEvent): void => {
+      const origin = event.target as HTMLElement | null;
+      const link = origin?.closest?.('a[href^="tel:"]');
+      if (!link || typeof window.gtag !== "function") return;
+      window.gtag("event", "phone_call_click");
+      if (ADS_ID && CALL_LABEL) {
+        window.gtag("event", "conversion", { send_to: `${ADS_ID}/${CALL_LABEL}` });
+      }
+    };
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, []);
+
+  if (!loaderId) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${loaderId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="gtag-init" strategy="afterInteractive">
+        {[
+          "window.dataLayer = window.dataLayer || [];",
+          "function gtag(){dataLayer.push(arguments);}",
+          "gtag('js', new Date());",
+          GA4_ID ? `gtag('config', '${GA4_ID}');` : "",
+          ADS_ID ? `gtag('config', '${ADS_ID}');` : "",
+        ]
+          .filter(Boolean)
+          .join("\n")}
+      </Script>
+    </>
+  );
+}

--- a/src/shared/types/gtag.d.ts
+++ b/src/shared/types/gtag.d.ts
@@ -1,0 +1,16 @@
+// src/shared/types/gtag.d.ts
+/**
+ * @file gtag.d.ts
+ * @description Global type augmentation for the Google tag (gtag.js) on window.
+ */
+
+export {};
+
+type GtagCommand = "js" | "config" | "event" | "set" | "consent";
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (command: GtagCommand, ...args: unknown[]) => void;
+  }
+}


### PR DESCRIPTION
## What this does

Adds the Google tag (gtag.js) so the site can feed Google Analytics 4 and Google Ads. Previously there was no Google tracking at all, so a Google Ads campaign would have had no conversion signal to optimise against. Everything is driven by `NEXT_PUBLIC_*` env vars and no-ops cleanly when they are unset, so the site runs untracked until real IDs are in place.

## Changes

- New `GoogleTag` client component that loads `gtag.js` once and configures GA4 and/or Ads from env vars, rendered from the root layout next to the existing analytics
- New `BookingConversion` component on the booking success page that fires the Ads conversion once on mount - it only renders after a confirmed booking, so it maps one-to-one to a real lead
- Phone-call conversion: a single delegated click listener reports any `tel:` link tap, covering raw anchors and Button-rendered links without touching each one
- `gtag.d.ts` types `window.gtag` / `dataLayer` to avoid `any`
- Documents the new env vars in `.env.example`

## New env vars

- `NEXT_PUBLIC_GA4_ID` - GA4 measurement ID (G-XXXXXXX), optional
- `NEXT_PUBLIC_GOOGLE_ADS_ID` - Google Ads tag ID (AW-XXXXXXX)
- `NEXT_PUBLIC_GOOGLE_ADS_BOOKING_LABEL` - conversion label fired on /booking/success
- `NEXT_PUBLIC_GOOGLE_ADS_CALL_LABEL` - conversion label fired on tel: taps, optional

## Follow-up (not in this PR)

- Because `NEXT_PUBLIC_*` is inlined at build time, the live values must be set in the Vercel project env vars (Production) and redeployed
- GA4 ID is in place locally; the Ads ID + labels still need to be created in Google Ads and added
