### PR TITLE
feat(booking): show the quote in admin + inline rough estimate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.107.0",
+      "version": "1.108.0",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -41,6 +41,8 @@ export default async function AdminBookingsPage(): Promise<React.ReactElement> {
       status: true,
       cancelToken: true,
       reviewSentAt: true,
+      quotedLowAtBooking: true,
+      quotedHighAtBooking: true,
     },
   });
 
@@ -56,6 +58,8 @@ export default async function AdminBookingsPage(): Promise<React.ReactElement> {
     status: b.status as AdminBookingRow["status"],
     cancelToken: b.cancelToken,
     reviewSentAt: b.reviewSentAt?.toISOString() ?? null,
+    quotedLow: b.quotedLowAtBooking ?? null,
+    quotedHigh: b.quotedHighAtBooking ?? null,
   }));
 
   const confirmedCount = allBookings.filter((b) => b.status === "confirmed").length;

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -20,6 +20,7 @@ import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
 import { CARD, FrostedSection, PageShell, SOFT_CARD } from "@/shared/components/PageLayout";
 import { cn } from "@/shared/lib/cn";
 import { prisma } from "@/shared/lib/prisma";
+import { getSettings } from "@/shared/lib/settings/get-settings";
 import type { Metadata } from "next";
 import type React from "react";
 import { Suspense } from "react";
@@ -206,6 +207,8 @@ const SKELETON_BLOCK = cn("bg-seasalt-900/40 rounded-lg");
 async function BookingFormIsland(): Promise<React.ReactElement> {
   const { days, degraded, sameDayClosed, acceptingBookings, closedMessage, durations } =
     await getAvailableDays();
+  // Pricing context for the inline "get a rough estimate" affordance.
+  const settings = await getSettings();
   if (!acceptingBookings) {
     return (
       <div
@@ -250,7 +253,13 @@ async function BookingFormIsland(): Promise<React.ReactElement> {
           </p>
         </div>
       )}
-      <BookingForm availableDays={days} durations={durations} />
+      <BookingForm
+        availableDays={days}
+        durations={durations}
+        estimatorRange={settings.estimator.range}
+        minBillableMins={settings.pricing.minBillableMins}
+        minTravelCharge={settings.pricing.minTravelCharge}
+      />
     </div>
   );
 }

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -17,11 +17,13 @@ import {
   type StartMinute,
   type TimeOfDay,
 } from "@/features/booking/lib/booking";
+import { fetchQuickEstimate } from "@/features/business/lib/quick-estimate";
 import { Button } from "@/shared/components/Button";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
 import { cn } from "@/shared/lib/cn";
 import { validatePhone } from "@/shared/lib/normalise-phone";
+import type { EstimatorRange } from "@/shared/lib/settings/types";
 import { useRouter, useSearchParams } from "next/navigation";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
@@ -92,6 +94,12 @@ export interface BookingFormProps {
   durations: { short: number; long: number };
   cancelToken?: string;
   initialValues?: BookingFormInitialValues;
+  /** Live estimator range widths - enables the inline "get a rough estimate" (new bookings only). */
+  estimatorRange?: EstimatorRange;
+  /** Min billable minutes (live setting) for the inline estimate. */
+  minBillableMins?: number;
+  /** Travel floor (live setting) for the inline estimate. */
+  minTravelCharge?: number;
 }
 
 /**
@@ -101,6 +109,9 @@ export interface BookingFormProps {
  * @param props.durations - Live job durations (minutes) for the picker labels.
  * @param props.cancelToken - Cancel token for edit mode; omit for new bookings
  * @param props.initialValues - Pre-filled values for edit mode
+ * @param props.estimatorRange - Live estimator range widths; enables the inline rough estimate.
+ * @param props.minBillableMins - Min billable minutes for the inline estimate.
+ * @param props.minTravelCharge - Travel floor for the inline estimate.
  * @returns Booking form element
  */
 export default function BookingForm({
@@ -108,14 +119,25 @@ export default function BookingForm({
   durations,
   cancelToken,
   initialValues,
+  estimatorRange,
+  minBillableMins,
+  minTravelCharge,
 }: BookingFormProps): React.ReactElement {
   const router = useRouter();
   const isEditMode = Boolean(cancelToken);
-  // Carried from the /pricing wizard's "Book now" link (?estimate=<id>); lets
-  // the booking snapshot which public quote the customer saw. 24-hex only.
+  // Estimate id sent with the booking so it can snapshot which public quote the
+  // customer saw - seeded from the /pricing wizard's "Book now" link
+  // (?estimate=<id>, 24-hex) and replaced if they run the inline estimate below.
   const estimateParam = useSearchParams().get("estimate");
-  const estimateId =
-    estimateParam && /^[a-f0-9]{24}$/i.test(estimateParam) ? estimateParam : undefined;
+  const [estimateId, setEstimateId] = useState<string | undefined>(
+    estimateParam && /^[a-f0-9]{24}$/i.test(estimateParam) ? estimateParam : undefined,
+  );
+  // Inline "get a rough estimate" state (new bookings only).
+  const [estimating, setEstimating] = useState(false);
+  const [quote, setQuote] = useState<{ low: number; high: number } | null>(null);
+  const [quoteError, setQuoteError] = useState<string | null>(null);
+  const canInlineEstimate =
+    !isEditMode && estimatorRange != null && minBillableMins != null && minTravelCharge != null;
 
   // Duration choices built from the live settings; labels reflect the operator's
   // configured short/long lengths. Descriptions stay as fixed copy.
@@ -180,6 +202,34 @@ export default function BookingForm({
   // to fake a success response without creating a booking.
   const [website, setWebsite] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  /**
+   * Runs the inline rough estimate from the current description + meeting +
+   * address, shows the range, and captures the logged estimate id so the
+   * booking snapshots the quote the customer saw.
+   * @returns Resolves when the estimate completes.
+   */
+  async function runInlineEstimate(): Promise<void> {
+    if (!estimatorRange || minBillableMins == null || minTravelCharge == null) return;
+    setEstimating(true);
+    setQuoteError(null);
+    try {
+      const res = await fetchQuickEstimate({
+        description: notes.trim(),
+        meeting: meetingType === "remote" ? "remote" : "in-person",
+        address: meetingType === "remote" ? undefined : combineUnitAndAddress(unit, address),
+        estimatorRange,
+        minBillableMins,
+        minTravelCharge,
+      });
+      setQuote({ low: res.low, high: res.high });
+      if (res.estimateId) setEstimateId(res.estimateId);
+    } catch {
+      setQuoteError("Couldn't get an estimate just now - you can still book.");
+    } finally {
+      setEstimating(false);
+    }
+  }
   const [error, setError] = useState<string | null>(null);
   // Submit-time validation errors. Rendered both in a top summary and inline.
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -1242,6 +1292,31 @@ export default function BookingForm({
             </p>
           )}
         </div>
+
+        {canInlineEstimate && (
+          <div className={cn("flex flex-col gap-2")}>
+            <button
+              type="button"
+              onClick={() => void runInlineEstimate()}
+              disabled={estimating || notes.trim().length < BOOKING_FIELD_LIMITS.notesMin}
+              className={cn(
+                "border-russian-violet/40 text-russian-violet hover:bg-russian-violet/5 self-start rounded-md border px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50",
+              )}
+            >
+              {estimating ? "Estimating..." : "Get a rough estimate"}
+            </button>
+            {quote && (
+              <p className={cn("text-rich-black text-sm")}>
+                Rough estimate:{" "}
+                <strong>
+                  ${quote.low} &ndash; ${quote.high}
+                </strong>
+                . A ballpark from your description - the final cost is confirmed before any work.
+              </p>
+            )}
+            {quoteError && <p className={cn("text-coquelicot-600 text-sm")}>{quoteError}</p>}
+          </div>
+        )}
       </fieldset>
 
       {/* Booking summary - live recap of what's selected so the user can see

--- a/src/features/booking/components/admin/BookingAdminList.tsx
+++ b/src/features/booking/components/admin/BookingAdminList.tsx
@@ -23,6 +23,9 @@ export interface AdminBookingRow {
   status: "held" | "confirmed" | "cancelled" | "completed";
   cancelToken: string;
   reviewSentAt: string | null;
+  /** Public quote the customer saw before booking (snapshot); null when they didn't get one. */
+  quotedLow: number | null;
+  quotedHigh: number | null;
 }
 
 type StatusFilter = "all" | "held" | "confirmed" | "cancelled" | "completed";
@@ -320,6 +323,12 @@ export function BookingAdminList({
                   <span className={cn("text-xs text-slate-500")}>
                     {formatDateTimeShort(b.startAt)} &ndash; {formatDateTimeShort(b.endAt)}
                   </span>
+                  {b.quotedLow != null && b.quotedHigh != null && (
+                    <span className={cn("text-xs text-slate-500")}>
+                      <span className={cn("text-slate-400")}>Quoted: </span>${b.quotedLow} &ndash; $
+                      {b.quotedHigh}
+                    </span>
+                  )}
                 </div>
 
                 <div className={cn("flex flex-wrap gap-2 sm:shrink-0")}>

--- a/src/features/business/lib/quick-estimate.ts
+++ b/src/features/business/lib/quick-estimate.ts
@@ -1,0 +1,146 @@
+// src/features/business/lib/quick-estimate.ts
+/**
+ * @file quick-estimate.ts
+ * @description Client-safe one-shot price estimate used by the booking form's
+ * inline "get a rough estimate" affordance (for customers who skipped the
+ * /pricing wizard). Orchestrates the same public endpoints the wizard uses and
+ * reuses {@link priceRangeFor} so the two stay in sync, then logs the estimate
+ * to capture an id the booking can snapshot.
+ */
+
+import { priceRangeFor } from "@/features/business/lib/estimate-range";
+import { calcTravelCharge } from "@/features/business/lib/pricing-policy";
+import { applyPromoToHourlyRate, type ActivePromo } from "@/features/business/lib/promos";
+import type { PublicRate } from "@/features/business/types/pricing";
+import type { EstimateConfidence, EstimatorRange } from "@/shared/lib/settings/types";
+
+/** Inputs for a one-shot estimate from the booking form. */
+export interface QuickEstimateInput {
+  description: string;
+  meeting: "in-person" | "remote";
+  address?: string;
+  estimatorRange: EstimatorRange;
+  minBillableMins: number;
+  minTravelCharge: number;
+}
+
+/** Result of a one-shot estimate. `estimateId` is null when logging failed. */
+export interface QuickEstimateResult {
+  low: number;
+  high: number;
+  estimateId: string | null;
+  confidence: EstimateConfidence;
+  explanation: string;
+}
+
+/**
+ * Runs the full public-estimate flow (rates + promo + AI duration + travel),
+ * computes the confidence-scaled range, logs it, and returns the range + log id.
+ * @param input - Description, meeting mode, address, and live pricing settings.
+ * @returns The price range, the logged estimate id, and the AI confidence/explanation.
+ */
+export async function fetchQuickEstimate(input: QuickEstimateInput): Promise<QuickEstimateResult> {
+  const { description, meeting, address, estimatorRange, minBillableMins, minTravelCharge } = input;
+  const dest =
+    meeting === "remote"
+      ? ""
+      : (address ?? "")
+          .trim()
+          .replace(/,?\s*New Zealand$/i, "")
+          .trim();
+
+  const [ratesRes, promoRes, travelRes, estimateRes] = await Promise.allSettled([
+    fetch("/api/pricing/rates").then((r) => r.json() as Promise<{ rates?: PublicRate[] }>),
+    fetch("/api/promos/active").then((r) => r.json() as Promise<{ promo?: ActivePromo | null }>),
+    dest
+      ? fetch("/api/pricing/travel-time", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ destination: dest }),
+        }).then((r) => r.json() as Promise<{ durationMins?: number }>)
+      : Promise.resolve({ durationMins: 0 }),
+    fetch("/api/pricing/estimate-duration", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description }),
+    }).then(
+      (r) =>
+        r.json() as Promise<{
+          ok: boolean;
+          result?: {
+            estimatedMins: number;
+            confidence: EstimateConfidence;
+            explanation: string;
+            tasks: { label: string; mins: number }[];
+          };
+        }>,
+    ),
+  ]);
+
+  const rates: PublicRate[] = ratesRes.status === "fulfilled" ? (ratesRes.value.rates ?? []) : [];
+  const promo: ActivePromo | null =
+    promoRes.status === "fulfilled" ? (promoRes.value.promo ?? null) : null;
+  const travelMins =
+    meeting === "remote"
+      ? 0
+      : travelRes.status === "fulfilled"
+        ? (travelRes.value.durationMins ?? 0)
+        : 0;
+
+  let estimatedMins = 60;
+  let confidence: EstimateConfidence = "medium";
+  let explanation = "";
+  let tasks: { label: string; mins: number }[] = [];
+  let fullRate = 65;
+  if (estimateRes.status === "fulfilled" && estimateRes.value.ok && estimateRes.value.result) {
+    const ai = estimateRes.value.result;
+    estimatedMins = ai.estimatedMins;
+    confidence = ai.confidence ?? "medium";
+    explanation = ai.explanation;
+    tasks = Array.isArray(ai.tasks) ? ai.tasks : [];
+    const baseStandard =
+      rates.find((r) => r.ratePerHour !== null && r.isDefault)?.ratePerHour ??
+      rates.find((r) => r.ratePerHour !== null)?.ratePerHour ??
+      65;
+    const remoteDelta =
+      meeting === "remote"
+        ? (rates.find((r) => r.label === "Remote" && r.hourlyDelta !== null)?.hourlyDelta ?? 0)
+        : 0;
+    fullRate = baseStandard + remoteDelta;
+  }
+
+  const travelRatePerHour =
+    rates.find((r) => r.unit === "travel-hour" && r.ratePerHour !== null)?.ratePerHour ?? 40;
+  const promoRate = applyPromoToHourlyRate(fullRate, promo);
+  const effectiveMins = Math.max(minBillableMins, estimatedMins);
+  const band = priceRangeFor(effectiveMins, promoRate, confidence, estimatorRange);
+  const travel = calcTravelCharge(travelMins, travelRatePerHour, minTravelCharge);
+  const low = band.low + travel;
+  const high = band.high + travel;
+
+  // Log the estimate (best effort) to capture the id for the booking snapshot.
+  let estimateId: string | null = null;
+  try {
+    const logged = await fetch("/api/pricing/log-estimate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        description,
+        aiEstimatedMins: estimatedMins,
+        aiExplanation: explanation,
+        aiTasks: tasks,
+        address: dest || null,
+        travelMins,
+        meetingType: meeting === "in-person" ? "in_person" : "remote",
+        hourlyRate: promoRate,
+        priceLow: low,
+        priceHigh: high,
+      }),
+    }).then((r) => r.json() as Promise<{ id?: string }>);
+    if (logged?.id) estimateId = logged.id;
+  } catch {
+    // Logging is best-effort; the range still shows without an id.
+  }
+
+  return { low, high, estimateId, confidence, explanation };
+}


### PR DESCRIPTION
Completes the quote-to-booking follow-ups (6e, 6f) noted in #180.

- **Admin:** the bookings list shows the snapshotted public quote ("Quoted: \$low - \$high") on rows that have one.
- **Inline estimate:** the booking form gains a "Get a rough estimate" button (new bookings) that reuses priceRangeFor + the public estimate endpoints, shows a range, and sets the estimate id so the booking snapshots whichever quote the customer saw (inline or carried from /pricing).
- **Shared helper:** new quick-estimate lib keeps the inline booking estimate and the /pricing wizard in sync.