### PR TITLE
chore: add prettier organize-imports + packagejson plugins

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,10 @@
 // eslint.config.mjs
-import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import prettier from "eslint-config-prettier/flat";
-import prettierPlugin from "eslint-plugin-prettier/recommended";
 import jsdoc from "eslint-plugin-jsdoc";
+import prettierPlugin from "eslint-plugin-prettier/recommended";
+import { defineConfig, globalIgnores } from "eslint/config";
 import globals from "globals";
 
 export default defineConfig([

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.100.2",
+  "version": "1.100.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.100.2",
+      "version": "1.100.3",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",
@@ -52,6 +52,8 @@
         "png-to-ico": "^3.0.1",
         "postcss": "^8.5.15",
         "prettier": "^3.8.3",
+        "prettier-plugin-organize-imports": "^4.3.0",
+        "prettier-plugin-packagejson": "^3.0.2",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "prisma": "6.19.3",
         "puppeteer": "^25.1.0",
@@ -4529,6 +4531,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-indent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
+      "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4537,6 +4552,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
+      "integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/devtools-protocol": {
@@ -6033,6 +6061,16 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/git-hooks-list": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.2.1.tgz",
+      "integrity": "sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -6690,6 +6728,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -8604,6 +8655,41 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.3.0.tgz",
+      "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0 || 3"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prettier-plugin-packagejson": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-3.0.2.tgz",
+      "integrity": "sha512-kmoj3hEynXwoHDo8ZhmWAIjRBoQWCDUVackiWfSDWdgD0rS3LGB61T9zoVbume/cotYdCoadUh4sqViAmXvpBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-package-json": "^3.6.0"
+      },
+      "peerDependencies": {
+        "prettier": "^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prettier-plugin-tailwindcss": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
@@ -9569,6 +9655,35 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/sort-object-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-2.1.0.tgz",
+      "integrity": "sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sort-package-json": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.7.1.tgz",
+      "integrity": "sha512-ssk1HG7whF8N/T1IsNAQrtHG5Cbdi0rAgRJZXYBr9hF5xaHnBNzUx/W6LcthEW7FhOwvZssbESZuO+GxssqAyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-indent": "^7.0.2",
+        "detect-newline": "^4.0.1",
+        "git-hooks-list": "^4.1.1",
+        "is-plain-obj": "^4.1.0",
+        "semver": "^7.7.3",
+        "sort-object-keys": "^2.0.1",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "sort-package-json": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,52 @@
 {
   "name": "tech-support-site",
-  "version": "1.100.2",
+  "version": "1.100.3",
   "private": true,
   "type": "module",
   "scripts": {
-    "prepare": "simple-git-hooks",
-    "postinstall": "prisma generate",
-    "dev": "next dev --turbopack",
     "build": "next build --turbopack",
-    "start": "next start",
-    "db:push": "prisma db push",
-    "lint": "eslint \"{src,scripts}/**/*.{js,ts,jsx,tsx}\"",
-    "format": "prettier --write \"**/*.{js,ts,jsx,tsx,mjs,css,html,md,json,yml,yaml}\"",
+    "build:all": "npm run build:icons && npm run build",
     "build:icons": "tsx scripts/build-icons/index.ts",
     "build:poster": "npx tsx scripts/export-poster-screenshot.ts",
-    "build:all": "npm run build:icons && npm run build",
+    "db:push": "prisma db push",
+    "dev": "next dev --turbopack",
+    "format": "prettier --write \"**/*.{js,ts,jsx,tsx,mjs,css,html,md,json,yml,yaml}\"",
+    "postinstall": "prisma generate",
+    "lint": "eslint \"{src,scripts}/**/*.{js,ts,jsx,tsx}\"",
+    "prepare": "simple-git-hooks",
+    "settings:seed": "dotenv -e .env.local -- tsx scripts/seed-settings.ts",
     "smoke": "dotenv -e .env.local -- tsx scripts/smoke-test.ts",
-    "settings:seed": "dotenv -e .env.local -- tsx scripts/seed-settings.ts"
+    "start": "next start"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npm install && git add package-lock.json && npx lint-staged",
+    "pre-push": "npm run build && npm run smoke"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "eslint --max-warnings=0"
+    ],
+    "**/*.{css,html,json,md,mjs,yml,yaml}": "prettier --write"
+  },
+  "browserslist": [
+    "chrome >= 93",
+    "firefox >= 92",
+    "safari >= 15.4",
+    "edge >= 93"
+  ],
+  "overrides": {
+    "@typescript-eslint/typescript-estree": {
+      "minimatch": "^10.2.1"
+    },
+    "basic-ftp": "^5.3.1",
+    "glob": {
+      "minimatch": "^10.2.1"
+    },
+    "ip-address": "^10.2.0",
+    "minimatch": "^10.2.1",
+    "typescript-eslint": "8.58.1",
+    "vite": "^7.3.2"
   },
   "dependencies": {
     "@swc/helpers": "^0.5.23",
@@ -62,6 +92,8 @@
     "png-to-ico": "^3.0.1",
     "postcss": "^8.5.15",
     "prettier": "^3.8.3",
+    "prettier-plugin-organize-imports": "^4.3.0",
+    "prettier-plugin-packagejson": "^3.0.2",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "prisma": "6.19.3",
     "puppeteer": "^25.1.0",
@@ -72,39 +104,8 @@
     "tsx": "^4.22.4",
     "typescript": "6.0.3"
   },
-  "browserslist": [
-    "chrome >= 93",
-    "firefox >= 92",
-    "safari >= 15.4",
-    "edge >= 93"
-  ],
-  "browserslistNote": "Targets evergreen browsers with full ES2021+ and modern CSS support, matching Next.js 16's baseline.",
   "engines": {
     "node": "24.x",
     "npm": ">=10.0.0"
-  },
-  "overrides": {
-    "minimatch": "^10.2.1",
-    "@typescript-eslint/typescript-estree": {
-      "minimatch": "^10.2.1"
-    },
-    "glob": {
-      "minimatch": "^10.2.1"
-    },
-    "basic-ftp": "^5.3.1",
-    "ip-address": "^10.2.0",
-    "vite": "^7.3.2",
-    "typescript-eslint": "8.58.1"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "npm install && git add package-lock.json && npx lint-staged",
-    "pre-push": "npm run build && npm run smoke"
-  },
-  "lint-staged": {
-    "**/*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --max-warnings=0"
-    ],
-    "**/*.{css,html,json,md,mjs,yml,yaml}": "prettier --write"
   }
 }

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -3,7 +3,11 @@ import type { Config } from "prettier";
 
 const config: Config = {
   $schema: "https://json.schemastore.org/prettierrc",
-  plugins: ["prettier-plugin-tailwindcss"],
+  plugins: [
+    "prettier-plugin-organize-imports",
+    "prettier-plugin-packagejson",
+    "prettier-plugin-tailwindcss",
+  ],
   tailwindConfig: "./tailwind.config.ts",
 
   printWidth: 100,

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,6 +1,6 @@
 // prisma.config.ts
-import type { PrismaConfig } from "prisma";
 import { config } from "dotenv";
+import type { PrismaConfig } from "prisma";
 
 // Load .env.local for Prisma CLI commands
 config({ path: ".env.local" });

--- a/scripts/build-icons/generators.ts
+++ b/scripts/build-icons/generators.ts
@@ -4,24 +4,24 @@
  * @description Generator functions for favicons, social images, additional assets, QR codes, and manifests.
  */
 
-import sharp from "sharp";
+import { JSDOM } from "jsdom";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
-import { JSDOM } from "jsdom";
 import pngToIco from "png-to-ico";
+import sharp from "sharp";
 import {
-  PALETTE,
-  LOGO_MARK,
-  LOGO_FULL,
-  LOGO_PROFILE,
-  BACKDROP,
-  FAVICON_SPECS,
-  SOCIAL_SPECS,
-  BACKDROP_VARIANTS,
   ADDITIONAL_ASSETS,
+  BACKDROP,
+  BACKDROP_VARIANTS,
+  FAVICON_SPECS,
+  LOGO_FULL,
+  LOGO_MARK,
+  LOGO_PROFILE,
+  PALETTE,
   QR_CODE_SPECS,
+  SOCIAL_SPECS,
 } from "./config.js";
-import { ensureDir, makeFrostedCard, makeCoquelicotSvg } from "./helpers.js";
+import { ensureDir, makeCoquelicotSvg, makeFrostedCard } from "./helpers.js";
 
 // Opaque background colours used by the favicon renderer.
 const BG_LIGHT = { r: 246, g: 247, b: 248, alpha: 1 } as const; // seasalt

--- a/scripts/build-icons/index.ts
+++ b/scripts/build-icons/index.ts
@@ -8,24 +8,24 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
-  LOGO_MARK,
-  LOGO_FULL,
-  LOGO_PROFILE,
-  BACKDROP,
-  FAVICON_SPECS,
-  SOCIAL_SPECS,
-  BACKDROP_VARIANTS,
   ADDITIONAL_ASSETS,
+  BACKDROP,
+  BACKDROP_VARIANTS,
+  FAVICON_SPECS,
+  LOGO_FULL,
+  LOGO_MARK,
+  LOGO_PROFILE,
   QR_CODE_SPECS,
+  SOCIAL_SPECS,
 } from "./config.js";
 import {
+  buildAdditionalAssets,
+  buildBackdropVariants,
   buildFavicons,
   buildFaviconSvg,
-  buildSocialImages,
-  buildBackdropVariants,
-  buildAdditionalAssets,
-  buildQRCodes,
   buildManifest,
+  buildQRCodes,
+  buildSocialImages,
 } from "./generators.js";
 
 /* ---------- Preflight Check ---------- */

--- a/scripts/export-poster-screenshot.ts
+++ b/scripts/export-poster-screenshot.ts
@@ -7,8 +7,8 @@
  */
 
 import fs from "fs";
-import puppeteer, { type Browser } from "puppeteer";
 import { PDFDocument, PDFPage, rgb } from "pdf-lib";
+import puppeteer, { type Browser } from "puppeteer";
 
 /* ---------- Types ---------- */
 

--- a/scripts/reauth-google.ts
+++ b/scripts/reauth-google.ts
@@ -7,10 +7,10 @@
  * Run:  npx tsx scripts/reauth-google.ts
  */
 
-import * as readline from "readline";
-import * as fs from "fs";
 import * as dotenv from "dotenv";
+import * as fs from "fs";
 import { google } from "googleapis";
+import * as readline from "readline";
 
 dotenv.config({ path: ".env.local" });
 

--- a/src/app/(email-previews)/page.tsx
+++ b/src/app/(email-previews)/page.tsx
@@ -4,9 +4,9 @@
  * @description Dev-only email preview placeholder so the project compiles.
  */
 
-import type React from "react";
 import { FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;

--- a/src/app/about/loading.tsx
+++ b/src/app/about/loading.tsx
@@ -5,10 +5,10 @@
  * approach and "who I help" list cards.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * About route-loading skeleton.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,12 +4,12 @@
  * @description About page: background, approach, and who I help.
  */
 
-import type { Metadata } from "next";
-import type React from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
 import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
+import type { Metadata } from "next";
 import Link from "next/link";
+import type React from "react";
 
 export const metadata: Metadata = {
   title: "About Harrison Raynes - Local Tech Support in Auckland",

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -1,14 +1,14 @@
 // src/app/admin/bookings/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import { prisma } from "@/shared/lib/prisma";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { cn } from "@/shared/lib/cn";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import {
   BookingAdminList,
   type AdminBookingRow,
 } from "@/features/booking/components/admin/BookingAdminList";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { cn } from "@/shared/lib/cn";
+import { prisma } from "@/shared/lib/prisma";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/business/calculator/loading.tsx
+++ b/src/app/admin/business/calculator/loading.tsx
@@ -6,10 +6,10 @@
  * left and the totals / invoice-preview panel on the right.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Calculator page loading skeleton.

--- a/src/app/admin/business/calculator/page.tsx
+++ b/src/app/admin/business/calculator/page.tsx
@@ -1,12 +1,12 @@
+import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import { CalculatorView } from "@/features/business/components/CalculatorView";
+import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { getIdentity } from "@/shared/lib/business-identity.server";
+import { cn } from "@/shared/lib/cn";
 import type { Metadata } from "next";
 import type React from "react";
 import { Suspense } from "react";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
-import { CalculatorView } from "@/features/business/components/CalculatorView";
-import { getIdentity } from "@/shared/lib/business-identity.server";
-import { getPolicy } from "@/features/business/lib/pricing-policy.server";
-import { cn } from "@/shared/lib/cn";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/business/expenses/page.tsx
+++ b/src/app/admin/business/expenses/page.tsx
@@ -1,10 +1,10 @@
-import type { Metadata } from "next";
-import type React from "react";
-import { requireAdminAuth } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { ExpensesView } from "@/features/business/components/ExpensesView";
 import { SubscriptionsView } from "@/features/business/components/SubscriptionsView";
+import { requireAdminAuth } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/business/income/page.tsx
+++ b/src/app/admin/business/income/page.tsx
@@ -1,9 +1,9 @@
-import type { Metadata } from "next";
-import type React from "react";
-import { requireAdminAuth } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { IncomeView } from "@/features/business/components/IncomeView";
+import { requireAdminAuth } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/business/invoices/[id]/InvoiceActions.tsx
+++ b/src/app/admin/business/invoices/[id]/InvoiceActions.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import type React from "react";
-import { useState } from "react";
-import { FaCaretLeft } from "react-icons/fa6";
-import { useRouter } from "next/navigation";
-import Link from "next/link";
-import { cn } from "@/shared/lib/cn";
+import { AddToContactsModal } from "@/features/business/components/AddToContactsModal";
+import type { InvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
 import {
   DEFAULT_INVOICE_EMAIL_BODY,
   DEFAULT_VOID_EMAIL_BODY,
 } from "@/features/business/lib/invoice-email-defaults";
-import type { InvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
-import { AddToContactsModal } from "@/features/business/components/AddToContactsModal";
+import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useState } from "react";
+import { FaCaretLeft } from "react-icons/fa6";
 
 interface InvoiceActionsProps {
   backHref: string;

--- a/src/app/admin/business/invoices/[id]/loading.tsx
+++ b/src/app/admin/business/invoices/[id]/loading.tsx
@@ -6,10 +6,10 @@
  * in the same max-w-3xl column the page uses.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Invoice detail loading skeleton.

--- a/src/app/admin/business/invoices/[id]/page.tsx
+++ b/src/app/admin/business/invoices/[id]/page.tsx
@@ -1,14 +1,14 @@
+import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import { formatNZD } from "@/features/business/lib/business";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { getIdentity } from "@/shared/lib/business-identity.server";
+import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
+import { prisma } from "@/shared/lib/prisma";
 import type { Metadata } from "next";
-import type React from "react";
 import Image from "next/image";
 import { notFound } from "next/navigation";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
-import { prisma } from "@/shared/lib/prisma";
-import { formatNZD } from "@/features/business/lib/business";
-import { formatDateShort } from "@/shared/lib/date-format";
-import { cn } from "@/shared/lib/cn";
-import { getIdentity } from "@/shared/lib/business-identity.server";
+import type React from "react";
 import { InvoiceActions } from "./InvoiceActions";
 
 export const dynamic = "force-dynamic";

--- a/src/app/admin/business/invoices/page.tsx
+++ b/src/app/admin/business/invoices/page.tsx
@@ -1,9 +1,9 @@
-import type { Metadata } from "next";
-import type React from "react";
-import { requireAdminAuth } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { InvoicesListView } from "@/features/business/components/InvoicesListView";
+import { requireAdminAuth } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/business/loading.tsx
+++ b/src/app/admin/business/loading.tsx
@@ -5,10 +5,10 @@
  * overview stat cards, the tax-planner panel and the action-link row.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Business dashboard loading skeleton.

--- a/src/app/admin/business/page.tsx
+++ b/src/app/admin/business/page.tsx
@@ -1,31 +1,31 @@
 // src/app/admin/business/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import Link from "next/link";
-import { requireAdminAuth } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
-import { cn } from "@/shared/lib/cn";
-import { prisma } from "@/shared/lib/prisma";
-import { listFinancialYears } from "@/features/business/lib/financial-year";
-import { SheetImportButton } from "@/features/business/components/SheetImportButton";
-import { TaxPlannerSection } from "@/features/business/components/TaxPlannerSection";
-import { getFySheetIdForDate } from "@/features/business/lib/sheets-sync";
-import { listSpreadsheetsInFolder } from "@/features/business/lib/google-drive";
-import { readPlannerConfig } from "@/features/business/lib/tax-settings";
-import { DEFAULT_TAX_RATES, type TaxRates } from "@/features/business/lib/tax-planner";
-import { getSettings } from "@/shared/lib/settings/get-settings";
-import { getIdentity } from "@/shared/lib/business-identity.server";
-import {
-  readCachedTaxSnapshot,
-  writeCachedTaxSnapshot,
-  clearTaxCache,
-} from "@/features/business/lib/tax-cache";
 import {
   BusinessDashboardCards,
-  type IncomeRow,
   type ExpenseRow,
+  type IncomeRow,
   type InvoiceRow,
 } from "@/features/business/components/BusinessDashboardCards";
+import { SheetImportButton } from "@/features/business/components/SheetImportButton";
+import { TaxPlannerSection } from "@/features/business/components/TaxPlannerSection";
+import { listFinancialYears } from "@/features/business/lib/financial-year";
+import { listSpreadsheetsInFolder } from "@/features/business/lib/google-drive";
+import { getFySheetIdForDate } from "@/features/business/lib/sheets-sync";
+import {
+  clearTaxCache,
+  readCachedTaxSnapshot,
+  writeCachedTaxSnapshot,
+} from "@/features/business/lib/tax-cache";
+import { DEFAULT_TAX_RATES, type TaxRates } from "@/features/business/lib/tax-planner";
+import { readPlannerConfig } from "@/features/business/lib/tax-settings";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { getIdentity } from "@/shared/lib/business-identity.server";
+import { cn } from "@/shared/lib/cn";
+import { prisma } from "@/shared/lib/prisma";
+import { getSettings } from "@/shared/lib/settings/get-settings";
+import type { Metadata } from "next";
+import Link from "next/link";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/contacts/conflicts/loading.tsx
+++ b/src/app/admin/contacts/conflicts/loading.tsx
@@ -6,10 +6,10 @@
  * between).
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Contact conflicts loading skeleton.

--- a/src/app/admin/contacts/conflicts/page.tsx
+++ b/src/app/admin/contacts/conflicts/page.tsx
@@ -1,14 +1,14 @@
 // src/app/admin/contacts/conflicts/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import { prisma } from "@/shared/lib/prisma";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { cn } from "@/shared/lib/cn";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import {
   ContactConflictsView,
   type ConflictRow,
 } from "@/features/admin/components/ContactConflictsView";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { cn } from "@/shared/lib/cn";
+import { prisma } from "@/shared/lib/prisma";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/contacts/page.tsx
+++ b/src/app/admin/contacts/page.tsx
@@ -1,13 +1,13 @@
 // src/app/admin/contacts/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import Link from "next/link";
-import { prisma } from "@/shared/lib/prisma";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { cn } from "@/shared/lib/cn";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { ContactsAdminView } from "@/features/admin/components/ContactsAdminView";
 import { autoMaintain } from "@/features/admin/lib/auto-maintain";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { cn } from "@/shared/lib/cn";
+import { prisma } from "@/shared/lib/prisma";
+import type { Metadata } from "next";
+import Link from "next/link";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -7,10 +7,10 @@
 
 "use client";
 
-import type React from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
 import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 import { FaArrowRotateRight, FaGauge } from "react-icons/fa6";
 
 /**

--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -7,10 +7,10 @@
  * doubles as the generic fallback.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Admin dashboard loading skeleton.

--- a/src/app/admin/login/loading.tsx
+++ b/src/app/admin/login/loading.tsx
@@ -6,9 +6,9 @@
  * login route doesn't flash the operator-panel layout.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Admin login route-loading skeleton.

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -6,10 +6,10 @@
  * server component shell; the form is a tiny client component below.
  */
 
-import type { Metadata } from "next";
-import type React from "react";
 import { LoginForm } from "@/features/admin/components/LoginForm";
 import { cn } from "@/shared/lib/cn";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/not-found.tsx
+++ b/src/app/admin/not-found.tsx
@@ -6,10 +6,10 @@
  * root 404, so a missing invoice/record still has the nav to recover from.
  */
 
-import type React from "react";
-import Link from "next/link";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import type React from "react";
 
 /**
  * Admin not-found page.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,15 +1,15 @@
 // src/app/admin/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import Link from "next/link";
-import { prisma } from "@/shared/lib/prisma";
-import { requireAdminAuth } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { DashboardQuickActions } from "@/features/admin/components/DashboardQuickActions";
-import { toE164NZ } from "@/shared/lib/normalise-phone";
+import { formatNZD } from "@/features/business/lib/business";
+import { requireAdminAuth } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
 import { formatDateShort, formatDateTimeShort } from "@/shared/lib/date-format";
-import { formatNZD } from "@/features/business/lib/business";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import type { Metadata } from "next";
+import Link from "next/link";
+import type React from "react";
 import { FaCaretRight } from "react-icons/fa6";
 
 export const dynamic = "force-dynamic";

--- a/src/app/admin/price-estimates/page.tsx
+++ b/src/app/admin/price-estimates/page.tsx
@@ -1,13 +1,13 @@
 // src/app/admin/price-estimates/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import Link from "next/link";
-import { prisma } from "@/shared/lib/prisma";
-import { AppEnvironment, type Prisma } from "@prisma/client";
-import { requireAdminAuth } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import { requireAdminAuth } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
 import { formatDateTimeShort } from "@/shared/lib/date-format";
+import { prisma } from "@/shared/lib/prisma";
+import { AppEnvironment, type Prisma } from "@prisma/client";
+import type { Metadata } from "next";
+import Link from "next/link";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/promos/page.tsx
+++ b/src/app/admin/promos/page.tsx
@@ -1,11 +1,11 @@
 // src/app/admin/promos/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import { requireAdminAuth } from "@/shared/lib/auth";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import { PromosView } from "@/features/business/components/PromosView";
+import { requireAdminAuth } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
 import { prisma } from "@/shared/lib/prisma";
-import { PromosView } from "@/features/business/components/PromosView";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/reviews/loading.tsx
+++ b/src/app/admin/reviews/loading.tsx
@@ -6,10 +6,10 @@
  * send-link and link-history cards.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Reviews page loading skeleton.

--- a/src/app/admin/reviews/page.tsx
+++ b/src/app/admin/reviews/page.tsx
@@ -1,15 +1,15 @@
 // src/app/admin/reviews/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import { prisma } from "@/shared/lib/prisma";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { toE164NZ } from "@/shared/lib/normalise-phone";
-import { cn } from "@/shared/lib/cn";
-import { getSiteUrl } from "@/shared/lib/site-url";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
 import { ReviewApprovalList } from "@/features/reviews/components/admin/ReviewApprovalList";
 import { ReviewLinkHistoryTable } from "@/features/reviews/components/admin/ReviewLinkHistoryTable";
 import { SendReviewLinkForm } from "@/features/reviews/components/admin/SendReviewLinkForm";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { cn } from "@/shared/lib/cn";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { getSiteUrl } from "@/shared/lib/site-url";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/schedule/loading.tsx
+++ b/src/app/admin/schedule/loading.tsx
@@ -6,10 +6,10 @@
  * DayAgendaView / WeekView split.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Schedule page loading skeleton.

--- a/src/app/admin/schedule/page.tsx
+++ b/src/app/admin/schedule/page.tsx
@@ -1,15 +1,15 @@
 // src/app/admin/schedule/page.tsx
+import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import { DayAgendaView } from "@/features/admin/components/DayAgendaView";
+import { WeekView } from "@/features/admin/components/WeekView";
+import { mondayOf, type WeekEvent, type WeekViewKind } from "@/features/admin/lib/schedule-types";
+import { addDays, resolveWeekStart, toNZDateKey } from "@/features/admin/lib/week";
+import { lookupPublicHoliday } from "@/features/business/lib/pricing-policy.server";
+import { getCachedScheduleEvents } from "@/features/calendar/lib/google-calendar";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
 import type { Metadata } from "next";
 import type React from "react";
-import { prisma } from "@/shared/lib/prisma";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
-import { getCachedScheduleEvents } from "@/features/calendar/lib/google-calendar";
-import { addDays, resolveWeekStart, toNZDateKey } from "@/features/admin/lib/week";
-import { WeekView } from "@/features/admin/components/WeekView";
-import { DayAgendaView } from "@/features/admin/components/DayAgendaView";
-import { mondayOf, type WeekEvent, type WeekViewKind } from "@/features/admin/lib/schedule-types";
-import { lookupPublicHoliday } from "@/features/business/lib/pricing-policy.server";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/settings/loading.tsx
+++ b/src/app/admin/settings/loading.tsx
@@ -5,10 +5,10 @@
  * horizontal tab strip and a form card of labelled field rows with a save bar.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Settings page loading skeleton.

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,12 +1,12 @@
 // src/app/admin/settings/page.tsx
+import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import { SettingsView } from "@/features/admin/components/settings/SettingsView";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { cn } from "@/shared/lib/cn";
+import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
+import { getSettings } from "@/shared/lib/settings/get-settings";
 import type { Metadata } from "next";
 import type React from "react";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
-import { cn } from "@/shared/lib/cn";
-import { getSettings } from "@/shared/lib/settings/get-settings";
-import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
-import { SettingsView } from "@/features/admin/components/settings/SettingsView";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/admin/travel/page.tsx
+++ b/src/app/admin/travel/page.tsx
@@ -1,15 +1,15 @@
 // src/app/admin/travel/page.tsx
-import type { Metadata } from "next";
-import type React from "react";
-import { prisma } from "@/shared/lib/prisma";
-import { requireAdminAuth } from "@/shared/lib/auth";
-import { cn } from "@/shared/lib/cn";
 import { AdminPageLayout } from "@/features/admin/components/AdminPageLayout";
+import { RecalculateButton } from "@/features/admin/components/RecalculateButton";
 import {
   TravelBlockAdminList,
   type TravelBlockRow,
 } from "@/features/admin/components/TravelBlockAdminList";
-import { RecalculateButton } from "@/features/admin/components/RecalculateButton";
+import { requireAdminAuth } from "@/shared/lib/auth";
+import { cn } from "@/shared/lib/cn";
+import { prisma } from "@/shared/lib/prisma";
+import type { Metadata } from "next";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/api/admin/blocked-days/[eventId]/route.ts
+++ b/src/app/api/admin/blocked-days/[eventId]/route.ts
@@ -5,10 +5,10 @@
  * underlying Google Calendar event.
  */
 
-import { type NextRequest, NextResponse } from "next/server";
-import { revalidateTag } from "next/cache";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { deleteBookingEvent, SCHEDULE_CALENDAR_TAG } from "@/features/calendar/lib/google-calendar";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/blocked-days/route.ts
+++ b/src/app/api/admin/blocked-days/route.ts
@@ -6,15 +6,15 @@
  * on the chosen NZ day - personal-calendar events on the day are ignored.
  */
 
-import { type NextRequest, NextResponse } from "next/server";
-import { revalidateTag } from "next/cache";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import {
   createBlockedDayEvent,
   SCHEDULE_CALENDAR_TAG,
 } from "@/features/calendar/lib/google-calendar";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
 import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/bookings/[id]/resend-review/route.ts
+++ b/src/app/api/admin/bookings/[id]/resend-review/route.ts
@@ -4,10 +4,10 @@
  * @description Admin API to manually (re)send a review request email for a booking.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/bookings/[id]/route.ts
+++ b/src/app/api/admin/bookings/[id]/route.ts
@@ -4,19 +4,19 @@
  * @description Admin API for editing and cancelling bookings by ID.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { revalidateTag } from "next/cache";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
-import { deleteBookingEvent, SCHEDULE_CALENDAR_TAG } from "@/features/calendar/lib/google-calendar";
-import { toE164NZ } from "@/shared/lib/normalise-phone";
-import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
+import { createDraftCancellationInvoice } from "@/features/business/lib/cancellation-invoice";
 import {
   isWithinCancellationWindow,
   isWithinTravelWindow,
 } from "@/features/business/lib/pricing-policy";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
-import { createDraftCancellationInvoice } from "@/features/business/lib/cancellation-invoice";
+import { deleteBookingEvent, SCHEDULE_CALENDAR_TAG } from "@/features/calendar/lib/google-calendar";
+import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/bookings/route.ts
+++ b/src/app/api/admin/bookings/route.ts
@@ -6,27 +6,27 @@
  * instead of the public slot model.
  */
 
-import { type NextRequest, NextResponse } from "next/server";
-import { randomUUID } from "crypto";
-import { revalidateTag } from "next/cache";
-import { Prisma } from "@prisma/client";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import {
   BOOKING_CONFIG,
   BOOKING_FIELD_LIMITS,
   validateEmail,
 } from "@/features/booking/lib/booking";
-import { getSettings } from "@/shared/lib/settings/get-settings";
 import {
   createBookingEvent,
   fetchAllCalendarEvents,
   SCHEDULE_CALENDAR_TAG,
 } from "@/features/calendar/lib/google-calendar";
-import { sendCustomerBookingConfirmation } from "@/features/reviews/lib/email";
-import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
+import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { sendCustomerBookingConfirmation } from "@/features/reviews/lib/email";
+import { isAdminRequest } from "@/shared/lib/auth";
 import { validatePhone } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { getSettings } from "@/shared/lib/settings/get-settings";
+import { Prisma } from "@prisma/client";
+import { randomUUID } from "crypto";
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/contacts/[id]/clear-review-link/route.ts
+++ b/src/app/api/admin/contacts/[id]/clear-review-link/route.ts
@@ -7,9 +7,9 @@
  * (replaces the old DELETE /api/admin/review-requests/[id] flow).
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/admin/contacts/[id]/clear-review-link

--- a/src/app/api/admin/contacts/[id]/route.ts
+++ b/src/app/api/admin/contacts/[id]/route.ts
@@ -4,11 +4,11 @@
  * @description Admin API route for updating individual contacts.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
-import { toE164NZ, normalisePhone, isValidPhone } from "@/shared/lib/normalise-phone";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { isValidPhone, normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 interface ContactPatchBody {
   name?: string;

--- a/src/app/api/admin/contacts/[id]/sync-google/route.ts
+++ b/src/app/api/admin/contacts/[id]/sync-google/route.ts
@@ -4,9 +4,9 @@
  * @description Admin API to sync a single contact to Google Contacts.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/contacts/backfill/route.ts
+++ b/src/app/api/admin/contacts/backfill/route.ts
@@ -6,11 +6,11 @@
  * are the only remaining seed for backfill.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
+import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
-import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/contacts/check/route.ts
+++ b/src/app/api/admin/contacts/check/route.ts
@@ -5,9 +5,9 @@
  * "Add to contacts?" popup to decide whether to prompt the operator.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/admin/contacts/check?email=...

--- a/src/app/api/admin/contacts/conflicts/[id]/route.ts
+++ b/src/app/api/admin/contacts/conflicts/[id]/route.ts
@@ -8,10 +8,10 @@
  * lastSyncedAt + lastGoogleEtag catch up).
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/admin/contacts/conflicts/[id]

--- a/src/app/api/admin/contacts/conflicts/route.ts
+++ b/src/app/api/admin/contacts/conflicts/route.ts
@@ -4,9 +4,9 @@
  * @description Admin endpoint listing pending Google Contacts sync conflicts.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/admin/contacts/conflicts

--- a/src/app/api/admin/contacts/enrich-from-reviews/route.ts
+++ b/src/app/api/admin/contacts/enrich-from-reviews/route.ts
@@ -8,9 +8,9 @@
  * bookings handle phone enrichment via auto-maintain.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/contacts/export/route.ts
+++ b/src/app/api/admin/contacts/export/route.ts
@@ -5,9 +5,9 @@
  * Column layout matches the format produced by Google Contacts own export tool.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/contacts/import/route.ts
+++ b/src/app/api/admin/contacts/import/route.ts
@@ -4,9 +4,9 @@
  * @description Admin API route to import contacts from Google Contacts.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { importFromGoogleContacts } from "@/features/contacts/lib/google-contacts";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/contacts/resolve-conflict/route.ts
+++ b/src/app/api/admin/contacts/resolve-conflict/route.ts
@@ -5,10 +5,10 @@
  * the contact and the source record (Booking or Review).
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 interface ResolveBody {
   /** Local contact ID to update. */

--- a/src/app/api/admin/contacts/route.ts
+++ b/src/app/api/admin/contacts/route.ts
@@ -4,12 +4,12 @@
  * @description Admin API for listing and creating contacts.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
+import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
+import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
-import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
-import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/admin/contacts

--- a/src/app/api/admin/contacts/sync/route.ts
+++ b/src/app/api/admin/contacts/sync/route.ts
@@ -5,12 +5,12 @@
  * Imports all Google contacts into the local DB, then pushes all local contacts to Google.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { isAdminRequest } from "@/shared/lib/auth";
 import {
   importFromGoogleContacts,
   syncAllContactsToGoogle,
 } from "@/features/contacts/lib/google-contacts";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -7,14 +7,14 @@
  * stops fast.
  */
 
-import { type NextRequest, NextResponse } from "next/server";
-import { timingSafeEqual } from "crypto";
-import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import {
   ADMIN_SESSION_COOKIE,
   ADMIN_SESSION_MAX_AGE_SECONDS,
   createSessionCookieValue,
 } from "@/shared/lib/admin-session";
+import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { timingSafeEqual } from "crypto";
+import { type NextRequest, NextResponse } from "next/server";
 
 /**
  * Constant-time compare a candidate secret against `ADMIN_SECRET`.

--- a/src/app/api/admin/logout/route.ts
+++ b/src/app/api/admin/logout/route.ts
@@ -5,8 +5,8 @@
  * required to log out - hitting this endpoint without a session is a no-op.
  */
 
-import { NextResponse } from "next/server";
 import { ADMIN_SESSION_COOKIE } from "@/shared/lib/admin-session";
+import { NextResponse } from "next/server";
 
 /**
  * POST /api/admin/logout

--- a/src/app/api/admin/preview-review-email/route.ts
+++ b/src/app/api/admin/preview-review-email/route.ts
@@ -4,9 +4,9 @@
  * @description Admin endpoint that returns the rendered HTML preview for a past-client review email.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { buildPastClientReviewEmailHtml } from "@/features/reviews/lib/email";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/admin/preview-review-email

--- a/src/app/api/admin/reviews/[id]/route.ts
+++ b/src/app/api/admin/reviews/[id]/route.ts
@@ -5,11 +5,11 @@
  * Protected by ADMIN_SECRET via constant-time comparison.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
-import { revalidateReviewPaths } from "@/features/reviews/lib/revalidate";
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
+import { revalidateReviewPaths } from "@/features/reviews/lib/revalidate";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * PATCH /api/admin/reviews/[id] - admin-auth gated.

--- a/src/app/api/admin/reviews/match-contacts/route.ts
+++ b/src/app/api/admin/reviews/match-contacts/route.ts
@@ -4,10 +4,10 @@
  * @description Admin API to auto-match reviews to contacts by email or phone.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ, normalisePhone } from "@/shared/lib/normalise-phone";
+import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/reviews/route.ts
+++ b/src/app/api/admin/reviews/route.ts
@@ -4,10 +4,10 @@
  * @description Admin API for manually creating reviews (for past clients).
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { reviewTextError } from "@/features/reviews/lib/validation";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/admin/reviews

--- a/src/app/api/admin/send-review-link/route.ts
+++ b/src/app/api/admin/send-review-link/route.ts
@@ -7,18 +7,18 @@
  * ReviewRequest model was retired; all send-state lives on Contact now.
  */
 
-import { randomUUID } from "crypto";
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { ReviewLinkMode } from "@prisma/client";
-import { sendPastClientReviewRequest } from "@/features/reviews/lib/email";
-import { isAdminRequest } from "@/shared/lib/auth";
-import { getSiteUrl } from "@/shared/lib/site-url";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
 import {
   findOrCreateContactByEmail,
   findOrCreateContactByPhone,
 } from "@/features/contacts/lib/find-or-create";
+import { sendPastClientReviewRequest } from "@/features/reviews/lib/email";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { isValidPhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { getSiteUrl } from "@/shared/lib/site-url";
+import { ReviewLinkMode } from "@prisma/client";
+import { randomUUID } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/admin/settings/[group]/history/route.ts
+++ b/src/app/api/admin/settings/[group]/history/route.ts
@@ -7,11 +7,11 @@
  * load a prior version back into the editor for review + re-save.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
 import type { SettingsGroup } from "@/shared/lib/settings/types";
+import { NextRequest, NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/api/admin/settings/[group]/route.ts
+++ b/src/app/api/admin/settings/[group]/route.ts
@@ -7,13 +7,13 @@
  * always reject; WARNs reject unless the client confirms.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
 import { getSettings } from "@/shared/lib/settings/get-settings";
 import { saveSettingsGroup } from "@/shared/lib/settings/set-settings";
-import { checkGuardrails, validateGroup } from "@/shared/lib/settings/validate";
-import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
 import type { Settings, SettingsGroup } from "@/shared/lib/settings/types";
+import { checkGuardrails, validateGroup } from "@/shared/lib/settings/validate";
+import { NextRequest, NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/api/admin/travel/[id]/route.ts
+++ b/src/app/api/admin/travel/[id]/route.ts
@@ -6,10 +6,10 @@
  * minutes so the next refresh recalculates.
  */
 
-import { type NextRequest, NextResponse } from "next/server";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { TransportMode } from "@prisma/client";
+import { type NextRequest, NextResponse } from "next/server";
 
 const VALID_MODES = new Set<string>(Object.values(TransportMode));
 

--- a/src/app/api/admin/travel/recalculate/route.ts
+++ b/src/app/api/admin/travel/recalculate/route.ts
@@ -5,10 +5,10 @@
  * Clears stored TravelBlock records so the next cache refresh recomputes fresh travel times.
  */
 
-import { type NextRequest, NextResponse } from "next/server";
+import { refreshCalendarCache } from "@/features/calendar/lib/calendar-cache";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import { refreshCalendarCache } from "@/features/calendar/lib/calendar-cache";
+import { type NextRequest, NextResponse } from "next/server";
 
 /**
  * Force-deletes all TravelBlock records and runs a full calendar cache refresh

--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -7,16 +7,16 @@
  * a DRAFT invoice when the cancel lands inside the fee window.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { deleteBookingEvent } from "@/features/calendar/lib/google-calendar";
-import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { createDraftCancellationInvoice } from "@/features/business/lib/cancellation-invoice";
 import {
   isWithinCancellationWindow,
   isWithinTravelWindow,
 } from "@/features/business/lib/pricing-policy";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
-import { createDraftCancellationInvoice } from "@/features/business/lib/cancellation-invoice";
+import { deleteBookingEvent } from "@/features/calendar/lib/google-calendar";
+import { prisma } from "@/shared/lib/prisma";
+import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/booking/contact-lookup/route.ts
+++ b/src/app/api/booking/contact-lookup/route.ts
@@ -4,9 +4,9 @@
  * @description Looks up a contact by email so the booking form can pre-fill name/phone/address.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/booking/contact-lookup?email=<email>

--- a/src/app/api/booking/days/route.ts
+++ b/src/app/api/booking/days/route.ts
@@ -4,15 +4,15 @@
  * @description API route to get available booking days (blocks calendar events and DB bookings).
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
+import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
 import {
   BOOKING_CONFIG,
   buildAvailableDays,
   type ExistingBooking,
 } from "@/features/booking/lib/booking";
-import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
+import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/booking/edit/route.ts
+++ b/src/app/api/booking/edit/route.ts
@@ -4,33 +4,33 @@
  * @description API route to edit an existing booking by cancel token.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import {
-  validateBookingRequest,
-  validateBookingPayloadFields,
-  parseHourLabel,
-  type TimeOfDay,
-  type StartMinute,
-  type JobDuration,
-  type ExistingBooking,
-} from "@/features/booking/lib/booking";
 import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
-import { getSettings } from "@/shared/lib/settings/get-settings";
-import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import {
+  parseHourLabel,
+  validateBookingPayloadFields,
+  validateBookingRequest,
+  type ExistingBooking,
+  type JobDuration,
+  type StartMinute,
+  type TimeOfDay,
+} from "@/features/booking/lib/booking";
 import {
   createBookingEvent,
   deleteBookingEvent,
   fetchAllCalendarEvents,
 } from "@/features/calendar/lib/google-calendar";
-import { Prisma } from "@prisma/client";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
-import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
 import {
   sendCustomerBookingConfirmation,
   sendOwnerBookingNotification,
 } from "@/features/reviews/lib/email";
-import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { isValidPhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { getSettings } from "@/shared/lib/settings/get-settings";
+import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { Prisma } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/booking/hold/route.ts
+++ b/src/app/api/booking/hold/route.ts
@@ -4,17 +4,17 @@
  * @description API route to create a booking hold with Google Calendar integration.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { revalidatePath } from "next/cache";
-import { prisma } from "@/shared/lib/prisma";
 import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
+import { createBookingEvent } from "@/features/calendar/lib/google-calendar";
+import { toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { getSettings } from "@/shared/lib/settings/get-settings";
 import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
-import { createBookingEvent } from "@/features/calendar/lib/google-calendar";
-import { randomUUID } from "crypto";
 import { Prisma } from "@prisma/client";
-import { toE164NZ } from "@/shared/lib/normalise-phone";
-import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { randomUUID } from "crypto";
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/booking/request/route.ts
+++ b/src/app/api/booking/request/route.ts
@@ -4,38 +4,38 @@
  * @description API route with duration support (1hr vs 2hr jobs).
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
+import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
 import {
-  validateBookingRequest,
-  validateBookingPayloadFields,
   parseHourLabel,
   splitUnitFromAddress,
-  type TimeOfDay,
-  type StartMinute,
-  type JobDuration,
+  validateBookingPayloadFields,
+  validateBookingRequest,
   type ExistingBooking,
+  type JobDuration,
+  type StartMinute,
+  type TimeOfDay,
 } from "@/features/booking/lib/booking";
-import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
-import { getSettings } from "@/shared/lib/settings/get-settings";
-import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { lookupPublicHoliday } from "@/features/business/lib/pricing-policy.server";
+import { getActivePromo } from "@/features/business/lib/promos";
+import { lookupDriveDistance } from "@/features/business/lib/travel-distance";
 import {
   createBookingEvent,
   fetchAllCalendarEvents,
 } from "@/features/calendar/lib/google-calendar";
-import {
-  sendOwnerBookingNotification,
-  sendCustomerBookingConfirmation,
-} from "@/features/reviews/lib/email";
-import { randomUUID } from "crypto";
-import { Prisma } from "@prisma/client";
-import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
-import { toE164NZ, isValidPhone } from "@/shared/lib/normalise-phone";
+import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import {
+  sendCustomerBookingConfirmation,
+  sendOwnerBookingNotification,
+} from "@/features/reviews/lib/email";
+import { isValidPhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
-import { getActivePromo } from "@/features/business/lib/promos";
-import { lookupDriveDistance } from "@/features/business/lib/travel-distance";
-import { lookupPublicHoliday } from "@/features/business/lib/pricing-policy.server";
+import { getSettings } from "@/shared/lib/settings/get-settings";
+import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { Prisma } from "@prisma/client";
+import { randomUUID } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/contacts/route.ts
+++ b/src/app/api/business/contacts/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
-import { google } from "googleapis";
+import type { GoogleContact } from "@/features/business/types/business";
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
 import { isAdminRequest } from "@/shared/lib/auth";
-import type { GoogleContact } from "@/features/business/types/business";
+import { google } from "googleapis";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/expenses/[id]/route.ts
+++ b/src/app/api/business/expenses/[id]/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * DELETE /api/business/expenses/[id] - Deletes an expense entry by ID.

--- a/src/app/api/business/expenses/route.ts
+++ b/src/app/api/business/expenses/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
-import { parseAmount, parseRate } from "@/features/business/lib/validation";
 import { GST_RATE } from "@/features/business/lib/pricing-policy";
+import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/business/expenses - Returns all expense entries ordered by date descending.

--- a/src/app/api/business/income/[id]/route.ts
+++ b/src/app/api/business/income/[id]/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * DELETE /api/business/income/[id] - Deletes an income entry by ID.

--- a/src/app/api/business/income/route.ts
+++ b/src/app/api/business/income/route.ts
@@ -1,12 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
-import { parseAmount } from "@/features/business/lib/validation";
 import {
   appendRowWithSyncId,
   formatDateForSheet,
   getFySheetIdForDate,
 } from "@/features/business/lib/sheets-sync";
+import { parseAmount } from "@/features/business/lib/validation";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/business/income - Returns all income entries ordered by date descending.

--- a/src/app/api/business/invoices/[id]/pdf/route.ts
+++ b/src/app/api/business/invoices/[id]/pdf/route.ts
@@ -1,8 +1,8 @@
 // src/app/api/business/invoices/[id]/pdf/route.ts
-import { NextRequest, NextResponse } from "next/server";
+import { generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import { generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/invoices/[id]/preview-email/route.ts
+++ b/src/app/api/business/invoices/[id]/preview-email/route.ts
@@ -1,10 +1,10 @@
 // src/app/api/business/invoices/[id]/preview-email/route.ts
-import { NextRequest, NextResponse } from "next/server";
+import { getInvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
+import { buildInvoiceEmail } from "@/features/reviews/lib/email";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSiteUrl } from "@/shared/lib/site-url";
-import { buildInvoiceEmail } from "@/features/reviews/lib/email";
-import { getInvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/business/invoices/[id]/preview-email

--- a/src/app/api/business/invoices/[id]/preview-void-email/route.ts
+++ b/src/app/api/business/invoices/[id]/preview-void-email/route.ts
@@ -1,8 +1,8 @@
 // src/app/api/business/invoices/[id]/preview-void-email/route.ts
-import { NextRequest, NextResponse } from "next/server";
+import { buildVoidEmail } from "@/features/reviews/lib/email";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import { buildVoidEmail } from "@/features/reviews/lib/email";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/business/invoices/[id]/preview-void-email

--- a/src/app/api/business/invoices/[id]/route.ts
+++ b/src/app/api/business/invoices/[id]/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { calcInvoiceTotals } from "@/features/business/lib/business";
-import { getPolicy } from "@/features/business/lib/pricing-policy.server";
-import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
+import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
+import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
 import type { InvoiceStatus } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/invoices/[id]/send-email/route.ts
+++ b/src/app/api/business/invoices/[id]/send-email/route.ts
@@ -1,12 +1,12 @@
 // src/app/api/business/invoices/[id]/send-email/route.ts
-import { NextRequest, NextResponse } from "next/server";
+import { getInvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
+import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
+import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
+import { sendInvoiceEmail } from "@/features/reviews/lib/email";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSiteUrl } from "@/shared/lib/site-url";
-import { sendInvoiceEmail } from "@/features/reviews/lib/email";
-import { getInvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
-import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
-import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/invoices/[id]/void/route.ts
+++ b/src/app/api/business/invoices/[id]/void/route.ts
@@ -1,10 +1,10 @@
 // src/app/api/business/invoices/[id]/void/route.ts
-import { NextRequest, NextResponse } from "next/server";
+import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
+import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
+import { sendVoidNotification } from "@/features/reviews/lib/email";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import { sendVoidNotification } from "@/features/reviews/lib/email";
-import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
-import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/invoices/import-drive/route.ts
+++ b/src/app/api/business/invoices/import-drive/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
-import { inflateSync } from "node:zlib";
+import { downloadDriveFile, searchAllInvoicePdfs } from "@/features/business/lib/google-drive";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import { searchAllInvoicePdfs, downloadDriveFile } from "@/features/business/lib/google-drive";
+import { NextRequest, NextResponse } from "next/server";
+import { inflateSync } from "node:zlib";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/invoices/preview-pdf/route.ts
+++ b/src/app/api/business/invoices/preview-pdf/route.ts
@@ -1,8 +1,8 @@
 // src/app/api/business/invoices/preview-pdf/route.ts
-import { NextRequest, NextResponse } from "next/server";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import type { Invoice, LineItem } from "@/features/business/types/business";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/invoices/route.ts
+++ b/src/app/api/business/invoices/route.ts
@@ -1,15 +1,15 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { calcInvoiceTotals } from "@/features/business/lib/business";
-import { getPolicy } from "@/features/business/lib/pricing-policy.server";
-import { generateInvoicePdf, extractYearCode } from "@/features/business/lib/invoice-pdf";
 import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
 import {
   getNextInvoiceNumber,
   writeBackInvoiceCounter,
 } from "@/features/business/lib/invoice-numbering";
+import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
+import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { isAdminRequest } from "@/shared/lib/auth";
 import { getIdentity } from "@/shared/lib/business-identity.server";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/business/invoices - Returns all invoices ordered by creation date descending.

--- a/src/app/api/business/invoices/sync-drive/route.ts
+++ b/src/app/api/business/invoices/sync-drive/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { searchAllInvoicePdfs } from "@/features/business/lib/google-drive";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import { searchAllInvoicePdfs } from "@/features/business/lib/google-drive";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/parse-job/route.ts
+++ b/src/app/api/business/parse-job/route.ts
@@ -1,19 +1,19 @@
-import { NextRequest, NextResponse } from "next/server";
-import OpenAI from "openai";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
+import { composeDescription, effectiveHourlyRate } from "@/features/business/lib/business";
 import {
-  buildParseJobPrompt,
   buildParseJobContext,
+  buildParseJobPrompt,
 } from "@/features/business/lib/prompts/parse-job";
-import { effectiveHourlyRate, composeDescription } from "@/features/business/lib/business";
 import { lookupDriveDistance } from "@/features/business/lib/travel-distance";
 import type {
-  ParseJobResponse,
   ParseJobQuestion,
+  ParseJobResponse,
   ParsedRange,
   RateConfig,
 } from "@/features/business/types/business";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/promos/[id]/route.ts
+++ b/src/app/api/business/promos/[id]/route.ts
@@ -1,9 +1,9 @@
 // src/app/api/business/promos/[id]/route.ts
-import { NextRequest, NextResponse } from "next/server";
-import { revalidateTag } from "next/cache";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { ACTIVE_PROMO_TAG } from "@/features/business/lib/promos";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * PATCH /api/business/promos/[id] - Partial update; invalidates the cache.

--- a/src/app/api/business/promos/route.ts
+++ b/src/app/api/business/promos/route.ts
@@ -1,9 +1,9 @@
 // src/app/api/business/promos/route.ts
-import { NextRequest, NextResponse } from "next/server";
-import { revalidateTag } from "next/cache";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { ACTIVE_PROMO_TAG } from "@/features/business/lib/promos";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
 
 interface PromoBody {
   title?: string;

--- a/src/app/api/business/rates/[id]/route.ts
+++ b/src/app/api/business/rates/[id]/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * PATCH /api/business/rates/[id] - Updates a rate configuration, handling isDefault exclusivity.

--- a/src/app/api/business/rates/route.ts
+++ b/src/app/api/business/rates/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Seed shape: one base hourly rate (Standard), modifier rates that shift the
 // effective $/hr (Complex +$20, At home -$10, Remote -$10), a percentage

--- a/src/app/api/business/sheets/import/route.ts
+++ b/src/app/api/business/sheets/import/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { runSheetsImport } from "@/features/business/lib/sheets-import";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/sheets/invoice-counter/route.ts
+++ b/src/app/api/business/sheets/invoice-counter/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { getInvoiceCounter, setInvoiceCounter } from "@/features/business/lib/google-sheets";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/business/subscriptions/[id]/record/route.ts
+++ b/src/app/api/business/subscriptions/[id]/record/route.ts
@@ -1,12 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import {
   advanceNextDue,
   calcGstFromInclusive,
   formatUTCDDMMYYYY,
 } from "@/features/business/lib/business";
-import { getSheetsClient, getSheetId } from "@/features/business/lib/google-sheets";
+import { getSheetId, getSheetsClient } from "@/features/business/lib/google-sheets";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/business/subscriptions/[id]/record - Records one subscription payment.

--- a/src/app/api/business/subscriptions/[id]/route.ts
+++ b/src/app/api/business/subscriptions/[id]/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { VALID_FREQUENCIES } from "@/features/business/lib/constants";
 import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * PATCH /api/business/subscriptions/[id] - Updates a subscription's fields.

--- a/src/app/api/business/subscriptions/route.ts
+++ b/src/app/api/business/subscriptions/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { VALID_FREQUENCIES } from "@/features/business/lib/constants";
 import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/business/subscriptions - Returns all subscriptions ordered by nextDue ascending.

--- a/src/app/api/business/summary/route.ts
+++ b/src/app/api/business/summary/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { aggregateByFinancialYear } from "@/features/business/lib/financial-year";
-import { getSettings } from "@/shared/lib/settings/get-settings";
+import { isAdminRequest } from "@/shared/lib/auth";
 import { getIdentity } from "@/shared/lib/business-identity.server";
+import { prisma } from "@/shared/lib/prisma";
+import { getSettings } from "@/shared/lib/settings/get-settings";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/business/summary - Returns aggregated income, expense, profit, and tax reserve stats,

--- a/src/app/api/business/task-templates/[id]/route.ts
+++ b/src/app/api/business/task-templates/[id]/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * DELETE /api/business/task-templates/[id] - Deletes a saved task template.

--- a/src/app/api/business/task-templates/actions/[name]/route.ts
+++ b/src/app/api/business/task-templates/actions/[name]/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * DELETE /api/business/task-templates/actions/[name]

--- a/src/app/api/business/task-templates/devices/[name]/route.ts
+++ b/src/app/api/business/task-templates/devices/[name]/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * DELETE /api/business/task-templates/devices/[name]

--- a/src/app/api/business/task-templates/route.ts
+++ b/src/app/api/business/task-templates/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isAdminRequest } from "@/shared/lib/auth";
 import { composeDescription } from "@/features/business/lib/business";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Normalises a free-text taxonomy value (device or action): trims, collapses

--- a/src/app/api/business/task-templates/taxonomy/route.ts
+++ b/src/app/api/business/task-templates/taxonomy/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/business/task-templates/taxonomy

--- a/src/app/api/cron/purge-price-estimates/route.ts
+++ b/src/app/api/cron/purge-price-estimates/route.ts
@@ -5,10 +5,10 @@
  * Called externally via cron-job.org (daily cadence).
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isCronAuthorized } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/cron/record-subscriptions/route.ts
+++ b/src/app/api/cron/record-subscriptions/route.ts
@@ -1,12 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
-import { isCronAuthorized } from "@/shared/lib/auth";
 import {
   advanceNextDue,
   calcGstFromInclusive,
   formatUTCDDMMYYYY,
 } from "@/features/business/lib/business";
-import { getSheetsClient, getSheetId } from "@/features/business/lib/google-sheets";
+import { getSheetId, getSheetsClient } from "@/features/business/lib/google-sheets";
+import { isCronAuthorized } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/cron/refresh-calendar-cache/route.ts
+++ b/src/app/api/cron/refresh-calendar-cache/route.ts
@@ -5,9 +5,9 @@
  * Called externally via cron-job.org every 15 minutes.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { refreshCalendarCache } from "@/features/calendar/lib/calendar-cache";
 import { isCronAuthorized } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/cron/refresh-public-holidays/route.ts
+++ b/src/app/api/cron/refresh-public-holidays/route.ts
@@ -5,11 +5,11 @@
  * Google's public NZ holidays calendar. Called monthly via cron-job.org.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { google } from "googleapis";
-import { prisma } from "@/shared/lib/prisma";
+import { HOME_REGION, NZ_REGION } from "@/features/business/lib/pricing-policy";
 import { isCronAuthorized } from "@/shared/lib/auth";
-import { NZ_REGION, HOME_REGION } from "@/features/business/lib/pricing-policy";
+import { prisma } from "@/shared/lib/prisma";
+import { google } from "googleapis";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/cron/release-holds/route.ts
+++ b/src/app/api/cron/release-holds/route.ts
@@ -5,9 +5,9 @@
  * Called externally via cron-job.org every 15 minutes.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { isCronAuthorized } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/cron/send-booking-reminders/route.ts
+++ b/src/app/api/cron/send-booking-reminders/route.ts
@@ -10,12 +10,12 @@
  * fee in a reminder would read as a bait-and-switch.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
+import { getPolicy } from "@/features/business/lib/pricing-policy.server";
 import { sendBookingReminderEmail } from "@/features/reviews/lib/email";
 import { isCronAuthorized } from "@/shared/lib/auth";
-import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/cron/send-review-emails/route.ts
+++ b/src/app/api/cron/send-review-emails/route.ts
@@ -5,11 +5,11 @@
  * Called externally via cron-job.org every 15 minutes.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/shared/lib/prisma";
 import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
 import { isCronAuthorized } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/cron/sync-sheets/route.ts
+++ b/src/app/api/cron/sync-sheets/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { isCronAuthorized } from "@/shared/lib/auth";
 import { runSheetsImport } from "@/features/business/lib/sheets-import";
+import { isCronAuthorized } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/pricing/estimate-duration/route.ts
+++ b/src/app/api/pricing/estimate-duration/route.ts
@@ -1,6 +1,6 @@
+import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
-import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/pricing/log-estimate/route.ts
+++ b/src/app/api/pricing/log-estimate/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
-import { AiEstimateCategory } from "@prisma/client";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { AiEstimateCategory } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
 
 interface LogBody {
   description?: unknown;

--- a/src/app/api/pricing/public-holiday/route.ts
+++ b/src/app/api/pricing/public-holiday/route.ts
@@ -6,9 +6,9 @@
  * chosen booking time falls on a holiday.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { lookupPublicHoliday } from "@/features/business/lib/pricing-policy.server";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * GET /api/pricing/public-holiday?date=YYYY-MM-DD

--- a/src/app/api/pricing/rates/route.ts
+++ b/src/app/api/pricing/rates/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
+import { NextResponse } from "next/server";
 
 /**
  * GET /api/pricing/rates - Public endpoint returning rate labels and amounts (no auth required).

--- a/src/app/api/pricing/travel-time/route.ts
+++ b/src/app/api/pricing/travel-time/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { lookupDriveDistance } from "@/features/business/lib/travel-distance";
+import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;

--- a/src/app/api/promos/active/route.ts
+++ b/src/app/api/promos/active/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/promos/active/route.ts
-import { NextResponse } from "next/server";
 import { getActivePromo } from "@/features/business/lib/promos";
+import { NextResponse } from "next/server";
 
 /**
  * GET /api/promos/active - Public, returns the active promo or null.

--- a/src/app/api/reviews/[id]/route.ts
+++ b/src/app/api/reviews/[id]/route.ts
@@ -4,9 +4,9 @@
  * @description PATCH /api/reviews/[id] - Allows a customer to edit their review (with valid customerRef), resets status to pending.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * PATCH /api/reviews/[id] - Allows a customer to edit their review.

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -4,14 +4,14 @@
  * @description API routes for reviews with verification support.
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { revalidatePath, revalidateTag } from "next/cache";
-import { prisma as prismaClient } from "@/shared/lib/prisma";
 import { sendOwnerReviewNotification } from "@/features/reviews/lib/email";
-import { normalisePhone } from "@/shared/lib/normalise-phone";
 import { reviewTextError } from "@/features/reviews/lib/validation";
+import { normalisePhone } from "@/shared/lib/normalise-phone";
+import { prisma as prismaClient } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { getSettings } from "@/shared/lib/settings/get-settings";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Factory for reviews API handlers, allows dependency injection of Prisma client.

--- a/src/app/booking/cancel/loading.tsx
+++ b/src/app/booking/cancel/loading.tsx
@@ -7,9 +7,9 @@
  * banner placeholder and the action buttons.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 const CARD = "border-seasalt-400/60 bg-seasalt-800 rounded-xl border p-5 shadow-sm sm:p-6";
 

--- a/src/app/booking/cancel/page.tsx
+++ b/src/app/booking/cancel/page.tsx
@@ -8,17 +8,17 @@
 
 "use client";
 
-import type React from "react";
-import { Suspense, useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { cn } from "@/shared/lib/cn";
-import { Button } from "@/shared/components/Button";
 import {
   CANCELLATION,
   isWithinCancellationWindow,
   isWithinTravelWindow,
 } from "@/features/business/lib/pricing-policy";
+import { Button } from "@/shared/components/Button";
+import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
+import { useSearchParams } from "next/navigation";
+import type React from "react";
+import { Suspense, useEffect, useState } from "react";
 
 const CARD = "border-seasalt-400/60 bg-seasalt-800 rounded-xl border p-5 shadow-sm sm:p-6";
 

--- a/src/app/booking/edit/page.tsx
+++ b/src/app/booking/edit/page.tsx
@@ -4,27 +4,27 @@
  * @description Edit an existing booking using the cancel token.
  */
 
-import type React from "react";
-import { notFound } from "next/navigation";
-import { cn } from "@/shared/lib/cn";
-import {
-  DURATION_OPTIONS,
-  TIME_OF_DAY_OPTIONS,
-  SUB_SLOT_MINUTES,
-  buildAvailableDays,
-  type ExistingBooking,
-  type BookableDay,
-  type JobDuration,
-  type TimeOfDay,
-  type StartMinute,
-} from "@/features/booking/lib/booking";
-import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
-import { prisma } from "@/shared/lib/prisma";
-import { fetchAllCalendarEvents } from "@/features/calendar/lib/google-calendar";
 import BookingForm, {
   type BookingFormInitialValues,
 } from "@/features/booking/components/BookingForm";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
+import {
+  DURATION_OPTIONS,
+  SUB_SLOT_MINUTES,
+  TIME_OF_DAY_OPTIONS,
+  buildAvailableDays,
+  type BookableDay,
+  type ExistingBooking,
+  type JobDuration,
+  type StartMinute,
+  type TimeOfDay,
+} from "@/features/booking/lib/booking";
+import { fetchAllCalendarEvents } from "@/features/calendar/lib/google-calendar";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
+import { cn } from "@/shared/lib/cn";
+import { prisma } from "@/shared/lib/prisma";
+import { notFound } from "next/navigation";
+import type React from "react";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/booking/error.tsx
+++ b/src/app/booking/error.tsx
@@ -7,10 +7,10 @@
 
 "use client";
 
-import type React from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
 import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 import { FaArrowRotateRight, FaCalendarDays } from "react-icons/fa6";
 
 /**

--- a/src/app/booking/loading.tsx
+++ b/src/app/booking/loading.tsx
@@ -5,10 +5,10 @@
  * /booking/edit, which reuses the same form).
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Booking route-loading skeleton.

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -8,21 +8,21 @@
  *   live Google Calendar API.
  */
 
+import BookingForm from "@/features/booking/components/BookingForm";
+import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
+import {
+  buildAvailableDays,
+  type BookableDay,
+  type ExistingBooking,
+} from "@/features/booking/lib/booking";
+import { fetchAllCalendarEvents } from "@/features/calendar/lib/google-calendar";
+import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
+import { CARD, FrostedSection, PageShell, SOFT_CARD } from "@/shared/components/PageLayout";
+import { cn } from "@/shared/lib/cn";
+import { prisma } from "@/shared/lib/prisma";
 import type { Metadata } from "next";
 import type React from "react";
 import { Suspense } from "react";
-import { cn } from "@/shared/lib/cn";
-import {
-  buildAvailableDays,
-  type ExistingBooking,
-  type BookableDay,
-} from "@/features/booking/lib/booking";
-import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
-import { prisma } from "@/shared/lib/prisma";
-import { fetchAllCalendarEvents } from "@/features/calendar/lib/google-calendar";
-import BookingForm from "@/features/booking/components/BookingForm";
-import { FrostedSection, PageShell, CARD, SOFT_CARD } from "@/shared/components/PageLayout";
-import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
 import { FaCalendarCheck, FaClock, FaEnvelopeOpenText, FaListCheck } from "react-icons/fa6";
 
 export const metadata: Metadata = {

--- a/src/app/booking/success/loading.tsx
+++ b/src/app/booking/success/loading.tsx
@@ -7,9 +7,9 @@
  * the cancellation-policy card.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 const CARD = "border-seasalt-400/60 bg-seasalt-800 rounded-xl border p-5 shadow-sm sm:p-6";
 

--- a/src/app/booking/success/page.tsx
+++ b/src/app/booking/success/page.tsx
@@ -4,13 +4,13 @@
  * @description Booking request success page.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Button } from "@/shared/components/Button";
-import { FaCircleCheck, FaHouse, FaPenToSquare, FaTag } from "react-icons/fa6";
 import { cancellationCopy } from "@/features/business/lib/pricing-policy";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { Button } from "@/shared/components/Button";
+import { cn } from "@/shared/lib/cn";
 import { prisma } from "@/shared/lib/prisma";
+import type React from "react";
+import { FaCircleCheck, FaHouse, FaPenToSquare, FaTag } from "react-icons/fa6";
 import { BookingConversion } from "./BookingConversion";
 
 const CARD = "border-seasalt-400/60 bg-seasalt-800 rounded-xl border p-5 shadow-sm sm:p-6";

--- a/src/app/contact/loading.tsx
+++ b/src/app/contact/loading.tsx
@@ -5,10 +5,10 @@
  * call/email buttons, service-area card, what-to-include list and a CTA card.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Contact route-loading skeleton.

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,13 +4,13 @@
  * @description Contact page: how to get in touch.
  */
 
-import type { Metadata } from "next";
-import type React from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
 import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
 import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
-import { FaEnvelope, FaPhone, FaMapLocationDot } from "react-icons/fa6";
+import type { Metadata } from "next";
+import type React from "react";
+import { FaEnvelope, FaMapLocationDot, FaPhone } from "react-icons/fa6";
 
 export const metadata: Metadata = {
   title: "Contact - Local Tech Support in Auckland",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -6,11 +6,11 @@
 
 "use client";
 
+import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
+import { cn } from "@/shared/lib/cn";
 import type React from "react";
 import { useState } from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
-import { Button } from "@/shared/components/Button";
-import { cn } from "@/shared/lib/cn";
 import { FaArrowRotateRight, FaHouse } from "react-icons/fa6";
 
 const MESSAGES = [

--- a/src/app/faq/loading.tsx
+++ b/src/app/faq/loading.tsx
@@ -5,10 +5,10 @@
  * two-column stack of collapsed accordion rows and a next-steps card.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD, SOFT_CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell, SOFT_CARD } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * FAQ route-loading skeleton.

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -8,18 +8,18 @@
  * never drifts from the /pricing accordion + booking emails.
  */
 
-import type { Metadata } from "next";
-import type React from "react";
-import Link from "next/link";
-import { FrostedSection, PageShell, CARD, SOFT_CARD } from "@/shared/components/PageLayout";
-import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
-import { cn } from "@/shared/lib/cn";
-import { getPolicy, getPublicPricing } from "@/features/business/lib/pricing-policy.server";
 import {
   cancellationCopy,
-  unsuccessfulWorkCopy,
   gstCopy,
+  unsuccessfulWorkCopy,
 } from "@/features/business/lib/pricing-policy";
+import { getPolicy, getPublicPricing } from "@/features/business/lib/pricing-policy.server";
+import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
+import { CARD, FrostedSection, PageShell, SOFT_CARD } from "@/shared/components/PageLayout";
+import { cn } from "@/shared/lib/cn";
+import type { Metadata } from "next";
+import Link from "next/link";
+import type React from "react";
 
 export const metadata: Metadata = {
   title: "FAQ - Tech Support Questions Answered",

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -6,9 +6,9 @@
 
 "use client";
 
-import type React from "react";
-import Link from "next/link";
 import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import type React from "react";
 import { FaArrowRotateRight, FaHouse } from "react-icons/fa6";
 
 /**

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,17 +4,17 @@
  * @description Root layout for the App Router. Injects global styles, metadata, and JSON-LD.
  */
 
+import { getPublicPricing } from "@/features/business/lib/pricing-policy.server";
+import { GoogleTag } from "@/shared/components/GoogleTag";
+import { NavBar } from "@/shared/components/NavBar";
+import { PromoBanner } from "@/shared/components/PromoBanner";
+import { getSettings } from "@/shared/lib/settings/get-settings";
+import { getSiteUrl } from "@/shared/lib/site-url";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { Exo } from "next/font/google";
 import "./globals.css";
-import { GoogleTag } from "@/shared/components/GoogleTag";
-import { NavBar } from "@/shared/components/NavBar";
-import { PromoBanner } from "@/shared/components/PromoBanner";
-import { getSiteUrl } from "@/shared/lib/site-url";
-import { getSettings } from "@/shared/lib/settings/get-settings";
-import { getPublicPricing } from "@/features/business/lib/pricing-policy.server";
 
 const exo = Exo({
   subsets: ["latin"],

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -6,10 +6,10 @@
  * instantly while the approved-reviews query runs.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Home route-loading skeleton.

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,11 +6,11 @@
 
 "use client";
 
+import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
+import { cn } from "@/shared/lib/cn";
 import type React from "react";
 import { useState } from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
-import { Button } from "@/shared/components/Button";
-import { cn } from "@/shared/lib/cn";
 import { FaHouse } from "react-icons/fa6";
 
 const MESSAGES = [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,20 +4,22 @@
  * @description Main landing page for tech support company.
  */
 
-import type React from "react";
 import Reviews, { type ReviewItem } from "@/features/reviews/components/Reviews";
 import { formatReviewerName } from "@/features/reviews/lib/formatting";
-import { FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Button } from "@/shared/components/Button";
+import { FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
+import { unstable_cache } from "next/cache";
 import Image from "next/image";
+import type React from "react";
+import type { IconType } from "react-icons";
 import {
   FaCalendarCheck,
   FaCircleCheck,
   FaCloud,
+  FaDownload,
   FaEnvelope,
   FaHandshake,
   FaHouse,
@@ -31,10 +33,8 @@ import {
   FaShieldHalved,
   FaToolbox,
   FaTv,
-  FaDownload,
   FaWifi,
 } from "react-icons/fa6";
-import type { IconType } from "react-icons";
 
 // Rely on on-demand revalidation (revalidateReviewPaths fires on every review change).
 // Long fallback avoids waking a cold DB on a fixed timer.

--- a/src/app/pricing/loading.tsx
+++ b/src/app/pricing/loading.tsx
@@ -6,10 +6,10 @@
  * next-steps and estimate cards. Shown while the live pricing policy loads.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Pricing route-loading skeleton.

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -6,28 +6,28 @@
  * page, booking emails, and FAQ stay aligned.
  */
 
-import type { Metadata } from "next";
-import type React from "react";
-import Link from "next/link";
-import { FrostedSection, PageShell, CARD, SOFT_CARD } from "@/shared/components/PageLayout";
-import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
-import { cn } from "@/shared/lib/cn";
 import { PricingWizard } from "@/features/business/components/PricingWizard";
+import {
+  cancellationCopy,
+  gstCopy,
+  minimumsCopy,
+  publicHolidayCopy,
+  travelCopy,
+  unsuccessfulWorkCopy,
+} from "@/features/business/lib/pricing-policy";
+import { getPolicy, getPublicPricing } from "@/features/business/lib/pricing-policy.server";
 import {
   applyPromoToHourlyRate,
   getActivePromo,
   summariseForBanner,
 } from "@/features/business/lib/promos";
-import { getPolicy, getPublicPricing } from "@/features/business/lib/pricing-policy.server";
-import {
-  cancellationCopy,
-  travelCopy,
-  minimumsCopy,
-  unsuccessfulWorkCopy,
-  publicHolidayCopy,
-  gstCopy,
-} from "@/features/business/lib/pricing-policy";
+import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
+import { CARD, FrostedSection, PageShell, SOFT_CARD } from "@/shared/components/PageLayout";
+import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
+import type { Metadata } from "next";
+import Link from "next/link";
+import type React from "react";
 import { FaCaretDown, FaCheck } from "react-icons/fa6";
 
 // Admin rate / promo edits must show on next visit.

--- a/src/app/review/error.tsx
+++ b/src/app/review/error.tsx
@@ -6,10 +6,10 @@
 
 "use client";
 
-import type React from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
 import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 import { FaArrowRotateRight, FaHouse } from "react-icons/fa6";
 
 /**

--- a/src/app/review/loading.tsx
+++ b/src/app/review/loading.tsx
@@ -6,9 +6,9 @@
  * Turns a 6s FCP into a near-instant render by streaming the shell first.
  */
 
-import { PageShell, FrostedSection, CARD } from "@/shared/components/PageLayout";
-import { cn } from "@/shared/lib/cn";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
 
 /**
  * Review page loading skeleton shown via React Suspense while DB queries run.

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -4,13 +4,13 @@
  * @description Protected review page - requires token OR allows public reviews.
  */
 
-import type React from "react";
-import Link from "next/link";
 import ReviewFormProtected from "@/features/reviews/components/ReviewForm";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
 import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
 import { prisma } from "@/shared/lib/prisma";
+import Link from "next/link";
+import type React from "react";
 
 // This page reads searchParams so it is always dynamic - revalidate has no effect.
 export const dynamic = "force-dynamic";

--- a/src/app/reviews/loading.tsx
+++ b/src/app/reviews/loading.tsx
@@ -6,10 +6,10 @@
  * Shown while the approved-reviews query runs.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Reviews route-loading skeleton.

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -4,15 +4,15 @@
  * @description Public reviews page showing all approved client reviews.
  */
 
-import type { Metadata } from "next";
-import type React from "react";
-import Link from "next/link";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { ReviewScrollHandler } from "@/features/reviews/components/ReviewScrollHandler";
+import { formatReviewerName } from "@/features/reviews/lib/formatting";
 import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
 import { prisma } from "@/shared/lib/prisma";
-import { formatReviewerName } from "@/features/reviews/lib/formatting";
-import { ReviewScrollHandler } from "@/features/reviews/components/ReviewScrollHandler";
+import type { Metadata } from "next";
+import Link from "next/link";
+import type React from "react";
 
 export const metadata: Metadata = {
   title: "Reviews - What Auckland Clients Say About To The Point Tech",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,8 +4,8 @@
  * @description robots.txt generator. Allows public routes, blocks admin/API/preview.
  */
 
-import type { MetadataRoute } from "next";
 import { getSiteUrl } from "@/shared/lib/site-url";
+import type { MetadataRoute } from "next";
 
 const siteUrl = getSiteUrl();
 

--- a/src/app/services/loading.tsx
+++ b/src/app/services/loading.tsx
@@ -6,10 +6,10 @@
  * and the closing CTA. Shown while the live pricing lookup runs.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Services route-loading skeleton.

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -4,14 +4,28 @@
  * @description Services page with wider layout and better organization.
  */
 
-import type { Metadata } from "next";
-import type React from "react";
-import { FrostedSection, PageShell, CARD } from "@/shared/components/PageLayout";
+import { getPublicPricing } from "@/features/business/lib/pricing-policy.server";
 import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
 import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
 import { getSiteUrl } from "@/shared/lib/site-url";
-import { getPublicPricing } from "@/features/business/lib/pricing-policy.server";
+import type { Metadata } from "next";
+import type React from "react";
+import {
+  FaCloud,
+  FaEnvelope,
+  FaHouse,
+  FaImages,
+  FaLaptop,
+  FaMobileScreen,
+  FaPrint,
+  FaRightLeft,
+  FaShieldHalved,
+  FaToolbox,
+  FaTv,
+  FaWifi,
+} from "react-icons/fa6";
 
 export const metadata: Metadata = {
   title: "Tech Support Services - Computers, Wi-Fi, Phones & More",
@@ -37,20 +51,6 @@ export const metadata: Metadata = {
     url: "/services",
   },
 };
-import {
-  FaCloud,
-  FaHouse,
-  FaImages,
-  FaLaptop,
-  FaMobileScreen,
-  FaPrint,
-  FaRightLeft,
-  FaShieldHalved,
-  FaToolbox,
-  FaTv,
-  FaWifi,
-  FaEnvelope,
-} from "react-icons/fa6";
 
 interface ServiceArea {
   icon: React.ReactElement;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,8 +4,8 @@
  * @description Dynamic sitemap for search engines. Lists all crawlable public routes.
  */
 
-import type { MetadataRoute } from "next";
 import { getSiteUrl } from "@/shared/lib/site-url";
+import type { MetadataRoute } from "next";
 
 const siteUrl = getSiteUrl();
 

--- a/src/features/admin/components/AdminListSkeleton.tsx
+++ b/src/features/admin/components/AdminListSkeleton.tsx
@@ -7,10 +7,10 @@
  * The data-table route loading.tsx files re-export this as their default.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { Bone } from "@/shared/components/Skeleton";
 import { AdminSkeletonShell } from "@/features/admin/components/AdminSkeletonShell";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /**
  * Admin list-view loading skeleton.

--- a/src/features/admin/components/AdminPageLayout.tsx
+++ b/src/features/admin/components/AdminPageLayout.tsx
@@ -1,6 +1,6 @@
-import type React from "react";
 import { AdminSidebar, type AdminPage } from "@/features/admin/components/AdminSidebar";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 interface AdminPageLayoutProps {
   current: AdminPage;

--- a/src/features/admin/components/AdminSidebar.tsx
+++ b/src/features/admin/components/AdminSidebar.tsx
@@ -1,29 +1,29 @@
 "use client";
 // src/features/admin/components/AdminSidebar.tsx
-import { useState } from "react";
-import type React from "react";
+import { cn } from "@/shared/lib/cn";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useState } from "react";
 import {
-  FaGaugeHigh,
-  FaStar,
   FaAddressBook,
+  FaArrowRightFromBracket,
+  FaArrowTrendUp,
+  FaArrowUpRightFromSquare,
+  FaBars,
+  FaBriefcase,
+  FaCalculator,
   FaCalendarDays,
   FaCalendarWeek,
-  FaRoute,
-  FaBriefcase,
-  FaArrowTrendUp,
-  FaReceipt,
   FaFileInvoiceDollar,
-  FaCalculator,
-  FaTags,
+  FaGaugeHigh,
   FaGear,
-  FaBars,
-  FaXmark,
-  FaArrowUpRightFromSquare,
-  FaArrowRightFromBracket,
   FaMagnifyingGlassDollar,
+  FaReceipt,
+  FaRoute,
+  FaStar,
+  FaTags,
+  FaXmark,
 } from "react-icons/fa6";
 
 export type AdminPage =

--- a/src/features/admin/components/AdminSkeletonShell.tsx
+++ b/src/features/admin/components/AdminSkeletonShell.tsx
@@ -6,9 +6,9 @@
  * admin route-loading file only has to supply its own content bones.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /** Props for AdminSkeletonShell. */
 interface AdminSkeletonShellProps {

--- a/src/features/admin/components/BlockDayButton.tsx
+++ b/src/features/admin/components/BlockDayButton.tsx
@@ -7,9 +7,9 @@
  * header, and a full-width labelled button used by the mobile day-agenda view.
  */
 
+import { cn } from "@/shared/lib/cn";
 import type React from "react";
 import { FaBan, FaCircleCheck } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
 
 export interface BlockDayButtonProps {
   dateKey: string;

--- a/src/features/admin/components/ContactAdminList.tsx
+++ b/src/features/admin/components/ContactAdminList.tsx
@@ -8,16 +8,16 @@
  * (already linked to Google Contacts, shown in a collapsible drawer).
  */
 
-import type React from "react";
-import { useState, useEffect } from "react";
-import { cn } from "@/shared/lib/cn";
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
-import { formatReviewerName } from "@/features/reviews/lib/formatting";
-import { validatePhone } from "@/shared/lib/normalise-phone";
 import { validateEmail } from "@/features/booking/lib/booking";
+import { formatReviewerName } from "@/features/reviews/lib/formatting";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
+import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
+import { validatePhone } from "@/shared/lib/normalise-phone";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 export interface ContactRow {
   id: string;

--- a/src/features/admin/components/ContactConflictsView.tsx
+++ b/src/features/admin/components/ContactConflictsView.tsx
@@ -8,11 +8,11 @@
  * Google. Once resolved, the row disappears from the list.
  */
 
-import { useState } from "react";
-import type React from "react";
-import { FaCaretLeft } from "react-icons/fa6";
-import Link from "next/link";
 import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import type React from "react";
+import { useState } from "react";
+import { FaCaretLeft } from "react-icons/fa6";
 
 /** A single unresolved conflict as returned by the GET endpoint. */
 export interface ConflictRow {

--- a/src/features/admin/components/ContactsAdminView.tsx
+++ b/src/features/admin/components/ContactsAdminView.tsx
@@ -1,11 +1,11 @@
 "use client";
 // src/features/admin/components/ContactsAdminView.tsx
-import { useState, useCallback } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
-import { cn } from "@/shared/lib/cn";
-import { ContactAdminList, type ContactRow } from "./ContactAdminList";
 import type { ConflictEntry } from "@/app/api/admin/contacts/enrich-from-reviews/route";
+import { cn } from "@/shared/lib/cn";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useCallback, useState } from "react";
+import { ContactAdminList, type ContactRow } from "./ContactAdminList";
 
 interface ContactsAdminViewProps {
   initialConflicts: ConflictEntry[];

--- a/src/features/admin/components/DashboardQuickActions.tsx
+++ b/src/features/admin/components/DashboardQuickActions.tsx
@@ -6,15 +6,15 @@
  * send a review link to a past client, or mark a completed event and send its review.
  */
 
-import { useState } from "react";
-import type React from "react";
-import { FaCheck } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
 import {
   SendReviewLinkForm,
   type ContactSuggestion,
 } from "@/features/reviews/components/admin/SendReviewLinkForm";
+import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
+import type React from "react";
+import { useState } from "react";
+import { FaCheck } from "react-icons/fa6";
 
 /**
  * A past confirmed booking that is ready to be completed.

--- a/src/features/admin/components/DayAgendaView.tsx
+++ b/src/features/admin/components/DayAgendaView.tsx
@@ -12,15 +12,9 @@
  * week's calendar events.
  */
 
-import { useMemo, useRef, useState, useTransition } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
-import { FaCalendarDay, FaChevronLeft, FaChevronRight, FaRegCalendar } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
-import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
-import { ManualBookingModal } from "@/features/admin/components/ManualBookingModal";
 import { BlockDayButton } from "@/features/admin/components/BlockDayButton";
 import { EventActionSheet } from "@/features/admin/components/EventActionSheet";
+import { ManualBookingModal } from "@/features/admin/components/ManualBookingModal";
 import {
   KIND_BAR_BG,
   KIND_STYLES,
@@ -30,6 +24,12 @@ import {
   mondayOf,
   type WeekEvent,
 } from "@/features/admin/lib/schedule-types";
+import { cn } from "@/shared/lib/cn";
+import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useMemo, useRef, useState, useTransition } from "react";
+import { FaCalendarDay, FaChevronLeft, FaChevronRight, FaRegCalendar } from "react-icons/fa6";
 
 /**
  * Formats a positive minute count as "Xh Ym free" / "Xh free" / "Ym free".

--- a/src/features/admin/components/EventActionSheet.tsx
+++ b/src/features/admin/components/EventActionSheet.tsx
@@ -8,15 +8,15 @@
  * (test bookings only).
  */
 
-import { useState } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
-import { cn } from "@/shared/lib/cn";
 import type {
   BookingStatus,
   WeekEvent,
   WeekEventBooking,
 } from "@/features/admin/lib/schedule-types";
+import { cn } from "@/shared/lib/cn";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useState } from "react";
 
 interface EventActionSheetProps {
   /**

--- a/src/features/admin/components/LoginForm.tsx
+++ b/src/features/admin/components/LoginForm.tsx
@@ -8,10 +8,10 @@
  * distinguished from a rate-limited one (defence-in-depth).
  */
 
-import { useState } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
 import { cn } from "@/shared/lib/cn";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useState } from "react";
 
 interface LoginFormProps {
   /** Validated relative path to land on after a successful sign-in. */

--- a/src/features/admin/components/ManualBookingModal.tsx
+++ b/src/features/admin/components/ManualBookingModal.tsx
@@ -7,17 +7,17 @@
  * the clicked slot and POSTs to the admin booking-create endpoint.
  */
 
-import { useEffect, useRef, useState } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
-import { FaXmark } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
-import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
-import { formatNZPhone, validatePhone } from "@/shared/lib/normalise-phone";
 import { validateEmail } from "@/features/booking/lib/booking";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
+import { cn } from "@/shared/lib/cn";
+import { formatNZPhone, validatePhone } from "@/shared/lib/normalise-phone";
+import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import { FaXmark } from "react-icons/fa6";
 
 const NZ_TZ = "Pacific/Auckland";
 

--- a/src/features/admin/components/RecalculateButton.tsx
+++ b/src/features/admin/components/RecalculateButton.tsx
@@ -1,9 +1,9 @@
 "use client";
 // src/features/admin/components/RecalculateButton.tsx
-import { useState, useCallback } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
 import { cn } from "@/shared/lib/cn";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useCallback, useState } from "react";
 
 /**
  * Client button that triggers the travel time recalculation API and shows the result.

--- a/src/features/admin/components/TravelBlockAdminList.tsx
+++ b/src/features/admin/components/TravelBlockAdminList.tsx
@@ -6,9 +6,9 @@
  * with per-event transport mode selector and custom origin override.
  */
 
-import { useState, useEffect } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 export interface TravelBlockRow {
   id: string;

--- a/src/features/admin/components/WeekView.tsx
+++ b/src/features/admin/components/WeekView.tsx
@@ -7,14 +7,8 @@
  * slot is clicked.
  */
 
-import { useMemo, useState, useTransition } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
-import { FaChevronLeft, FaChevronRight, FaCalendarDay } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
-import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
-import { ManualBookingModal } from "@/features/admin/components/ManualBookingModal";
 import { BlockDayButton } from "@/features/admin/components/BlockDayButton";
+import { ManualBookingModal } from "@/features/admin/components/ManualBookingModal";
 import {
   KIND_STYLES,
   LegendDot,
@@ -24,6 +18,12 @@ import {
   type WeekEvent,
   type WeekViewKind,
 } from "@/features/admin/lib/schedule-types";
+import { cn } from "@/shared/lib/cn";
+import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useMemo, useState, useTransition } from "react";
+import { FaCalendarDay, FaChevronLeft, FaChevronRight } from "react-icons/fa6";
 
 export type { WeekEvent, WeekViewKind };
 

--- a/src/features/admin/components/settings/AvailabilityPreview.tsx
+++ b/src/features/admin/components/settings/AvailabilityPreview.tsx
@@ -9,11 +9,11 @@
  * cutoff, caps) are reflected, not just the raw hours.
  */
 
-import { useMemo } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { buildAvailableDays, hourLabel } from "@/features/booking/lib/booking";
+import { cn } from "@/shared/lib/cn";
 import type { AvailabilitySettings } from "@/shared/lib/settings/types";
+import type React from "react";
+import { useMemo } from "react";
 
 /** App timezone; the booking engine is NZ-only. */
 const TIME_ZONE = "Pacific/Auckland";

--- a/src/features/admin/components/settings/AvailabilityTab.tsx
+++ b/src/features/admin/components/settings/AvailabilityTab.tsx
@@ -9,19 +9,19 @@
  * job) come back from the API and surface inline.
  */
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { AVAILABILITY_FIELD_META } from "@/shared/lib/settings/field-meta";
-import { hourLabel } from "@/features/booking/lib/booking";
-import type { AvailabilitySettings, DayWindow } from "@/shared/lib/settings/types";
+import { AvailabilityPreview } from "@/features/admin/components/settings/AvailabilityPreview";
 import {
+  FieldShell,
   NumberField,
   ToggleField,
-  FieldShell,
 } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
-import { AvailabilityPreview } from "@/features/admin/components/settings/AvailabilityPreview";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
+import { hourLabel } from "@/features/booking/lib/booking";
+import { cn } from "@/shared/lib/cn";
+import { AVAILABILITY_FIELD_META } from "@/shared/lib/settings/field-meta";
+import type { AvailabilitySettings, DayWindow } from "@/shared/lib/settings/types";
+import type React from "react";
 
 interface Props {
   initial: AvailabilitySettings;

--- a/src/features/admin/components/settings/CommsTab.tsx
+++ b/src/features/admin/components/settings/CommsTab.tsx
@@ -8,13 +8,13 @@
  * settings form hook.
  */
 
-import type React from "react";
+import { NumberField, ToggleField } from "@/features/admin/components/settings/SettingsFields";
+import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { COMMS_FIELD_META } from "@/shared/lib/settings/field-meta";
 import type { CommsSettings } from "@/shared/lib/settings/types";
-import { NumberField, ToggleField } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
-import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import type React from "react";
 
 interface Props {
   initial: CommsSettings;

--- a/src/features/admin/components/settings/HoldsTab.tsx
+++ b/src/features/admin/components/settings/HoldsTab.tsx
@@ -6,13 +6,13 @@
  * slot-hold expiry; the job-notes length limits stay structural code consts.
  */
 
-import type React from "react";
+import { NumberField } from "@/features/admin/components/settings/SettingsFields";
+import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { HOLDS_FIELD_META } from "@/shared/lib/settings/field-meta";
 import type { HoldsSettings } from "@/shared/lib/settings/types";
-import { NumberField } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
-import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import type React from "react";
 
 interface Props {
   initial: HoldsSettings;

--- a/src/features/admin/components/settings/IdentityTab.tsx
+++ b/src/features/admin/components/settings/IdentityTab.tsx
@@ -9,13 +9,13 @@
  * the DB; the public/invoice/email consumers read these in the follow-up step.
  */
 
-import type React from "react";
+import { NumberField, TextField } from "@/features/admin/components/settings/SettingsFields";
+import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { IDENTITY_FIELD_META } from "@/shared/lib/settings/field-meta";
 import type { BaseAddress, IdentitySettings } from "@/shared/lib/settings/types";
-import { NumberField, TextField } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
-import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import type React from "react";
 
 interface Props {
   initial: IdentitySettings;

--- a/src/features/admin/components/settings/PricingPreview.tsx
+++ b/src/features/admin/components/settings/PricingPreview.tsx
@@ -8,9 +8,9 @@
  * numbers have a concrete meaning before saving.
  */
 
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
 import type { PricingSettings } from "@/shared/lib/settings/types";
+import type React from "react";
 
 interface Props {
   config: PricingSettings;

--- a/src/features/admin/components/settings/PricingTab.tsx
+++ b/src/features/admin/components/settings/PricingTab.tsx
@@ -9,14 +9,14 @@
  * these yet; that wiring lands in the next part.
  */
 
-import type React from "react";
+import { PricingPreview } from "@/features/admin/components/settings/PricingPreview";
+import { NumberField, ToggleField } from "@/features/admin/components/settings/SettingsFields";
+import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { PRICING_FIELD_META } from "@/shared/lib/settings/field-meta";
 import type { PricingSettings } from "@/shared/lib/settings/types";
-import { NumberField, ToggleField } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
-import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
-import { PricingPreview } from "@/features/admin/components/settings/PricingPreview";
+import type React from "react";
 
 interface Props {
   initial: PricingSettings;

--- a/src/features/admin/components/settings/ReviewsTab.tsx
+++ b/src/features/admin/components/settings/ReviewsTab.tsx
@@ -7,13 +7,13 @@
  * review-request cooldown. Saves through the shared settings form hook.
  */
 
-import type React from "react";
+import { NumberField, ToggleField } from "@/features/admin/components/settings/SettingsFields";
+import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { REVIEWS_FIELD_META } from "@/shared/lib/settings/field-meta";
 import type { ReviewsSettings } from "@/shared/lib/settings/types";
-import { NumberField, ToggleField } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
-import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import type React from "react";
 
 interface Props {
   initial: ReviewsSettings;

--- a/src/features/admin/components/settings/SchedulingTab.tsx
+++ b/src/features/admin/components/settings/SchedulingTab.tsx
@@ -8,13 +8,13 @@
  * - the defaults are sensible and most operators never need to touch these.
  */
 
-import type React from "react";
+import { NumberField } from "@/features/admin/components/settings/SettingsFields";
+import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { SCHEDULING_FIELD_META } from "@/shared/lib/settings/field-meta";
 import type { SchedulingSettings } from "@/shared/lib/settings/types";
-import { NumberField } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
-import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import type React from "react";
 
 interface Props {
   initial: SchedulingSettings;

--- a/src/features/admin/components/settings/SettingsFields.tsx
+++ b/src/features/admin/components/settings/SettingsFields.tsx
@@ -8,10 +8,10 @@
  * Inputs are sized larger than the app default for the older admin audience.
  */
 
-import type React from "react";
-import { useState } from "react";
 import { cn } from "@/shared/lib/cn";
 import type { FieldMeta } from "@/shared/lib/settings/field-meta";
+import type React from "react";
+import { useState } from "react";
 
 interface FieldShellProps {
   id: string;

--- a/src/features/admin/components/settings/SettingsHistory.tsx
+++ b/src/features/admin/components/settings/SettingsHistory.tsx
@@ -9,11 +9,11 @@
  * a revert is just another tracked change.
  */
 
-import { useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
 import { formatDateTimeLong } from "@/shared/lib/date-format";
 import type { SettingsGroup } from "@/shared/lib/settings/types";
+import type React from "react";
+import { useState } from "react";
 
 /** One history row as returned by the history route. */
 interface HistoryEntry {

--- a/src/features/admin/components/settings/SettingsSearch.tsx
+++ b/src/features/admin/components/settings/SettingsSearch.tsx
@@ -8,11 +8,11 @@
  * shared field metadata, so search and the editors never drift apart.
  */
 
-import { useMemo, useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
 import { FIELD_META_BY_GROUP, GROUP_META } from "@/shared/lib/settings/field-meta";
 import type { SettingsGroup } from "@/shared/lib/settings/types";
+import type React from "react";
+import { useMemo, useState } from "react";
 
 /** One searchable field entry. */
 interface SearchItem {

--- a/src/features/admin/components/settings/SettingsView.tsx
+++ b/src/features/admin/components/settings/SettingsView.tsx
@@ -7,8 +7,16 @@
  * built show a placeholder noting they're still managed in code.
  */
 
-import { useEffect, useState } from "react";
-import type React from "react";
+import { AvailabilityTab } from "@/features/admin/components/settings/AvailabilityTab";
+import { CommsTab } from "@/features/admin/components/settings/CommsTab";
+import { HoldsTab } from "@/features/admin/components/settings/HoldsTab";
+import { IdentityTab } from "@/features/admin/components/settings/IdentityTab";
+import { PricingTab } from "@/features/admin/components/settings/PricingTab";
+import { ReviewsTab } from "@/features/admin/components/settings/ReviewsTab";
+import { SchedulingTab } from "@/features/admin/components/settings/SchedulingTab";
+import { SettingsSearch } from "@/features/admin/components/settings/SettingsSearch";
+import { TaxTab } from "@/features/admin/components/settings/TaxTab";
+import { SettingsAllContext } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { GROUP_META } from "@/shared/lib/settings/field-meta";
 import type {
@@ -23,16 +31,8 @@ import type {
   SettingsGroup,
   TaxSettings,
 } from "@/shared/lib/settings/types";
-import { PricingTab } from "@/features/admin/components/settings/PricingTab";
-import { AvailabilityTab } from "@/features/admin/components/settings/AvailabilityTab";
-import { CommsTab } from "@/features/admin/components/settings/CommsTab";
-import { ReviewsTab } from "@/features/admin/components/settings/ReviewsTab";
-import { HoldsTab } from "@/features/admin/components/settings/HoldsTab";
-import { IdentityTab } from "@/features/admin/components/settings/IdentityTab";
-import { TaxTab } from "@/features/admin/components/settings/TaxTab";
-import { SchedulingTab } from "@/features/admin/components/settings/SchedulingTab";
-import { SettingsSearch } from "@/features/admin/components/settings/SettingsSearch";
-import { SettingsAllContext } from "@/features/admin/components/settings/useSettingsForm";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 /** Tab order shown in the settings bar. */
 const TAB_ORDER: SettingsGroup[] = [

--- a/src/features/admin/components/settings/TaxTab.tsx
+++ b/src/features/admin/components/settings/TaxTab.tsx
@@ -8,13 +8,13 @@
  * a per-FY workbook rate, when present, still takes precedence over these.
  */
 
-import type React from "react";
+import { NumberField } from "@/features/admin/components/settings/SettingsFields";
+import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
 import { cn } from "@/shared/lib/cn";
 import { TAX_FIELD_META } from "@/shared/lib/settings/field-meta";
 import type { TaxSettings } from "@/shared/lib/settings/types";
-import { NumberField } from "@/features/admin/components/settings/SettingsFields";
-import { useSettingsForm } from "@/features/admin/components/settings/useSettingsForm";
-import { SettingsHistory } from "@/features/admin/components/settings/SettingsHistory";
+import type React from "react";
 
 interface Props {
   initial: TaxSettings;

--- a/src/features/admin/components/settings/useSettingsForm.ts
+++ b/src/features/admin/components/settings/useSettingsForm.ts
@@ -8,10 +8,10 @@
  * by every settings tab so the save/validation flow stays consistent.
  */
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import type React from "react";
 import type { Settings, SettingsGroup } from "@/shared/lib/settings/types";
 import { checkGuardrails, type FieldError } from "@/shared/lib/settings/validate";
+import type React from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 /**
  * Full resolved settings, provided by SettingsView so each tab's form can run

--- a/src/features/admin/lib/auto-maintain.ts
+++ b/src/features/admin/lib/auto-maintain.ts
@@ -5,9 +5,9 @@
  * Operations are idempotent and fast when there is nothing to do.
  */
 
-import type { PrismaClient } from "@prisma/client";
-import { toE164NZ, normalisePhone } from "@/shared/lib/normalise-phone";
 import type { ConflictEntry } from "@/app/api/admin/contacts/enrich-from-reviews/route";
+import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import type { PrismaClient } from "@prisma/client";
 
 /**
  * Runs all maintenance tasks in order:

--- a/src/features/admin/lib/schedule-types.tsx
+++ b/src/features/admin/lib/schedule-types.tsx
@@ -5,8 +5,8 @@
  * week grid and the mobile day-agenda view.
  */
 
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 export const NZ_TZ = "Pacific/Auckland";
 

--- a/src/features/booking/components/AddressAutocomplete.tsx
+++ b/src/features/booking/components/AddressAutocomplete.tsx
@@ -14,12 +14,12 @@
 
 "use client";
 
+import { cn } from "@/shared/lib/cn";
+import { loadPlacesLibrary } from "@/shared/lib/google-maps-loader";
+import useOnVisible from "@/shared/lib/useOnVisible";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { FaTriangleExclamation } from "react-icons/fa6";
-import useOnVisible from "@/shared/lib/useOnVisible";
-import { loadPlacesLibrary } from "@/shared/lib/google-maps-loader";
-import { cn } from "@/shared/lib/cn";
 
 /**
  * Props for AddressAutocomplete component.

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -6,26 +6,26 @@
 
 "use client";
 
-import type React from "react";
-import { useState, useEffect, useRef } from "react";
-import { FaCheck } from "react-icons/fa6";
-import { useRouter } from "next/navigation";
-import { Button } from "@/shared/components/Button";
-import { cn } from "@/shared/lib/cn";
+import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
 import {
-  SUB_SLOT_MINUTES,
   BOOKING_FIELD_LIMITS,
-  validateEmail,
   splitUnitFromAddress,
+  SUB_SLOT_MINUTES,
+  validateEmail,
   type BookableDay,
-  type TimeOfDay,
-  type StartMinute,
   type JobDuration,
+  type StartMinute,
+  type TimeOfDay,
 } from "@/features/booking/lib/booking";
-import { validatePhone } from "@/shared/lib/normalise-phone";
+import { Button } from "@/shared/components/Button";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
-import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
+import { cn } from "@/shared/lib/cn";
+import { validatePhone } from "@/shared/lib/normalise-phone";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import { FaCheck } from "react-icons/fa6";
 
 /** localStorage key for the new-booking draft. Bumped when the shape changes. */
 const DRAFT_KEY = "booking-draft-v2";

--- a/src/features/booking/components/admin/BookingAdminList.tsx
+++ b/src/features/booking/components/admin/BookingAdminList.tsx
@@ -5,11 +5,11 @@
  * @description Interactive admin component for viewing and editing bookings.
  */
 
-import { useState } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
+import { cn } from "@/shared/lib/cn";
 import { formatDateTimeShort } from "@/shared/lib/date-format";
+import type React from "react";
+import { useState } from "react";
 
 export interface AdminBookingRow {
   id: string;

--- a/src/features/booking/lib/availability-config.server.ts
+++ b/src/features/booking/lib/availability-config.server.ts
@@ -7,9 +7,9 @@
  * source - the operator's saved availability plus the structural timezone.
  */
 
-import "server-only";
-import { getSettings } from "@/shared/lib/settings/get-settings";
 import { BOOKING_CONFIG, type AvailabilityConfig } from "@/features/booking/lib/booking";
+import { getSettings } from "@/shared/lib/settings/get-settings";
+import "server-only";
 
 /** Resolved availability plus the master "accepting bookings" switch + message. */
 export interface ResolvedAvailability {

--- a/src/features/booking/lib/booking.ts
+++ b/src/features/booking/lib/booking.ts
@@ -4,8 +4,8 @@
  * @description Booking system with duration selection (1hr quick jobs vs 2hr standard jobs).
  */
 
-import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
 import type { AvailabilitySettings } from "@/shared/lib/settings/types";
+import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
 
 /**
  * Splits an NZ-style apartment-prefixed address ("12/160 Kepa Road Orakei")

--- a/src/features/business/components/AddToContactsModal.tsx
+++ b/src/features/business/components/AddToContactsModal.tsx
@@ -9,9 +9,9 @@
  * doesn't already exist in the DB.
  */
 
-import { useEffect, useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Props for AddToContactsModal.

--- a/src/features/business/components/BreakdownModal.tsx
+++ b/src/features/business/components/BreakdownModal.tsx
@@ -6,12 +6,12 @@
  * listing the entries that summed to it, or by showing the calculation steps.
  */
 
-import { useEffect } from "react";
-import type React from "react";
-import { FaCaretRight } from "react-icons/fa6";
-import Link from "next/link";
-import { cn } from "@/shared/lib/cn";
 import { formatNZD } from "@/features/business/lib/business";
+import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import type React from "react";
+import { useEffect } from "react";
+import { FaCaretRight } from "react-icons/fa6";
 
 /**
  * One contributing row in a breakdown that lists entries.

--- a/src/features/business/components/BusinessDashboardCards.tsx
+++ b/src/features/business/components/BusinessDashboardCards.tsx
@@ -12,16 +12,16 @@
  * month falls outside the FY window and would always show zero.
  */
 
-import { useState } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { formatNZD } from "@/features/business/lib/business";
-import { formatDateSlash } from "@/shared/lib/date-format";
 import {
   BreakdownModal,
   type BreakdownData,
   type BreakdownRow,
 } from "@/features/business/components/BreakdownModal";
+import { formatNZD } from "@/features/business/lib/business";
+import { cn } from "@/shared/lib/cn";
+import { formatDateSlash } from "@/shared/lib/date-format";
+import type React from "react";
+import { useState } from "react";
 
 /** Income entry payload passed in from the server component (already scope-filtered). */
 export interface IncomeRow {

--- a/src/features/business/components/CalculatorView.tsx
+++ b/src/features/business/components/CalculatorView.tsx
@@ -1,49 +1,49 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import type React from "react";
-import { useRouter } from "next/navigation";
-import { cn } from "@/shared/lib/cn";
+import { AddToContactsModal } from "@/features/business/components/AddToContactsModal";
+import { InvoicePreviewPanel } from "@/features/business/components/InvoicePreviewPanel";
+import { ParseConfidenceBanner } from "@/features/business/components/ParseConfidenceBanner";
+import { TaxonomyManageModal } from "@/features/business/components/TaxonomyManageModal";
+import { ClientPickerSection } from "@/features/business/components/calculator/ClientPickerSection";
+import { JobDetailsSection } from "@/features/business/components/calculator/JobDetailsSection";
+import { PartsSection } from "@/features/business/components/calculator/PartsSection";
+import { RateConfigPanel } from "@/features/business/components/calculator/RateConfigPanel";
+import { TasksSection } from "@/features/business/components/calculator/TasksSection";
+import { TravelSection } from "@/features/business/components/calculator/TravelSection";
 import {
-  calcJobTotal,
-  jobToLineItems,
   buildIncomeDescription,
-  matchRateById,
-  effectiveHourlyRate,
-  composeDescription,
+  calcJobTotal,
   collapseToWindow,
+  composeDescription,
+  effectiveHourlyRate,
   hourlyTaskMinutes,
+  jobToLineItems,
+  matchRateById,
   timeDiffMins,
   todayISO,
   type JobPricing,
 } from "@/features/business/lib/business";
 import { calcTravelCharge } from "@/features/business/lib/pricing-policy";
-import type { IdentitySettings } from "@/shared/lib/settings/types";
-import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
-import { AddToContactsModal } from "@/features/business/components/AddToContactsModal";
-import { ParseConfidenceBanner } from "@/features/business/components/ParseConfidenceBanner";
-import { TaxonomyManageModal } from "@/features/business/components/TaxonomyManageModal";
-import { InvoicePreviewPanel } from "@/features/business/components/InvoicePreviewPanel";
-import { PartsSection } from "@/features/business/components/calculator/PartsSection";
-import { TravelSection } from "@/features/business/components/calculator/TravelSection";
-import { ClientPickerSection } from "@/features/business/components/calculator/ClientPickerSection";
-import { TasksSection } from "@/features/business/components/calculator/TasksSection";
-import { RateConfigPanel } from "@/features/business/components/calculator/RateConfigPanel";
-import { JobDetailsSection } from "@/features/business/components/calculator/JobDetailsSection";
-import { loadPlacesLibrary } from "@/shared/lib/google-maps-loader";
 import { summariseForBanner, type ActivePromo } from "@/features/business/lib/promos";
 import type {
+  GoogleContact,
+  JobCalculation,
+  ParseJobQuestion,
+  ParseJobResponse,
+  ParsedRange,
+  PartLine,
   RateConfig,
   TaskLine,
-  PartLine,
-  JobCalculation,
-  ParseJobResponse,
-  ParseJobQuestion,
-  ParsedRange,
-  GoogleContact,
   TaskTemplate,
   TravelEntry,
 } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import { loadPlacesLibrary } from "@/shared/lib/google-maps-loader";
+import type { IdentitySettings } from "@/shared/lib/settings/types";
+import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Returns the YYYY-MM-DD string for today + n days.

--- a/src/features/business/components/Combobox.tsx
+++ b/src/features/business/components/Combobox.tsx
@@ -9,9 +9,9 @@
  * Action so the operator isn't restricted to a fixed enum.
  */
 
-import { useEffect, useId, useRef, useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 interface Props {
   /** Current value (controlled). */

--- a/src/features/business/components/ContactPickerModal.tsx
+++ b/src/features/business/components/ContactPickerModal.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
-import type React from "react";
-import { FaCaretUp, FaCaretDown } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
 import type { GoogleContact } from "@/features/business/types/business";
 import { filterContacts } from "@/features/contacts/lib/contact-search";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FaCaretDown, FaCaretUp } from "react-icons/fa6";
 
 interface ContactPickerModalProps {
   onSelect: (contact: GoogleContact) => void;

--- a/src/features/business/components/ExpensesView.tsx
+++ b/src/features/business/components/ExpensesView.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { formatNZD, todayISO, calcGstFromInclusive } from "@/features/business/lib/business";
+import { calcGstFromInclusive, formatNZD, todayISO } from "@/features/business/lib/business";
 import { EXPENSE_CATEGORIES, PAYMENT_METHODS } from "@/features/business/lib/constants";
 import type { ExpenseEntry } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Client component for recording and displaying expense entries.

--- a/src/features/business/components/IncomeView.tsx
+++ b/src/features/business/components/IncomeView.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { formatNZD, todayISO } from "@/features/business/lib/business";
 import { INCOME_METHODS } from "@/features/business/lib/constants";
 import type { IncomeEntry } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Client component for recording and displaying income entries.

--- a/src/features/business/components/InvoicePreviewPanel.tsx
+++ b/src/features/business/components/InvoicePreviewPanel.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { memo } from "react";
-import type React from "react";
-import Image from "next/image";
-import { cn } from "@/shared/lib/cn";
 import { calcInvoiceTotals, formatNZD } from "@/features/business/lib/business";
-import { formatDateShort } from "@/shared/lib/date-format";
 import type { LineItem } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
 import type { IdentitySettings } from "@/shared/lib/settings/types";
+import Image from "next/image";
+import type React from "react";
+import { memo } from "react";
 
 interface Props {
   /** Live business identity (name, contact, bank account, GST#, payment terms). */

--- a/src/features/business/components/InvoicesListView.tsx
+++ b/src/features/business/components/InvoicesListView.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import type React from "react";
-import { FaCaretRight } from "react-icons/fa6";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { cn } from "@/shared/lib/cn";
 import { formatNZD } from "@/features/business/lib/business";
 import type { Invoice, InvoiceStatus } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { FaCaretRight } from "react-icons/fa6";
 
 const STATUS_COLORS: Record<InvoiceStatus, string> = {
   DRAFT: "bg-slate-100 text-slate-600",

--- a/src/features/business/components/ParseConfidenceBanner.tsx
+++ b/src/features/business/components/ParseConfidenceBanner.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type React from "react";
-import { FaCheck, FaTriangleExclamation, FaXmark } from "react-icons/fa6";
-import type { IconType } from "react-icons";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import type { IconType } from "react-icons";
+import { FaCheck, FaTriangleExclamation, FaXmark } from "react-icons/fa6";
 
 interface ParseConfidenceBannerProps {
   confidence: "high" | "medium" | "low";

--- a/src/features/business/components/PricingWizard.tsx
+++ b/src/features/business/components/PricingWizard.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import type React from "react";
-import { useState, useEffect } from "react";
-import Link from "next/link";
-import type { PublicRate, PriceRange } from "@/features/business/types/pricing";
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
-import { cn } from "@/shared/lib/cn";
+import { calcTravelCharge } from "@/features/business/lib/pricing-policy";
 import {
   applyPromoToHourlyRate,
   summariseForBanner,
   type ActivePromo,
 } from "@/features/business/lib/promos";
-import { calcTravelCharge } from "@/features/business/lib/pricing-policy";
+import type { PriceRange, PublicRate } from "@/features/business/types/pricing";
+import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 const SOFT_CARD = cn(
   "border-seasalt-400/80 bg-seasalt-900/60 rounded-xl border p-3 text-base sm:p-4 sm:text-lg",

--- a/src/features/business/components/PromosView.tsx
+++ b/src/features/business/components/PromosView.tsx
@@ -5,12 +5,12 @@
  * @description Admin promo CRUD - form-on-top + table-below + overlap warning.
  */
 
-import { useState } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { formatNZD } from "@/features/business/lib/business";
-import { formatDateShort } from "@/shared/lib/date-format";
 import type { PromoRow } from "@/app/admin/promos/page";
+import { formatNZD } from "@/features/business/lib/business";
+import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
+import type React from "react";
+import { useState } from "react";
 
 type PromoType = "flat" | "percent";
 

--- a/src/features/business/components/SheetImportButton.tsx
+++ b/src/features/business/components/SheetImportButton.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useState } from "react";
 
 interface PerSheetCounts {
   fileId: string;

--- a/src/features/business/components/SubscriptionsView.tsx
+++ b/src/features/business/components/SubscriptionsView.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { formatNZD, todayISO } from "@/features/business/lib/business";
 import {
   EXPENSE_CATEGORIES,
@@ -10,6 +7,9 @@ import {
   VALID_FREQUENCIES,
 } from "@/features/business/lib/constants";
 import type { Subscription } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface FormState {
   description: string;

--- a/src/features/business/components/TaxPlannerSection.tsx
+++ b/src/features/business/components/TaxPlannerSection.tsx
@@ -1,12 +1,12 @@
 // src/features/business/components/TaxPlannerSection.tsx
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { formatNZD } from "@/features/business/lib/business";
 import {
   computeTaxPlan,
   DEFAULT_TAX_RATES,
   type TaxRates,
 } from "@/features/business/lib/tax-planner";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 interface Props {
   /** Display label for the FY being summarised, e.g. "FY 2026-27 (current)". */

--- a/src/features/business/components/TaxonomyManageModal.tsx
+++ b/src/features/business/components/TaxonomyManageModal.tsx
@@ -8,9 +8,9 @@
  * Future parse-job runs will retag them.
  */
 
-import { useEffect, useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 interface TaxonomyResponse {
   ok: boolean;

--- a/src/features/business/components/calculator/ClientPickerSection.tsx
+++ b/src/features/business/components/calculator/ClientPickerSection.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import type { GoogleContact } from "@/features/business/types/business";
 import { filterContacts } from "@/features/contacts/lib/contact-search";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useMemo, useRef, useState } from "react";
 
 type AddressMode = "name" | "company" | "custom";
 

--- a/src/features/business/components/calculator/JobDetailsSection.tsx
+++ b/src/features/business/components/calculator/JobDetailsSection.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import type React from "react";
-import { FaCaretRight } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
 import {
+  billableMins,
   formatNZD,
   minsToHoursLabel,
-  billableMins,
   timeDiffMins,
 } from "@/features/business/lib/business";
 import type { ParsedRange, RateConfig } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { FaCaretRight } from "react-icons/fa6";
 
 /** Inline warning shown under a slot whose Start/End look off. */
 interface SlotIssue {

--- a/src/features/business/components/calculator/PartsSection.tsx
+++ b/src/features/business/components/calculator/PartsSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import type { PartLine } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 interface Props {
   parts: PartLine[];

--- a/src/features/business/components/calculator/RateConfigPanel.tsx
+++ b/src/features/business/components/calculator/RateConfigPanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import type { RateConfig } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
 import type React from "react";
 import { FaCheck } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
-import type { RateConfig } from "@/features/business/types/business";
 
 type RateType = "flat" | "hourly" | "modifier" | "percent";
 

--- a/src/features/business/components/calculator/TasksSection.tsx
+++ b/src/features/business/components/calculator/TasksSection.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
-import { formatNZD, composeDescription } from "@/features/business/lib/business";
 import { Combobox } from "@/features/business/components/Combobox";
+import { composeDescription, formatNZD } from "@/features/business/lib/business";
 import type { RateConfig, TaskLine, TaskTemplate } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 interface Props {
   tasks: TaskLine[];

--- a/src/features/business/components/calculator/TravelSection.tsx
+++ b/src/features/business/components/calculator/TravelSection.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import type React from "react";
-import type { RefObject } from "react";
-import { cn } from "@/shared/lib/cn";
 import { formatNZD, travelEntriesTotal } from "@/features/business/lib/business";
 import { breakdownTravelCharge } from "@/features/business/lib/pricing-policy";
 import type { TravelEntry } from "@/features/business/types/business";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import type { RefObject } from "react";
 
 interface Props {
   addressInputRef: RefObject<HTMLInputElement | null>;

--- a/src/features/business/lib/business.ts
+++ b/src/features/business/lib/business.ts
@@ -1,3 +1,8 @@
+import {
+  BILLING_INCREMENT_MINS,
+  GST_RATE,
+  GST_REGISTERED,
+} from "@/features/business/lib/pricing-policy";
 import type {
   JobCalculation,
   LineItem,
@@ -5,11 +10,6 @@ import type {
   TaskLine,
   TravelEntry,
 } from "@/features/business/types/business";
-import {
-  BILLING_INCREMENT_MINS,
-  GST_REGISTERED,
-  GST_RATE,
-} from "@/features/business/lib/pricing-policy";
 import { formatDateSlash } from "@/shared/lib/date-format";
 
 /**

--- a/src/features/business/lib/cancellation-invoice.ts
+++ b/src/features/business/lib/cancellation-invoice.ts
@@ -7,20 +7,20 @@
  * log but never throw so the cancel action that triggered this stays clean.
  */
 
-import type { Booking } from "@prisma/client";
-import { prisma } from "@/shared/lib/prisma";
-import { calcTravelCharge } from "@/features/business/lib/pricing-policy";
-import { getPolicy } from "@/features/business/lib/pricing-policy.server";
 import { calcInvoiceTotals } from "@/features/business/lib/business";
 import {
   getNextInvoiceNumber,
   writeBackInvoiceCounter,
 } from "@/features/business/lib/invoice-numbering";
+import { calcTravelCharge } from "@/features/business/lib/pricing-policy";
+import { getPolicy } from "@/features/business/lib/pricing-policy.server";
 import { lookupDriveDistance } from "@/features/business/lib/travel-distance";
+import type { LineItem } from "@/features/business/types/business";
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
 import { getIdentity } from "@/shared/lib/business-identity.server";
 import { formatDateShort } from "@/shared/lib/date-format";
-import type { LineItem } from "@/features/business/types/business";
+import { prisma } from "@/shared/lib/prisma";
+import type { Booking } from "@prisma/client";
 
 export interface DraftCancellationInvoiceOptions {
   /** True when the cancel lands inside CANCELLATION.travelChargeHours and round-trip travel should be billed. */

--- a/src/features/business/lib/contact-review-token.ts
+++ b/src/features/business/lib/contact-review-token.ts
@@ -4,9 +4,9 @@
  * @description Lazy generator for the per-contact review token used in invoice emails.
  */
 
-import { randomUUID } from "crypto";
 import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
+import { randomUUID } from "crypto";
 
 /**
  * Returns the contact's stable review token, creating + persisting one on first call.

--- a/src/features/business/lib/google-drive.ts
+++ b/src/features/business/lib/google-drive.ts
@@ -1,5 +1,5 @@
-import { google } from "googleapis";
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
+import { google } from "googleapis";
 import { Readable } from "stream";
 
 /** Module-level cache to avoid repeat folder lookups per deploy. */

--- a/src/features/business/lib/google-sheets.ts
+++ b/src/features/business/lib/google-sheets.ts
@@ -1,5 +1,5 @@
-import { google } from "googleapis";
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
+import { google } from "googleapis";
 
 export interface InvoiceCounterData {
   prefix: string;

--- a/src/features/business/lib/invoice-numbering.ts
+++ b/src/features/business/lib/invoice-numbering.ts
@@ -8,9 +8,9 @@
  * Prisma is the fallback when it's not.
  */
 
-import { prisma } from "@/shared/lib/prisma";
 import { nextInvoiceNumber } from "@/features/business/lib/business";
 import { getInvoiceCounter, setInvoiceCounter } from "@/features/business/lib/google-sheets";
+import { prisma } from "@/shared/lib/prisma";
 
 export interface NextInvoiceNumber {
   /** Formatted number ready to drop on the new invoice (e.g. TTP-2627-0042). */

--- a/src/features/business/lib/invoice-pdf.ts
+++ b/src/features/business/lib/invoice-pdf.ts
@@ -1,10 +1,10 @@
-import { PDFDocument, PDFFont, PDFPage, rgb, StandardFonts, degrees } from "pdf-lib";
-import path from "path";
-import { readFileSync } from "fs";
 import type { Invoice } from "@/features/business/types/business";
 import { getIdentity } from "@/shared/lib/business-identity.server";
-import type { IdentitySettings } from "@/shared/lib/settings/types";
 import { formatDateShort } from "@/shared/lib/date-format";
+import type { IdentitySettings } from "@/shared/lib/settings/types";
+import { readFileSync } from "fs";
+import path from "path";
+import { degrees, PDFDocument, PDFFont, PDFPage, rgb, StandardFonts } from "pdf-lib";
 
 // Colours mirror the web's Tailwind palette so the PDF reads as the same document.
 const BRAND = rgb(12 / 255, 10 / 255, 62 / 255); // russian-violet #0c0a3e

--- a/src/features/business/lib/pricing-policy.server.ts
+++ b/src/features/business/lib/pricing-policy.server.ts
@@ -6,18 +6,18 @@
  * without dragging Prisma into the browser bundle.
  */
 
-import "server-only";
-import Holidays from "date-holidays";
-import { prisma } from "@/shared/lib/prisma";
 import {
   GST_RATE,
-  PUBLIC_HOLIDAY_UPLIFT,
-  NZ_REGION,
   HOME_REGION,
+  NZ_REGION,
   nzDateKey,
+  PUBLIC_HOLIDAY_UPLIFT,
   type Policy,
 } from "@/features/business/lib/pricing-policy";
+import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
+import Holidays from "date-holidays";
+import "server-only";
 
 /**
  * Live policy bundle, resolved from the settings panel (defaults + DB override).

--- a/src/features/business/lib/promos.ts
+++ b/src/features/business/lib/promos.ts
@@ -4,8 +4,8 @@
  * @description Active-promo lookup + helpers. Cached 60s; admin writes revalidate.
  */
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/shared/lib/prisma";
+import { unstable_cache } from "next/cache";
 
 /** Cache tag invalidated by the promo CRUD routes. */
 export const ACTIVE_PROMO_TAG = "active-promo";

--- a/src/features/business/lib/sheets-import.ts
+++ b/src/features/business/lib/sheets-import.ts
@@ -1,7 +1,7 @@
-import { prisma } from "@/shared/lib/prisma";
-import { getSheetsClient, getSheetId } from "@/features/business/lib/google-sheets";
-import { listSpreadsheetsInFolder } from "@/features/business/lib/google-drive";
 import { calcGstFromInclusive } from "@/features/business/lib/business";
+import { listSpreadsheetsInFolder } from "@/features/business/lib/google-drive";
+import { getSheetId, getSheetsClient } from "@/features/business/lib/google-sheets";
+import { prisma } from "@/shared/lib/prisma";
 
 /**
  * Parses a raw date string in DD/MM/YYYY, YYYY-MM-DD, or JS Date format.

--- a/src/features/business/lib/sheets-sync.ts
+++ b/src/features/business/lib/sheets-sync.ts
@@ -5,11 +5,11 @@
  * carries a UUID so edits/deletes can find rows. Failures are non-fatal.
  */
 
-import { randomUUID } from "crypto";
-import { getSheetsClient } from "@/features/business/lib/google-sheets";
-import { getDriveClient } from "@/features/business/lib/google-drive";
-import { formatDateSlash } from "@/shared/lib/date-format";
 import { getFinancialYear } from "@/features/business/lib/financial-year";
+import { getDriveClient } from "@/features/business/lib/google-drive";
+import { getSheetsClient } from "@/features/business/lib/google-sheets";
+import { formatDateSlash } from "@/shared/lib/date-format";
+import { randomUUID } from "crypto";
 
 /** Cache: FY key (e.g. "2025-26") > spreadsheet file ID. */
 const fySheetCache = new Map<string, string>();

--- a/src/features/business/lib/tax-cache.ts
+++ b/src/features/business/lib/tax-cache.ts
@@ -4,8 +4,8 @@
  * @description Per-scope cache of tax-planner inputs in the Setting table.
  */
 
-import { prisma } from "@/shared/lib/prisma";
 import type { TaxRates } from "@/features/business/lib/tax-planner";
+import { prisma } from "@/shared/lib/prisma";
 
 /** How long a cached snapshot is fresh (1h trades staleness for fewer API calls). */
 export const TAX_CACHE_TTL_MS = 60 * 60 * 1000;

--- a/src/features/calendar/lib/calendar-cache.ts
+++ b/src/features/calendar/lib/calendar-cache.ts
@@ -4,13 +4,13 @@
  * @description Background task to fetch and cache Google Calendar events.
  */
 
-import { prisma } from "@/shared/lib/prisma";
 import {
   fetchAllCalendarEvents,
   getBookingCalendarId,
   type CalendarEvent,
 } from "@/features/calendar/lib/google-calendar";
 import { calculateTravelMinutes, type TransportMode } from "@/features/calendar/lib/travel-time";
+import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
 
 interface RefreshResult {

--- a/src/features/contacts/lib/contact-conflicts.ts
+++ b/src/features/contacts/lib/contact-conflicts.ts
@@ -8,7 +8,7 @@
  */
 
 import { prisma } from "@/shared/lib/prisma";
-import type { ContactField, ConflictResolution } from "@prisma/client";
+import type { ConflictResolution, ContactField } from "@prisma/client";
 
 // Re-export the Prisma enum types under the names the rest of the codebase
 // uses. The admin-driven resolution endpoint also accepts "auto" via the

--- a/src/features/contacts/lib/find-or-create.ts
+++ b/src/features/contacts/lib/find-or-create.ts
@@ -10,8 +10,8 @@
  * create pattern below is the canonical replacement.
  */
 
-import type { Contact } from "@prisma/client";
 import { prisma } from "@/shared/lib/prisma";
+import type { Contact } from "@prisma/client";
 
 /**
  * Fields used when creating a Contact. Caller is responsible for any

--- a/src/features/contacts/lib/google-contacts.ts
+++ b/src/features/contacts/lib/google-contacts.ts
@@ -8,11 +8,11 @@
  * (lastSyncedAt null) lets Google win for any field it has populated.
  */
 
-import { google } from "googleapis";
-import { prisma } from "@/shared/lib/prisma";
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
 import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
-import { recordContactConflict, clearContactConflict } from "./contact-conflicts";
+import { prisma } from "@/shared/lib/prisma";
+import { google } from "googleapis";
+import { clearContactConflict, recordContactConflict } from "./contact-conflicts";
 
 /**
  * Returns an authenticated Google People API client.

--- a/src/features/reviews/components/ReviewForm.tsx
+++ b/src/features/reviews/components/ReviewForm.tsx
@@ -6,14 +6,14 @@
 
 "use client";
 
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/components/Button";
-import { useId, useState } from "react";
-import { useRouter } from "next/navigation";
-import { formatNZPhone, normalisePhone, validatePhone } from "@/shared/lib/normalise-phone";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
+import { cn } from "@/shared/lib/cn";
+import { formatNZPhone, normalisePhone, validatePhone } from "@/shared/lib/normalise-phone";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useId, useState } from "react";
 
 type NameDisplay = "name" | "anonymous";
 

--- a/src/features/reviews/components/admin/CopyLinkButton.tsx
+++ b/src/features/reviews/components/admin/CopyLinkButton.tsx
@@ -5,9 +5,9 @@
  * @description Button that copies a review link to the clipboard.
  */
 
-import { useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useState } from "react";
 
 /**
  * Props for CopyLinkButton component.

--- a/src/features/reviews/components/admin/ReviewApprovalList.tsx
+++ b/src/features/reviews/components/admin/ReviewApprovalList.tsx
@@ -5,9 +5,9 @@
  * @description Interactive client component for approving, revoking, and deleting reviews.
  */
 
-import { useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useState } from "react";
 import type { ReviewRow } from "./review-types";
 import { ReviewCard } from "./ReviewCard";
 import { SendReviewLinkForm } from "./SendReviewLinkForm";

--- a/src/features/reviews/components/admin/ReviewCard.tsx
+++ b/src/features/reviews/components/admin/ReviewCard.tsx
@@ -5,13 +5,13 @@
  * @description Single review card with approve/revoke/delete actions.
  */
 
-import { useState, useRef, useEffect } from "react";
+import { formatReviewerName } from "@/features/reviews/lib/formatting";
 import { SOFT_CARD } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
-import { type ReviewRow } from "./review-types";
 import { formatDateShort } from "@/shared/lib/date-format";
-import { formatReviewerName } from "@/features/reviews/lib/formatting";
 import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import { type ReviewRow } from "./review-types";
 
 /**
  * Props for ReviewCard component.

--- a/src/features/reviews/components/admin/ReviewLinkHistoryTable.tsx
+++ b/src/features/reviews/components/admin/ReviewLinkHistoryTable.tsx
@@ -5,13 +5,13 @@
  * @description Table of review link history with inline editing for ReviewRequest entries.
  */
 
-import { useState } from "react";
-import type React from "react";
-import { FaCheck } from "react-icons/fa6";
 import { cn } from "@/shared/lib/cn";
-import { CopyLinkButton } from "./CopyLinkButton";
-import { toE164NZ, formatNZPhone, isValidPhone } from "@/shared/lib/normalise-phone";
 import { formatDateShort } from "@/shared/lib/date-format";
+import { formatNZPhone, isValidPhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import type React from "react";
+import { useState } from "react";
+import { FaCheck } from "react-icons/fa6";
+import { CopyLinkButton } from "./CopyLinkButton";
 
 /**
  * A single row in the review link history table.

--- a/src/features/reviews/components/admin/SendReviewLinkForm.tsx
+++ b/src/features/reviews/components/admin/SendReviewLinkForm.tsx
@@ -5,14 +5,14 @@
  * @description Form for sending a review link to a past client via email or SMS.
  */
 
-import { useState, useRef } from "react";
-import { cn } from "@/shared/lib/cn";
-import { CopyLinkButton } from "./CopyLinkButton";
-import { formatNZPhone, validatePhone } from "@/shared/lib/normalise-phone";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
+import { cn } from "@/shared/lib/cn";
+import { formatNZPhone, validatePhone } from "@/shared/lib/normalise-phone";
 import type React from "react";
+import { useRef, useState } from "react";
 import { FaCaretLeft } from "react-icons/fa6";
+import { CopyLinkButton } from "./CopyLinkButton";
 
 /**
  * A contact entry used to pre-fill the review link form.

--- a/src/features/reviews/lib/email.ts
+++ b/src/features/reviews/lib/email.ts
@@ -4,16 +4,16 @@
  * @description Shared Resend utility for sending transactional emails.
  */
 
-import { Resend } from "resend";
-import { getIdentity } from "@/shared/lib/business-identity.server";
-import { formatDateTimeLong, formatDateShort } from "@/shared/lib/date-format";
-import { getSiteUrl } from "@/shared/lib/site-url";
 import { formatNZD } from "@/features/business/lib/business";
 import {
   DEFAULT_INVOICE_EMAIL_BODY,
   DEFAULT_VOID_EMAIL_BODY,
 } from "@/features/business/lib/invoice-email-defaults";
 import { cancellationCopy } from "@/features/business/lib/pricing-policy";
+import { getIdentity } from "@/shared/lib/business-identity.server";
+import { formatDateShort, formatDateTimeLong } from "@/shared/lib/date-format";
+import { getSiteUrl } from "@/shared/lib/site-url";
+import { Resend } from "resend";
 
 /**
  * Escapes HTML so user-supplied values can be interpolated into email bodies.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,8 +8,8 @@
  * belt-and-braces.
  */
 
-import { NextRequest, NextResponse } from "next/server";
 import { ADMIN_SESSION_COOKIE, verifySessionCookieValue } from "@/shared/lib/admin-session";
+import { NextRequest, NextResponse } from "next/server";
 
 const PROTECTED_API_PREFIXES = ["/api/admin/", "/api/business/"];
 const PROTECTED_PAGE_PREFIX = "/admin";

--- a/src/shared/components/BreadcrumbJsonLd.tsx
+++ b/src/shared/components/BreadcrumbJsonLd.tsx
@@ -6,8 +6,8 @@
  *   instead of just the bare URL.
  */
 
-import type React from "react";
 import { getSiteUrl } from "@/shared/lib/site-url";
+import type React from "react";
 
 const siteUrl = getSiteUrl();
 

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -6,9 +6,9 @@
 
 "use client";
 
-import type React from "react";
-import Link from "next/link";
 import { cn } from "@/shared/lib/cn";
+import Link from "next/link";
+import type React from "react";
 
 export type ButtonVariant = "primary" | "secondary" | "tertiary" | "ghost";
 export type ButtonSize = "sm" | "md" | "lg";

--- a/src/shared/components/EmailInput.tsx
+++ b/src/shared/components/EmailInput.tsx
@@ -7,11 +7,11 @@
  * validation behaviour stays identical even when wording differs.
  */
 
-import { useState } from "react";
-import type React from "react";
-import { cn } from "@/shared/lib/cn";
 import { validateEmail } from "@/features/booking/lib/booking";
+import { cn } from "@/shared/lib/cn";
 import { suggestEmailCorrection } from "@/shared/lib/email-typo-suggestion";
+import type React from "react";
+import { useState } from "react";
 
 interface EmailInputProps {
   id: string;

--- a/src/shared/components/GoogleTag.tsx
+++ b/src/shared/components/GoogleTag.tsx
@@ -6,8 +6,8 @@
  */
 
 import Script from "next/script";
-import { useEffect } from "react";
 import type React from "react";
+import { useEffect } from "react";
 
 const GA4_ID = process.env.NEXT_PUBLIC_GA4_ID;
 const ADS_ID = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;

--- a/src/shared/components/NavBar.tsx
+++ b/src/shared/components/NavBar.tsx
@@ -6,13 +6,13 @@
 
 "use client";
 
-import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/shared/components/Button";
+import { cn } from "@/shared/lib/cn";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Button } from "@/shared/components/Button";
-import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface NavItem {
   label: string;

--- a/src/shared/components/PageLayout.tsx
+++ b/src/shared/components/PageLayout.tsx
@@ -4,8 +4,8 @@
  * @description Reusable layout components with frosted glass effect.
  */
 
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 export const CARD = cn(
   "border-seasalt-400/80 bg-seasalt-800 rounded-xl border p-5 shadow-sm sm:p-6",

--- a/src/shared/components/PhoneInput.tsx
+++ b/src/shared/components/PhoneInput.tsx
@@ -7,10 +7,10 @@
  * identically. Per-form wording can be customised via errorMessages.
  */
 
-import { useState } from "react";
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
 import { formatNZPhone, validatePhone } from "@/shared/lib/normalise-phone";
+import type React from "react";
+import { useState } from "react";
 
 interface PhoneInputProps {
   id: string;

--- a/src/shared/components/PromoBanner.tsx
+++ b/src/shared/components/PromoBanner.tsx
@@ -4,9 +4,9 @@
  * @description Server wrapper - fetches the active promo, hands it to the client banner.
  */
 
-import type React from "react";
 import { getActivePromo } from "@/features/business/lib/promos";
 import { PromoBannerClient } from "@/shared/components/PromoBannerClient";
+import type React from "react";
 
 /**
  * Renders the client banner for the active promo, or null when none.

--- a/src/shared/components/PromoBannerClient.tsx
+++ b/src/shared/components/PromoBannerClient.tsx
@@ -5,13 +5,13 @@
  * @description Banner with 24h dismissal, first-load delay, and navbar offset coordination.
  */
 
-import { useEffect, useRef, useState } from "react";
-import type React from "react";
+import { summariseForBanner, type ActivePromo } from "@/features/business/lib/promos";
+import { cn } from "@/shared/lib/cn";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
 import { FaBolt, FaXmark } from "react-icons/fa6";
-import { cn } from "@/shared/lib/cn";
-import { summariseForBanner, type ActivePromo } from "@/features/business/lib/promos";
 
 const PROMO_DISMISSED_KEY = "promo-banner-dismissed-at";
 const PROMO_SEEN_KEY = "promo-banner-seen-at";

--- a/src/shared/components/Skeleton.tsx
+++ b/src/shared/components/Skeleton.tsx
@@ -6,8 +6,8 @@
  * language instead of a blank frame.
  */
 
-import type React from "react";
 import { cn } from "@/shared/lib/cn";
+import type React from "react";
 
 /** Props for Bone. */
 interface BoneProps {

--- a/src/shared/lib/auth.ts
+++ b/src/shared/lib/auth.ts
@@ -6,12 +6,12 @@
  * scripts + cron still pass the header so curl / cron-job.org keep working.
  */
 
-import { timingSafeEqual } from "crypto";
-import { cookies } from "next/headers";
-import { NextRequest } from "next/server";
-import { redirect } from "next/navigation";
 import { ADMIN_SESSION_COOKIE, verifySessionCookieValue } from "@/shared/lib/admin-session";
 import { getClientIp } from "@/shared/lib/rate-limit";
+import { timingSafeEqual } from "crypto";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { NextRequest } from "next/server";
 
 /**
  * Validates a token against ADMIN_SECRET using constant-time comparison.

--- a/src/shared/lib/business-identity.server.ts
+++ b/src/shared/lib/business-identity.server.ts
@@ -9,9 +9,9 @@
  * is behaviour-preserving until the operator saves an override.
  */
 
-import "server-only";
 import { getSettings } from "@/shared/lib/settings/get-settings";
 import type { IdentitySettings } from "@/shared/lib/settings/types";
+import "server-only";
 
 /**
  * Resolves the live business identity.

--- a/src/shared/lib/settings/get-settings.ts
+++ b/src/shared/lib/settings/get-settings.ts
@@ -9,10 +9,10 @@
  * go live immediately. The 60s revalidate is only a cross-instance safety net.
  */
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/shared/lib/prisma";
 import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
 import type { Settings, SettingsGroup } from "@/shared/lib/settings/types";
+import { unstable_cache } from "next/cache";
 
 /** Cache tag invalidated by `saveSettingsGroup` on every write. */
 export const SETTINGS_TAG = "settings";

--- a/src/shared/lib/settings/set-settings.ts
+++ b/src/shared/lib/settings/set-settings.ts
@@ -7,10 +7,10 @@
  * immediately. Callers (the admin API route) validate the payload first.
  */
 
-import { revalidateTag } from "next/cache";
 import { prisma } from "@/shared/lib/prisma";
 import { SETTINGS_KEY_PREFIX, SETTINGS_TAG } from "@/shared/lib/settings/get-settings";
 import type { Settings, SettingsGroup } from "@/shared/lib/settings/types";
+import { revalidateTag } from "next/cache";
 
 /**
  * Persists one group's settings, records the change in the audit log, and


### PR DESCRIPTION
@
## What this does

Wires up two Prettier plugins that were already (or now) installed but not active, and applies their formatting across the repo. No runtime or logic changes - this is purely tooling and mechanical formatting.

## Changes

- **organize-imports.** Registers `prettier-plugin-organize-imports` so Prettier sorts imports, drops unused ones, and merges duplicates on every format (and via the lint-staged pre-commit hook). Side-effect imports (e.g. CSS) are preserved.
- **packagejson.** Adds `prettier-plugin-packagejson` to normalise `package.json` field order and alphabetise dependencies.
- **Plugin order.** `organize-imports` then `packagejson` then `tailwindcss`; the Tailwind plugin stays last as it requires being the final plugin in the chain.
- **package.json tidy.** Removes the non-standard `browserslistNote` key (the packagejson plugin orphaned it to the bottom, away from `browserslist`).

## Repo-wide churn

- The first run of organize-imports reordered/deduped imports across ~245 source files. These are import-statement-only edits with no behaviour change, kept as a single dedicated commit so they stay out of feature history.

## Verification

- Pre-commit lint-staged (Prettier + ESLint, max-warnings 0) passed on all staged chunks.
- Pre-push build + smoke test passed green.

## Notes

- Version bumped to 1.100.3.
@