### PR TITLE
refactor(ui+api): shared Field/Button, unified API responses, calculator time entry, a11y + CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,7 @@ const cspProd =
   "connect-src 'self' https://maps.googleapis.com; " +
   "worker-src 'self' blob:; " +
   "manifest-src 'self'; " +
+  "object-src 'none'; " +
   "frame-ancestors 'none'; " +
   "base-uri 'self'; " +
   "form-action 'self';";
@@ -26,6 +27,7 @@ const cspDev =
   "font-src 'self' data: https://fonts.gstatic.com; " +
   "connect-src 'self' ws: http://localhost:3000 http://127.0.0.1:3000 https://maps.googleapis.com https://va.vercel-scripts.com; " +
   "worker-src 'self' blob:; " +
+  "object-src 'none'; " +
   "frame-ancestors 'none'; " +
   "base-uri 'self'; " +
   "form-action 'self';";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.108.9",
+  "version": "1.109.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.108.9",
+      "version": "1.109.0",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.109.0",
+  "version": "1.110.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.109.0",
+      "version": "1.110.0",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.108.7",
+  "version": "1.108.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.108.7",
+      "version": "1.108.8",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.111.1",
+  "version": "1.111.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.111.1",
+      "version": "1.111.2",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.111.0",
+  "version": "1.111.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.111.0",
+      "version": "1.111.1",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.110.0",
+  "version": "1.111.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.110.0",
+      "version": "1.111.0",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.108.8",
+  "version": "1.108.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.108.8",
+      "version": "1.108.9",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.109.0",
+  "version": "1.110.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.111.1",
+  "version": "1.111.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.108.9",
+  "version": "1.109.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.111.0",
+  "version": "1.111.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.108.8",
+  "version": "1.108.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.108.7",
+  "version": "1.108.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.110.0",
+  "version": "1.111.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -75,13 +75,13 @@ export default function AboutPage(): React.ReactElement {
               About To The Point Tech
             </h1>
 
-            <p className={cn("mb-4 text-sm text-rich-black sm:text-base")}>
+            <p className={cn("mb-4 text-base text-rich-black sm:text-lg")}>
               I'm Harrison Raynes, a computer science graduate based in Auckland. I started To The
               Point Tech because I saw how many people struggle with everyday technology problems
               but don't have anyone reliable to call.
             </p>
 
-            <p className={cn("text-sm text-rich-black/80 sm:text-base")}>
+            <p className={cn("text-base text-rich-black/80 sm:text-lg")}>
               My focus is on practical fixes and clear explanations. I want to leave your tech in a
               better state than I found it, and make sure you understand what changed and why.
             </p>
@@ -98,7 +98,7 @@ export default function AboutPage(): React.ReactElement {
               My approach
             </h2>
 
-            <ul className={cn("mb-4 space-y-2.5 text-sm text-rich-black sm:text-base")}>
+            <ul className={cn("mb-4 space-y-2.5 text-base text-rich-black sm:text-lg")}>
               <li className={cn("flex gap-3")}>
                 <span className={cn("mt-1 text-lg text-moonstone-600")}>•</span>
                 <span>
@@ -129,7 +129,7 @@ export default function AboutPage(): React.ReactElement {
               </li>
             </ul>
 
-            <p className={cn("text-sm text-rich-black/80 sm:text-base")}>
+            <p className={cn("text-base text-rich-black/80 sm:text-lg")}>
               I'm happy to work with you directly, alongside family members, or with a small
               business owner. If you prefer, we can start with email and move to a visit once you're
               comfortable.
@@ -147,12 +147,12 @@ export default function AboutPage(): React.ReactElement {
               Who I help
             </h2>
 
-            <p className={cn("mb-4 text-sm text-rich-black sm:text-base")}>
+            <p className={cn("mb-4 text-base text-rich-black sm:text-lg")}>
               I mainly work with households and small businesses across Auckland who want their tech
               to just work, without wading through jargon or sales pitches.
             </p>
 
-            <ul className={cn("mb-4 space-y-2.5 text-sm text-rich-black sm:text-base")}>
+            <ul className={cn("mb-4 space-y-2.5 text-base text-rich-black sm:text-lg")}>
               <li className={cn("flex gap-3")}>
                 <span className={cn("mt-1 text-lg text-moonstone-600")}>•</span>
                 <span>Home users wanting reliable Wi-Fi, secure accounts, and proper backups.</span>
@@ -169,7 +169,7 @@ export default function AboutPage(): React.ReactElement {
               </li>
             </ul>
 
-            <p className={cn("text-sm text-rich-black/80 sm:text-base")}>
+            <p className={cn("text-base text-rich-black/80 sm:text-lg")}>
               See the{" "}
               <Link href="/services" className={linkStyle}>
                 services page

--- a/src/app/admin/business/invoices/[id]/InvoiceActions.tsx
+++ b/src/app/admin/business/invoices/[id]/InvoiceActions.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_VOID_EMAIL_BODY,
 } from "@/features/business/lib/invoice-email-defaults";
 import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type React from "react";
@@ -634,7 +635,7 @@ export function InvoiceActions({
                               {eligibility.reason === "already-reviewed" &&
                                 "(this customer has already left a review)"}
                               {eligibility.reason === "sent-recently" &&
-                                ` (review request sent ${new Date(eligibility.lastSentAt).toLocaleDateString()} - can re-send from ${new Date(eligibility.nextAllowedAt).toLocaleDateString()})`}
+                                ` (review request sent ${formatDateShort(eligibility.lastSentAt)} - can re-send from ${formatDateShort(eligibility.nextAllowedAt)})`}
                               {eligibility.reason === "no-contact" && (
                                 <>
                                   (no contact record -{" "}

--- a/src/app/api/admin/blocked-days/[eventId]/route.ts
+++ b/src/app/api/admin/blocked-days/[eventId]/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { deleteBookingEvent, SCHEDULE_CALENDAR_TAG } from "@/features/calendar/lib/google-calendar";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
@@ -26,12 +27,12 @@ export async function DELETE(
   { params }: { params: Promise<{ eventId: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { eventId } = await params;
   if (!eventId) {
-    return NextResponse.json({ ok: false, error: "Missing eventId." }, { status: 400 });
+    return errorResponse("Missing eventId.", 400);
   }
 
   try {

--- a/src/app/api/admin/blocked-days/route.ts
+++ b/src/app/api/admin/blocked-days/route.ts
@@ -10,6 +10,7 @@ import {
   createBlockedDayEvent,
   SCHEDULE_CALENDAR_TAG,
 } from "@/features/calendar/lib/google-calendar";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getPacificAucklandOffset } from "@/shared/lib/timezone-utils";
@@ -33,14 +34,14 @@ interface BlockedDayPayload {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = (await request.json()) as BlockedDayPayload;
   const dateKey = body.dateKey?.trim() ?? "";
 
   if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) {
-    return NextResponse.json({ ok: false, error: "Invalid date." }, { status: 400 });
+    return errorResponse("Invalid date.", 400);
   }
 
   const [y, m, d] = dateKey.split("-").map(Number);

--- a/src/app/api/admin/bookings/[id]/resend-review/route.ts
+++ b/src/app/api/admin/bookings/[id]/resend-review/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -28,7 +29,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -39,7 +40,7 @@ export async function POST(
   });
 
   if (!booking) {
-    return NextResponse.json({ error: "Booking not found." }, { status: 404 });
+    return errorResponse("Booking not found.", 404);
   }
 
   await sendCustomerReviewRequest(booking);

--- a/src/app/api/admin/bookings/[id]/route.ts
+++ b/src/app/api/admin/bookings/[id]/route.ts
@@ -12,6 +12,7 @@ import {
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
 import { deleteBookingEvent, SCHEDULE_CALENDAR_TAG } from "@/features/calendar/lib/google-calendar";
 import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -51,7 +52,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -60,7 +61,7 @@ export async function PATCH(
   // Load the booking
   const booking = await prisma.booking.findUnique({ where: { id } });
   if (!booking) {
-    return NextResponse.json({ error: "Booking not found." }, { status: 404 });
+    return errorResponse("Booking not found.", 404);
   }
 
   // Sparse update: only fields present in the body get written.
@@ -215,14 +216,14 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
 
   const booking = await prisma.booking.findUnique({ where: { id } });
   if (!booking) {
-    return NextResponse.json({ error: "Booking not found." }, { status: 404 });
+    return errorResponse("Booking not found.", 404);
   }
 
   if (booking.calendarEventId) {

--- a/src/app/api/admin/bookings/route.ts
+++ b/src/app/api/admin/bookings/route.ts
@@ -19,6 +19,7 @@ import {
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
 import { sendCustomerBookingConfirmation } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { validatePhone } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -51,7 +52,7 @@ interface AdminBookingPayload {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   // Parse the payload; trim free-text fields and lowercase the email
@@ -67,21 +68,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Validate fields
   if (!name || name.length > BOOKING_FIELD_LIMITS.name) {
-    return NextResponse.json({ ok: false, error: "Customer name is required." }, { status: 400 });
+    return errorResponse("Customer name is required.", 400);
   }
   const emailCheck = validateEmail(email);
   if (emailCheck !== "ok") {
     const msg = emailCheck === "too-long" ? "Email is too long." : "Valid email is required.";
-    return NextResponse.json({ ok: false, error: msg }, { status: 400 });
+    return errorResponse(msg, 400);
   }
   if (notes.length > BOOKING_FIELD_LIMITS.notes) {
-    return NextResponse.json({ ok: false, error: "Notes too long." }, { status: 400 });
+    return errorResponse("Notes too long.", 400);
   }
   if (address && address.length > BOOKING_FIELD_LIMITS.address) {
-    return NextResponse.json({ ok: false, error: "Address too long." }, { status: 400 });
+    return errorResponse("Address too long.", 400);
   }
   if (!startAtStr || isNaN(Date.parse(startAtStr))) {
-    return NextResponse.json({ ok: false, error: "Invalid start time." }, { status: 400 });
+    return errorResponse("Invalid start time.", 400);
   }
   if (durationMinutes !== 60 && durationMinutes !== 120) {
     return NextResponse.json(
@@ -94,7 +95,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (phoneRaw) {
     const phoneCheck = validatePhone(phoneRaw);
     if (phoneCheck.result !== "ok") {
-      return NextResponse.json({ ok: false, error: "Invalid phone number." }, { status: 400 });
+      return errorResponse("Invalid phone number.", 400);
     }
     phoneE164 = phoneCheck.e164;
   }
@@ -234,9 +235,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, bookingId: booking.id });
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
-      return NextResponse.json({ ok: false, error: "This slot was just taken." }, { status: 409 });
+      return errorResponse("This slot was just taken.", 409);
     }
     console.error("[admin/bookings] Booking insert failed:", err);
-    return NextResponse.json({ ok: false, error: "Failed to save booking." }, { status: 500 });
+    return errorResponse("Failed to save booking.", 500);
   }
 }

--- a/src/app/api/admin/contacts/[id]/clear-review-link/route.ts
+++ b/src/app/api/admin/contacts/[id]/clear-review-link/route.ts
@@ -7,6 +7,7 @@
  * (replaces the old DELETE /api/admin/review-requests/[id] flow).
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -24,7 +25,7 @@ export async function POST(
   params: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params.params;
@@ -41,6 +42,6 @@ export async function POST(
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error(`[api/admin/contacts/${id}/clear-review-link] failed:`, err);
-    return NextResponse.json({ error: "Failed to clear review link." }, { status: 500 });
+    return errorResponse("Failed to clear review link.", 500);
   }
 }

--- a/src/app/api/admin/contacts/[id]/route.ts
+++ b/src/app/api/admin/contacts/[id]/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { isValidPhone, normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -32,19 +33,19 @@ export async function PATCH(
   params: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params.params;
   const body = (await request.json()) as ContactPatchBody;
 
   if (body.name !== undefined && !body.name.trim()) {
-    return NextResponse.json({ error: "Name is required." }, { status: 400 });
+    return errorResponse("Name is required.", 400);
   }
   if (body.email !== undefined) {
     const trimmedEmail = body.email.trim().toLowerCase();
     if (trimmedEmail && !/^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/.test(trimmedEmail)) {
-      return NextResponse.json({ error: "Please enter a valid email address." }, { status: 400 });
+      return errorResponse("Please enter a valid email address.", 400);
     }
     if (trimmedEmail) {
       const dupe = await prisma.contact.findFirst({
@@ -52,12 +53,12 @@ export async function PATCH(
         select: { id: true },
       });
       if (dupe) {
-        return NextResponse.json({ error: "That email is already in use." }, { status: 409 });
+        return errorResponse("That email is already in use.", 409);
       }
     }
   }
   if (body.phone !== undefined && body.phone.trim() && !isValidPhone(normalisePhone(body.phone))) {
-    return NextResponse.json({ error: "Please enter a valid phone number." }, { status: 400 });
+    return errorResponse("Please enter a valid phone number.", 400);
   }
 
   const updateData: Record<string, string | null> = {};

--- a/src/app/api/admin/contacts/[id]/sync-google/route.ts
+++ b/src/app/api/admin/contacts/[id]/sync-google/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -26,7 +27,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -36,6 +37,6 @@ export async function POST(
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error(`[admin/contacts/${id}/sync-google] POST error:`, error);
-    return NextResponse.json({ ok: false, error: "Sync failed" });
+    return errorResponse("Sync failed", 200);
   }
 }

--- a/src/app/api/admin/contacts/backfill/route.ts
+++ b/src/app/api/admin/contacts/backfill/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -39,7 +40,7 @@ function parseNotes(notes: string | null): { phone: string | null; address: stri
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const mergedByEmail = new Map<

--- a/src/app/api/admin/contacts/check/route.ts
+++ b/src/app/api/admin/contacts/check/route.ts
@@ -5,6 +5,7 @@
  * "Add to contacts?" popup to decide whether to prompt the operator.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -18,7 +19,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const email = request.nextUrl.searchParams.get("email")?.trim().toLowerCase() ?? "";

--- a/src/app/api/admin/contacts/conflicts/[id]/route.ts
+++ b/src/app/api/admin/contacts/conflicts/[id]/route.ts
@@ -9,6 +9,7 @@
  */
 
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -30,7 +31,7 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await ctx.params;
@@ -56,7 +57,7 @@ export async function POST(
 
   const conflict = await prisma.contactConflict.findUnique({ where: { id } });
   if (!conflict || conflict.resolvedAt) {
-    return NextResponse.json({ error: "Conflict not found or already resolved" }, { status: 404 });
+    return errorResponse("Conflict not found or already resolved", 404);
   }
 
   // Decide the chosen value
@@ -92,6 +93,6 @@ export async function POST(
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("[admin/contacts/conflicts/id] POST error:", err);
-    return NextResponse.json({ error: "Failed to resolve conflict" }, { status: 500 });
+    return errorResponse("Failed to resolve conflict", 500);
   }
 }

--- a/src/app/api/admin/contacts/conflicts/route.ts
+++ b/src/app/api/admin/contacts/conflicts/route.ts
@@ -4,6 +4,7 @@
  * @description Admin endpoint listing pending Google Contacts sync conflicts.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -17,7 +18,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -52,6 +53,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
   } catch (err) {
     console.error("[admin/contacts/conflicts] GET error:", err);
-    return NextResponse.json({ error: "Failed to load conflicts" }, { status: 500 });
+    return errorResponse("Failed to load conflicts", 500);
   }
 }

--- a/src/app/api/admin/contacts/enrich-from-reviews/route.ts
+++ b/src/app/api/admin/contacts/enrich-from-reviews/route.ts
@@ -8,6 +8,7 @@
  * bookings handle phone enrichment via auto-maintain.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -41,7 +42,7 @@ export interface ConflictEntry {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const allContacts = await prisma.contact.findMany({

--- a/src/app/api/admin/contacts/export/route.ts
+++ b/src/app/api/admin/contacts/export/route.ts
@@ -5,6 +5,7 @@
  * Column layout matches the format produced by Google Contacts own export tool.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -45,7 +46,7 @@ function splitName(fullName: string): { first: string; last: string } {
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   // Load all contacts

--- a/src/app/api/admin/contacts/import/route.ts
+++ b/src/app/api/admin/contacts/import/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { importFromGoogleContacts } from "@/features/contacts/lib/google-contacts";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -20,7 +21,7 @@ export const maxDuration = 60;
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -31,6 +32,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Generic message to the client; the OAuth / Google API detail goes only
     // to the server log so a transient Google failure can't leak credential
     // shape or integration internals.
-    return NextResponse.json({ ok: false, error: "Contact import failed." }, { status: 500 });
+    return errorResponse("Contact import failed.", 500);
   }
 }

--- a/src/app/api/admin/contacts/resolve-conflict/route.ts
+++ b/src/app/api/admin/contacts/resolve-conflict/route.ts
@@ -5,6 +5,7 @@
  * the contact and the source record (Booking or Review).
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -33,14 +34,14 @@ interface ResolveBody {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = (await request.json()) as ResolveBody;
   const { contactId, sourceId, source, name, phone } = body;
 
   if (!contactId || !sourceId || !source) {
-    return NextResponse.json({ error: "Missing required fields." }, { status: 400 });
+    return errorResponse("Missing required fields.", 400);
   }
 
   const contactUpdate: Record<string, string | null> = {};
@@ -73,6 +74,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error("[admin/contacts/resolve-conflict] POST error:", error);
-    return NextResponse.json({ error: "Failed to resolve conflict." }, { status: 500 });
+    return errorResponse("Failed to resolve conflict.", 500);
   }
 }

--- a/src/app/api/admin/contacts/route.ts
+++ b/src/app/api/admin/contacts/route.ts
@@ -6,6 +6,7 @@
 
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -20,7 +21,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const contacts = await prisma.contact.findMany({
@@ -47,7 +48,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = (await request.json().catch(() => null)) as {
@@ -59,12 +60,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   } | null;
 
   if (!body || !body.name?.trim() || !body.email?.trim()) {
-    return NextResponse.json({ error: "Name and email are required" }, { status: 400 });
+    return errorResponse("Name and email are required", 400);
   }
 
   const email = body.email.trim().toLowerCase();
   if (!email.includes("@")) {
-    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+    return errorResponse("Invalid email", 400);
   }
 
   const phoneE164 = body.phone ? toE164NZ(body.phone) || null : null;

--- a/src/app/api/admin/contacts/sync/route.ts
+++ b/src/app/api/admin/contacts/sync/route.ts
@@ -9,6 +9,7 @@ import {
   importFromGoogleContacts,
   syncAllContactsToGoogle,
 } from "@/features/contacts/lib/google-contacts";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -24,7 +25,7 @@ export const maxDuration = 60;
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -38,6 +39,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Generic message to the client; the OAuth / Google API detail goes only
     // to the server log so a transient Google failure can't leak the shape of
     // the credentials or the integration internals.
-    return NextResponse.json({ ok: false, error: "Contact sync failed." }, { status: 500 });
+    return errorResponse("Contact sync failed.", 500);
   }
 }

--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -12,6 +12,7 @@ import {
   ADMIN_SESSION_MAX_AGE_SECONDS,
   createSessionCookieValue,
 } from "@/shared/lib/admin-session";
+import { errorResponse } from "@/shared/lib/api-response";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { timingSafeEqual } from "crypto";
 import { type NextRequest, NextResponse } from "next/server";
@@ -53,11 +54,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     body = (await request.json()) as { secret?: unknown };
   } catch {
-    return NextResponse.json({ ok: false, error: "Bad request." }, { status: 400 });
+    return errorResponse("Bad request.", 400);
   }
   const candidate = typeof body.secret === "string" ? body.secret : "";
   if (!matchesAdminSecret(candidate)) {
-    return NextResponse.json({ ok: false, error: "Invalid credentials." }, { status: 401 });
+    return errorResponse("Invalid credentials.", 401);
   }
 
   const cookieValue = await createSessionCookieValue();

--- a/src/app/api/admin/preview-review-email/route.ts
+++ b/src/app/api/admin/preview-review-email/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { buildPastClientReviewEmailHtml } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -17,7 +18,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { name } = body;
 
     if (!name?.trim()) {
-      return NextResponse.json({ ok: false, error: "Name is required." }, { status: 400 });
+      return errorResponse("Name is required.", 400);
     }
 
     const firstName = name.trim().split(" ")[0];
@@ -34,6 +35,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, html });
   } catch (error) {
     console.error("[admin/preview-review-email] Error:", error);
-    return NextResponse.json({ ok: false, error: "Failed to generate preview." }, { status: 500 });
+    return errorResponse("Failed to generate preview.", 500);
   }
 }

--- a/src/app/api/admin/reviews/[id]/route.ts
+++ b/src/app/api/admin/reviews/[id]/route.ts
@@ -7,6 +7,7 @@
 
 import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
 import { revalidateReviewPaths } from "@/features/reviews/lib/revalidate";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -26,7 +27,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = (await request.json()) as {
@@ -46,13 +47,13 @@ export async function PATCH(
       return NextResponse.json({ ok: true });
     } catch (error) {
       console.error(`[admin/reviews] PATCH contactId error for ${id}:`, error);
-      return NextResponse.json({ error: "Failed to update review" }, { status: 500 });
+      return errorResponse("Failed to update review", 500);
     }
   }
 
   const { action } = body;
   if (action !== "approve" && action !== "revoke") {
-    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+    return errorResponse("Invalid action", 400);
   }
 
   const { id } = await params;
@@ -126,7 +127,7 @@ export async function PATCH(
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error(`[admin/reviews] PATCH error for ${id}:`, error);
-    return NextResponse.json({ error: "Failed to update review" }, { status: 500 });
+    return errorResponse("Failed to update review", 500);
   }
 }
 
@@ -143,7 +144,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -157,6 +158,6 @@ export async function DELETE(
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error(`[admin/reviews] DELETE error for ${id}:`, error);
-    return NextResponse.json({ error: "Failed to delete review" }, { status: 500 });
+    return errorResponse("Failed to delete review", 500);
   }
 }

--- a/src/app/api/admin/reviews/match-contacts/route.ts
+++ b/src/app/api/admin/reviews/match-contacts/route.ts
@@ -4,6 +4,7 @@
  * @description Admin API to auto-match reviews to contacts by email or phone.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -24,7 +25,7 @@ export const maxDuration = 60;
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -107,6 +108,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, matchedCount });
   } catch (error) {
     console.error("[admin/reviews/match-contacts] POST error:", error);
-    return NextResponse.json({ error: "Failed to match contacts" }, { status: 500 });
+    return errorResponse("Failed to match contacts", 500);
   }
 }

--- a/src/app/api/admin/reviews/route.ts
+++ b/src/app/api/admin/reviews/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { reviewTextError } from "@/features/reviews/lib/validation";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -18,7 +19,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -31,7 +32,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const text = body.text?.trim() ?? "";
     const textErr = reviewTextError(text);
-    if (textErr) return NextResponse.json({ error: textErr }, { status: 400 });
+    if (textErr) return errorResponse(textErr, 400);
 
     const isAnonymous = body.isAnonymous ?? false;
     const firstName = isAnonymous ? null : body.firstName?.trim() || null;
@@ -61,6 +62,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, review }, { status: 201 });
   } catch (error) {
     console.error("[admin/reviews] POST error:", error);
-    return NextResponse.json({ error: "Failed to create review." }, { status: 500 });
+    return errorResponse("Failed to create review.", 500);
   }
 }

--- a/src/app/api/admin/send-review-link/route.ts
+++ b/src/app/api/admin/send-review-link/route.ts
@@ -12,6 +12,7 @@ import {
   findOrCreateContactByPhone,
 } from "@/features/contacts/lib/find-or-create";
 import { sendPastClientReviewRequest } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { isValidPhone, toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
@@ -33,7 +34,7 @@ export const maxDuration = 60;
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -47,10 +48,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { name, email, phone, mode = "email" } = body;
 
     if (!name?.trim()) {
-      return NextResponse.json({ ok: false, error: "Name is required." }, { status: 400 });
+      return errorResponse("Name is required.", 400);
     }
     if (mode === "email" && (!email?.trim() || !email.includes("@"))) {
-      return NextResponse.json({ ok: false, error: "Valid email is required." }, { status: 400 });
+      return errorResponse("Valid email is required.", 400);
     }
 
     const siteUrl = getSiteUrl();
@@ -60,11 +61,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let normalisedPhone: string | null = null;
     if (mode === "sms") {
       if (!phone) {
-        return NextResponse.json({ ok: false, error: "Phone is required." }, { status: 400 });
+        return errorResponse("Phone is required.", 400);
       }
       normalisedPhone = toE164NZ(phone);
       if (!isValidPhone(normalisedPhone)) {
-        return NextResponse.json({ ok: false, error: "Invalid phone number." }, { status: 400 });
+        return errorResponse("Invalid phone number.", 400);
       }
     }
 
@@ -122,6 +123,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, reviewUrl });
   } catch (error) {
     console.error("[admin/send-review-link] Error:", error);
-    return NextResponse.json({ ok: false, error: "Failed to send review link." }, { status: 500 });
+    return errorResponse("Failed to send review link.", 500);
   }
 }

--- a/src/app/api/admin/settings/[group]/history/route.ts
+++ b/src/app/api/admin/settings/[group]/history/route.ts
@@ -7,6 +7,7 @@
  * load a prior version back into the editor for review + re-save.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
@@ -63,10 +64,10 @@ export async function GET(
   { params }: { params: Promise<{ group: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const group = asGroup((await params).group);
-  if (!group) return NextResponse.json({ error: "Unknown settings group" }, { status: 404 });
+  if (!group) return errorResponse("Unknown settings group", 404);
 
   const rows = await prisma.settingAudit.findMany({
     where: { group },

--- a/src/app/api/admin/settings/[group]/route.ts
+++ b/src/app/api/admin/settings/[group]/route.ts
@@ -7,6 +7,7 @@
  * always reject; WARNs reject unless the client confirms.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { DEFAULT_SETTINGS } from "@/shared/lib/settings/defaults";
 import { getSettings } from "@/shared/lib/settings/get-settings";
@@ -40,10 +41,10 @@ export async function GET(
   { params }: { params: Promise<{ group: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const group = asGroup((await params).group);
-  if (!group) return NextResponse.json({ error: "Unknown settings group" }, { status: 404 });
+  if (!group) return errorResponse("Unknown settings group", 404);
 
   const settings = await getSettings();
   return NextResponse.json({ ok: true, value: settings[group] });
@@ -65,17 +66,17 @@ export async function PUT(
   { params }: { params: Promise<{ group: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const group = asGroup((await params).group);
-  if (!group) return NextResponse.json({ error: "Unknown settings group" }, { status: 404 });
+  if (!group) return errorResponse("Unknown settings group", 404);
 
   const body = (await request.json().catch(() => null)) as {
     value?: unknown;
     confirmWarnings?: boolean;
   } | null;
   if (!body || typeof body.value !== "object" || body.value === null) {
-    return NextResponse.json({ error: "Missing value" }, { status: 400 });
+    return errorResponse("Missing value", 400);
   }
 
   const value = body.value as Settings[typeof group];
@@ -83,7 +84,7 @@ export async function PUT(
   // 1. Per-field shape + bounds.
   const fieldErrors = validateGroup(group, value);
   if (fieldErrors.length > 0) {
-    return NextResponse.json({ error: "Invalid", fieldErrors }, { status: 400 });
+    return NextResponse.json({ ok: false, error: "Invalid", fieldErrors }, { status: 400 });
   }
 
   // 2. Cross-setting coherence on the full proposed settings. Assign via a
@@ -94,10 +95,10 @@ export async function PUT(
   const blocks = issues.filter((i) => i.level === "block").map((i) => i.message);
   const warns = issues.filter((i) => i.level === "warn").map((i) => i.message);
   if (blocks.length > 0) {
-    return NextResponse.json({ error: "Blocked", blocks }, { status: 422 });
+    return NextResponse.json({ ok: false, error: "Blocked", blocks }, { status: 422 });
   }
   if (warns.length > 0 && !body.confirmWarnings) {
-    return NextResponse.json({ error: "Confirm", warns }, { status: 409 });
+    return NextResponse.json({ ok: false, error: "Confirm", warns }, { status: 409 });
   }
 
   await saveSettingsGroup(group, value);

--- a/src/app/api/admin/travel/[id]/route.ts
+++ b/src/app/api/admin/travel/[id]/route.ts
@@ -6,6 +6,7 @@
  * minutes so the next refresh recalculates.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { TransportMode } from "@prisma/client";
@@ -26,7 +27,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -39,7 +40,7 @@ export async function PATCH(
 
   const rawMode = body.transportMode;
   if (rawMode !== undefined && !VALID_MODES.has(rawMode)) {
-    return NextResponse.json({ error: "Invalid transport mode" }, { status: 400 });
+    return errorResponse("Invalid transport mode", 400);
   }
   const mode = rawMode as TransportMode | undefined;
 
@@ -49,13 +50,13 @@ export async function PATCH(
   const hasIgnored = typeof body.ignored === "boolean";
 
   if (!hasMode && !hasOrigin && !hasBackDest && !hasIgnored) {
-    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+    return errorResponse("Nothing to update", 400);
   }
 
   try {
     const block = await prisma.travelBlock.findUnique({ where: { id } });
     if (!block) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+      return errorResponse("Not found", 404);
     }
 
     await prisma.travelBlock.update({
@@ -125,6 +126,6 @@ export async function PATCH(
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error("[travel/[id]] Error:", error);
-    return NextResponse.json({ ok: false, error: "Update failed" }, { status: 500 });
+    return errorResponse("Update failed", 500);
   }
 }

--- a/src/app/api/admin/travel/recalculate/route.ts
+++ b/src/app/api/admin/travel/recalculate/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { refreshCalendarCache } from "@/features/calendar/lib/calendar-cache";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { type NextRequest, NextResponse } from "next/server";
@@ -18,7 +19,7 @@ import { type NextRequest, NextResponse } from "next/server";
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -36,6 +37,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, cachedCount: result.cachedCount });
   } catch (error) {
     console.error("[travel/recalculate] Error:", error);
-    return NextResponse.json({ ok: false, error: "Recalculation failed" }, { status: 500 });
+    return errorResponse("Recalculation failed", 500);
   }
 }

--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/features/business/lib/pricing-policy";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
 import { deleteBookingEvent } from "@/features/calendar/lib/google-calendar";
+import { errorResponse } from "@/shared/lib/api-response";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { NextRequest, NextResponse } from "next/server";
@@ -37,7 +38,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   const token = request.nextUrl.searchParams.get("token");
   if (!token) {
-    return NextResponse.json({ ok: false, error: "Missing cancel token." }, { status: 400 });
+    return errorResponse("Missing cancel token.", 400);
   }
 
   const booking = await prisma.booking.findFirst({
@@ -45,7 +46,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     select: { startAt: true, status: true },
   });
   if (!booking) {
-    return NextResponse.json({ ok: false, error: "Booking not found." }, { status: 404 });
+    return errorResponse("Booking not found.", 404);
   }
 
   // Hand the live cancellation policy to the client so the fee banner quotes
@@ -80,7 +81,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { cancelToken } = body;
 
     if (!cancelToken) {
-      return NextResponse.json({ ok: false, error: "Missing cancel token." }, { status: 400 });
+      return errorResponse("Missing cancel token.", 400);
     }
 
     // Load the booking
@@ -89,11 +90,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
 
     if (!booking) {
-      return NextResponse.json({ ok: false, error: "Booking not found." }, { status: 404 });
+      return errorResponse("Booking not found.", 404);
     }
 
     if (booking.status === "cancelled") {
-      return NextResponse.json({ ok: false, error: "Booking already cancelled." }, { status: 400 });
+      return errorResponse("Booking already cancelled.", 400);
     }
 
     // Remove the calendar event
@@ -150,6 +151,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
   } catch (error) {
     console.error("[booking/cancel] Error:", error);
-    return NextResponse.json({ ok: false, error: "Failed to cancel booking." }, { status: 500 });
+    return errorResponse("Failed to cancel booking.", 500);
   }
 }

--- a/src/app/api/booking/edit/route.ts
+++ b/src/app/api/booking/edit/route.ts
@@ -24,6 +24,7 @@ import {
   sendCustomerBookingConfirmation,
   sendOwnerBookingNotification,
 } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isValidPhone, toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
@@ -74,13 +75,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     } = body;
 
     if (!cancelToken) {
-      return NextResponse.json({ ok: false, error: "Missing cancel token." }, { status: 400 });
+      return errorResponse("Missing cancel token.", 400);
     }
 
     // Find booking
     const booking = await prisma.booking.findFirst({ where: { cancelToken } });
     if (!booking) {
-      return NextResponse.json({ ok: false, error: "Booking not found." }, { status: 404 });
+      return errorResponse("Booking not found.", 404);
     }
     if (booking.status === "cancelled") {
       return NextResponse.json(
@@ -95,7 +96,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { requireEmail: false },
     );
     if (!payloadCheck.valid) {
-      return NextResponse.json({ ok: false, error: payloadCheck.error }, { status: 400 });
+      return errorResponse(payloadCheck.error, 400);
     }
 
     const now = new Date();
@@ -117,13 +118,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       reschedule.maxReschedules !== null &&
       booking.rescheduleCount >= reschedule.maxReschedules
     ) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error:
-            "This booking has already been changed the maximum number of times. Please call or text me to reschedule.",
-        },
-        { status: 400 },
+      return errorResponse(
+        "This booking has already been changed the maximum number of times. Please call or text me to reschedule.",
+        400,
       );
     }
 
@@ -180,13 +177,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
 
     if (!validation.valid) {
-      return NextResponse.json({ ok: false, error: validation.error }, { status: 400 });
+      return errorResponse(validation.error, 400);
     }
 
     // Resolve the new slot from the validated hour label + live durations.
     const startHour = parseHourLabel(timeOfDay);
     if (startHour === null) {
-      return NextResponse.json({ ok: false, error: "Invalid time or duration." }, { status: 400 });
+      return errorResponse("Invalid time or duration.", 400);
     }
     const durationMinutes = duration === "short" ? config.durations.short : config.durations.long;
     const durationLabel = `${duration === "short" ? "Standard" : "Extended"} (${durationMinutes} min)`;

--- a/src/app/api/booking/hold/route.ts
+++ b/src/app/api/booking/hold/route.ts
@@ -6,6 +6,7 @@
 
 import { getAvailabilityConfig } from "@/features/booking/lib/availability-config.server";
 import { createBookingEvent } from "@/features/calendar/lib/google-calendar";
+import { errorResponse } from "@/shared/lib/api-response";
 import { toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
@@ -71,13 +72,13 @@ export async function POST(request: NextRequest): Promise<NextResponse<CreateBoo
     const { name, email, phone, notes, dateKey, slotStart, slotEnd, meetingType, address } = body;
 
     if (!name?.trim()) {
-      return NextResponse.json({ ok: false, error: "Name is required." }, { status: 400 });
+      return errorResponse("Name is required.", 400);
     }
     if (!email?.trim() || !email.includes("@")) {
-      return NextResponse.json({ ok: false, error: "Valid email is required." }, { status: 400 });
+      return errorResponse("Valid email is required.", 400);
     }
     if (!dateKey || !slotStart || !slotEnd) {
-      return NextResponse.json({ ok: false, error: "Please select a time slot." }, { status: 400 });
+      return errorResponse("Please select a time slot.", 400);
     }
     if (!meetingType) {
       return NextResponse.json(
@@ -109,7 +110,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<CreateBoo
     const [endHour, endMinute] = slotEnd.split(":").map(Number);
 
     if (!year || !month || !day) {
-      return NextResponse.json({ ok: false, error: "Invalid date format." }, { status: 400 });
+      return errorResponse("Invalid date format.", 400);
     }
 
     // Get dynamic UTC offset for this date (handles NZDT/NZST)
@@ -120,7 +121,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<CreateBoo
     const endAt = new Date(Date.UTC(year, month - 1, day, endHour - utcOffset, endMinute, 0));
 
     if (startAt >= endAt) {
-      return NextResponse.json({ ok: false, error: "Invalid time range." }, { status: 400 });
+      return errorResponse("Invalid time range.", 400);
     }
 
     if (startAt < now) {

--- a/src/app/api/booking/request/route.ts
+++ b/src/app/api/booking/request/route.ts
@@ -28,6 +28,7 @@ import {
   sendCustomerBookingConfirmation,
   sendOwnerBookingNotification,
 } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isValidPhone, toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
@@ -122,7 +123,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { requireEmail: true },
     );
     if (!payloadCheck.valid) {
-      return NextResponse.json({ ok: false, error: payloadCheck.error }, { status: 400 });
+      return errorResponse(payloadCheck.error, 400);
     }
 
     const now = new Date();
@@ -184,13 +185,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
 
     if (!validation.valid) {
-      return NextResponse.json({ ok: false, error: validation.error }, { status: 400 });
+      return errorResponse(validation.error, 400);
     }
 
     // Resolve the slot from the (already-validated) hour label + live durations.
     const startHour = parseHourLabel(timeOfDay);
     if (startHour === null) {
-      return NextResponse.json({ ok: false, error: "Invalid time or duration" }, { status: 400 });
+      return errorResponse("Invalid time or duration", 400);
     }
     const durationMinutes = duration === "short" ? config.durations.short : config.durations.long;
 

--- a/src/app/api/business/contacts/route.ts
+++ b/src/app/api/business/contacts/route.ts
@@ -1,5 +1,6 @@
 import type { GoogleContact } from "@/features/business/types/business";
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { google } from "googleapis";
 import { NextRequest, NextResponse } from "next/server";
@@ -14,7 +15,7 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -42,6 +43,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, contacts });
   } catch (err) {
     console.error("[contacts] failed:", err);
-    return NextResponse.json({ error: "Could not fetch contacts" }, { status: 503 });
+    return errorResponse("Could not fetch contacts", 503);
   }
 }

--- a/src/app/api/business/expenses/[id]/route.ts
+++ b/src/app/api/business/expenses/[id]/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -14,7 +15,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;

--- a/src/app/api/business/expenses/route.ts
+++ b/src/app/api/business/expenses/route.ts
@@ -1,5 +1,6 @@
 import { GST_RATE } from "@/features/business/lib/pricing-policy";
 import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -11,7 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const entries = await prisma.expenseEntry.findMany({ orderBy: { date: "desc" } });
@@ -25,7 +26,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = await request.json();
@@ -33,17 +34,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     body;
 
   if (!date || !supplier || !description || !category || amountIncl === undefined || !method) {
-    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    return errorResponse("Missing required fields", 400);
   }
 
   const inclNum = parseAmount(amountIncl);
   if (inclNum === null) {
-    return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+    return errorResponse("Invalid amount", 400);
   }
 
   const rate = gstRate === undefined ? GST_RATE : parseRate(gstRate);
   if (rate === null) {
-    return NextResponse.json({ error: "Invalid GST rate" }, { status: 400 });
+    return errorResponse("Invalid GST rate", 400);
   }
 
   const gstAmount = Math.round(((inclNum * rate) / (1 + rate)) * 100) / 100;

--- a/src/app/api/business/income/[id]/route.ts
+++ b/src/app/api/business/income/[id]/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -14,7 +15,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;

--- a/src/app/api/business/income/route.ts
+++ b/src/app/api/business/income/route.ts
@@ -4,6 +4,7 @@ import {
   getFySheetIdForDate,
 } from "@/features/business/lib/sheets-sync";
 import { parseAmount } from "@/features/business/lib/validation";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -15,7 +16,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const entries = await prisma.incomeEntry.findMany({ orderBy: { date: "desc" } });
@@ -29,19 +30,19 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = await request.json();
   const { date, customer, description, amount, method, notes, invoiceId } = body;
 
   if (!date || !customer || !description || amount === undefined || !method) {
-    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    return errorResponse("Missing required fields", 400);
   }
 
   const safeAmount = parseAmount(amount);
   if (safeAmount === null) {
-    return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+    return errorResponse("Invalid amount", 400);
   }
 
   const entryDate = new Date(date);

--- a/src/app/api/business/invoices/[id]/pdf/route.ts
+++ b/src/app/api/business/invoices/[id]/pdf/route.ts
@@ -1,8 +1,9 @@
 // src/app/api/business/invoices/[id]/pdf/route.ts
 import { generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;
@@ -22,13 +23,13 @@ export async function GET(
   ctx: { params: Promise<{ id: string }> },
 ): Promise<Response> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await ctx.params;
   const invoice = await prisma.invoice.findUnique({ where: { id } });
   if (!invoice) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    return errorResponse("Invoice not found", 404);
   }
 
   const pdfBytes = await generateInvoicePdf({

--- a/src/app/api/business/invoices/[id]/preview-email/route.ts
+++ b/src/app/api/business/invoices/[id]/preview-email/route.ts
@@ -1,6 +1,7 @@
 // src/app/api/business/invoices/[id]/preview-email/route.ts
 import { getInvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
 import { buildInvoiceEmail } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSiteUrl } from "@/shared/lib/site-url";
@@ -20,13 +21,13 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await ctx.params;
   const invoice = await prisma.invoice.findUnique({ where: { id } });
   if (!invoice) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    return errorResponse("Invoice not found", 404);
   }
 
   // Optional operator overrides: greetingName targets a person inside a

--- a/src/app/api/business/invoices/[id]/preview-void-email/route.ts
+++ b/src/app/api/business/invoices/[id]/preview-void-email/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/business/invoices/[id]/preview-void-email/route.ts
 import { buildVoidEmail } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -18,13 +19,13 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await ctx.params;
   const invoice = await prisma.invoice.findUnique({ where: { id } });
   if (!invoice) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    return errorResponse("Invoice not found", 404);
   }
 
   const body = (await request.json().catch(() => ({}))) as {

--- a/src/app/api/business/invoices/[id]/route.ts
+++ b/src/app/api/business/invoices/[id]/route.ts
@@ -2,6 +2,7 @@ import { calcInvoiceTotals } from "@/features/business/lib/business";
 import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
 import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import type { InvoiceStatus } from "@prisma/client";
@@ -86,12 +87,12 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
   const invoice = await prisma.invoice.findUnique({ where: { id } });
-  if (!invoice) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (!invoice) return errorResponse("Not found", 404);
   return NextResponse.json({ ok: true, invoice });
 }
 
@@ -108,7 +109,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -122,7 +123,7 @@ export async function PATCH(
     select: { status: true },
   });
   if (!current) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    return errorResponse("Invoice not found", 404);
   }
 
   // Full update: the body carries invoice fields, not just a status.
@@ -136,7 +137,7 @@ export async function PATCH(
     const { clientName, clientEmail, issueDate, dueDate, lineItems, notes, status } = body;
     if (status !== undefined) {
       const err = validateTransition(current.status, status as InvoiceStatus);
-      if (err) return NextResponse.json({ error: err }, { status: 409 });
+      if (err) return errorResponse(err, 409);
     }
     // GST mode is driven by the live pricing settings (gstRegistered); the
     // request body does not carry gst. gstAmount is non-zero once that flag
@@ -172,11 +173,11 @@ export async function PATCH(
   // stamps/clears voidedAt so the detail page label stays in sync.
   const { status } = body;
   if (!["DRAFT", "SENT", "PAID", "VOIDED"].includes(status)) {
-    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    return errorResponse("Invalid status", 400);
   }
   const transitionErr = validateTransition(current.status, status as InvoiceStatus);
   if (transitionErr) {
-    return NextResponse.json({ error: transitionErr }, { status: 409 });
+    return errorResponse(transitionErr, 409);
   }
   const invoice = await prisma.invoice.update({
     where: { id },
@@ -199,7 +200,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -212,15 +213,12 @@ export async function DELETE(
     select: { status: true },
   });
   if (!existing) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    return errorResponse("Invoice not found", 404);
   }
   if (existing.status !== "DRAFT") {
-    return NextResponse.json(
-      {
-        error:
-          "Only DRAFT invoices can be deleted. Void the invoice instead to preserve the audit trail.",
-      },
-      { status: 409 },
+    return errorResponse(
+      "Only DRAFT invoices can be deleted. Void the invoice instead to preserve the audit trail.",
+      409,
     );
   }
   await prisma.invoice.delete({ where: { id } });

--- a/src/app/api/business/invoices/[id]/send-email/route.ts
+++ b/src/app/api/business/invoices/[id]/send-email/route.ts
@@ -3,6 +3,7 @@ import { getInvoiceReviewEligibility } from "@/features/business/lib/contact-rev
 import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
 import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import { sendInvoiceEmail } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSiteUrl } from "@/shared/lib/site-url";
@@ -25,17 +26,17 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   // Load the invoice
   const { id } = await ctx.params;
   const invoice = await prisma.invoice.findUnique({ where: { id } });
   if (!invoice) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    return errorResponse("Invoice not found", 404);
   }
   if (!invoice.clientEmail) {
-    return NextResponse.json({ error: "Invoice has no client email" }, { status: 400 });
+    return errorResponse("Invoice has no client email", 400);
   }
 
   // Optional operator overrides (match the preview): greetingName targets a
@@ -78,7 +79,7 @@ export async function POST(
     });
   } catch (err) {
     console.error(`[invoice-email] PDF generation failed for ${invoice.number}:`, err);
-    return NextResponse.json({ error: "PDF generation failed" }, { status: 500 });
+    return errorResponse("PDF generation failed", 500);
   }
 
   // Send the email
@@ -98,7 +99,7 @@ export async function POST(
     customBody,
   });
   if (!ok) {
-    return NextResponse.json({ error: "Email send failed" }, { status: 502 });
+    return errorResponse("Email send failed", 502);
   }
 
   // Stamp reviewLinkSentAt iff the review line was actually included. This is

--- a/src/app/api/business/invoices/[id]/void/route.ts
+++ b/src/app/api/business/invoices/[id]/void/route.ts
@@ -2,6 +2,7 @@
 import { uploadInvoicePdf } from "@/features/business/lib/google-drive";
 import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import { sendVoidNotification } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -25,14 +26,14 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   // Load the invoice
   const { id } = await ctx.params;
   const invoice = await prisma.invoice.findUnique({ where: { id } });
   if (!invoice) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    return errorResponse("Invoice not found", 404);
   }
 
   // Parse optional overrides

--- a/src/app/api/business/invoices/import-drive/route.ts
+++ b/src/app/api/business/invoices/import-drive/route.ts
@@ -1,4 +1,5 @@
 import { downloadDriveFile, searchAllInvoicePdfs } from "@/features/business/lib/google-drive";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -363,7 +364,7 @@ async function downloadAndParse(fileId: string): Promise<{ data: ParsedInvoiceDa
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -462,6 +463,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, created, skipped, updated, errors });
   } catch (err) {
     console.error("[import-drive] failed:", err);
-    return NextResponse.json({ error: "Import failed" }, { status: 503 });
+    return errorResponse("Import failed", 503);
   }
 }

--- a/src/app/api/business/invoices/preview-pdf/route.ts
+++ b/src/app/api/business/invoices/preview-pdf/route.ts
@@ -1,8 +1,9 @@
 // src/app/api/business/invoices/preview-pdf/route.ts
 import { generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import type { Invoice, LineItem } from "@/features/business/types/business";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;
@@ -33,12 +34,12 @@ interface PreviewPayload {
  */
 export async function POST(request: NextRequest): Promise<Response> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = (await request.json()) as PreviewPayload;
   if (!body.number || !body.clientName) {
-    return NextResponse.json({ error: "number and clientName are required" }, { status: 400 });
+    return errorResponse("number and clientName are required", 400);
   }
 
   // Build the minimum Invoice shape generateInvoicePdf needs. Status is

--- a/src/app/api/business/invoices/route.ts
+++ b/src/app/api/business/invoices/route.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/business/lib/invoice-numbering";
 import { extractYearCode, generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { getIdentity } from "@/shared/lib/business-identity.server";
 import { prisma } from "@/shared/lib/prisma";
@@ -18,7 +19,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const invoices = await prisma.invoice.findMany({ orderBy: { issueDate: "desc" } });
@@ -32,7 +33,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = await request.json();
@@ -66,7 +67,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   };
 
   if (!clientName || !clientEmail || !Array.isArray(lineItems)) {
-    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    return errorResponse("Missing required fields", 400);
   }
 
   // Default issue + due dates server-side so the calculator's direct-save path

--- a/src/app/api/business/invoices/sync-drive/route.ts
+++ b/src/app/api/business/invoices/sync-drive/route.ts
@@ -1,4 +1,5 @@
 import { searchAllInvoicePdfs } from "@/features/business/lib/google-drive";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -34,7 +35,7 @@ function extractCandidates(filename: string): string[] {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -74,6 +75,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
   } catch (err) {
     console.error("[sync-drive] failed:", err);
-    return NextResponse.json({ error: "Sync failed" }, { status: 503 });
+    return errorResponse("Sync failed", 503);
   }
 }

--- a/src/app/api/business/job-context/route.ts
+++ b/src/app/api/business/job-context/route.ts
@@ -9,6 +9,7 @@
 
 import { lookupPublicHoliday } from "@/features/business/lib/pricing-policy.server";
 import { resolvePromoForDate, type ActivePromo } from "@/features/business/lib/promos";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { getSettings } from "@/shared/lib/settings/get-settings";
 import { NextRequest, NextResponse } from "next/server";
@@ -29,12 +30,12 @@ interface JobContextResponse {
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const dateStr = request.nextUrl.searchParams.get("date");
   if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
-    return NextResponse.json({ error: "date (YYYY-MM-DD) is required" }, { status: 400 });
+    return errorResponse("date (YYYY-MM-DD) is required", 400);
   }
 
   // Pin to NZ midday so the holiday/promo lookups land on the intended NZ day

--- a/src/app/api/business/parse-job/route.ts
+++ b/src/app/api/business/parse-job/route.ts
@@ -11,6 +11,7 @@ import type {
   ParsedRange,
   RateConfig,
 } from "@/features/business/types/business";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
@@ -156,7 +157,7 @@ function findTemplateByTags<T extends { device: string | null; action: string | 
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   // Parse and validate body
@@ -164,10 +165,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { input, answers } = body as { input: unknown; answers?: Record<string, unknown> };
 
   if (!input || typeof input !== "string" || input.trim().length === 0) {
-    return NextResponse.json({ error: "input is required" }, { status: 400 });
+    return errorResponse("input is required", 400);
   }
   if (input.length > 1000) {
-    return NextResponse.json({ error: "input must be 1000 characters or fewer" }, { status: 400 });
+    return errorResponse("input must be 1000 characters or fewer", 400);
   }
 
   // Whitelist the clarification answer keys to the IDs the model is allowed to
@@ -442,6 +443,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, result: parsed });
   } catch (err) {
     console.error("[parse-job] failed:", err);
-    return NextResponse.json({ error: "Could not parse job description" }, { status: 422 });
+    return errorResponse("Could not parse job description", 422);
   }
 }

--- a/src/app/api/business/parse-job/route.ts
+++ b/src/app/api/business/parse-job/route.ts
@@ -26,8 +26,12 @@ interface RangeWithDuration extends ParsedRange {
   durationMins: number;
 }
 
+// Two times on one line, captured as start/end. The separator is forgiving so
+// the operator does not have to type a dash: a dash (-/–/—), the word "to", or
+// just whitespace all split the pair. Regex backtracking lets the bare-space
+// case work even though each time captures an optional trailing meridiem.
 const TIME_RANGE_RE =
-  /(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)\s*[-–—]\s*(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)/gi;
+  /(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)(?:\s*[-–—]\s*|\s+to\s+|\s+)(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)/gi;
 
 type Meridiem = "am" | "pm" | null;
 
@@ -76,9 +80,10 @@ function minsToHHMM(mins: number): string {
 }
 
 /**
- * Extracts every HH:MM-HH:MM segment found on digit-led lines. Used internally
- * to compute the worked-minutes hint passed to the AI as a "pre-computed
- * session total" annotation.
+ * Extracts every start/end time segment found on digit-led lines, accepting a
+ * dash, "to", or plain whitespace between the two times. Used internally to
+ * compute the worked-minutes hint passed to the AI as a "pre-computed session
+ * total" annotation.
  * @param input - Raw job description text.
  * @returns Array of parsed time ranges (may be empty when nothing detected).
  */

--- a/src/app/api/business/promos/[id]/route.ts
+++ b/src/app/api/business/promos/[id]/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/business/promos/[id]/route.ts
 import { ACTIVE_PROMO_TAG } from "@/features/business/lib/promos";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { revalidateTag } from "next/cache";
@@ -17,7 +18,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const { id } = await params;
   const body = (await request.json()) as Partial<{
@@ -47,7 +48,7 @@ export async function PATCH(
     revalidateTag(ACTIVE_PROMO_TAG, "default");
     return NextResponse.json({ ok: true, promo });
   } catch {
-    return NextResponse.json({ error: "Promo not found" }, { status: 404 });
+    return errorResponse("Promo not found", 404);
   }
 }
 
@@ -63,7 +64,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const { id } = await params;
   try {
@@ -72,6 +73,6 @@ export async function DELETE(
     revalidateTag(ACTIVE_PROMO_TAG, "default");
     return NextResponse.json({ ok: true });
   } catch {
-    return NextResponse.json({ error: "Promo not found" }, { status: 404 });
+    return errorResponse("Promo not found", 404);
   }
 }

--- a/src/app/api/business/promos/route.ts
+++ b/src/app/api/business/promos/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/business/promos/route.ts
 import { ACTIVE_PROMO_TAG } from "@/features/business/lib/promos";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { revalidateTag } from "next/cache";
@@ -44,7 +45,7 @@ function validatePromo(body: PromoBody): string | null {
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const promos = await prisma.promo.findMany({ orderBy: { startAt: "desc" } });
   return NextResponse.json({ ok: true, promos });
@@ -57,11 +58,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const body = (await request.json()) as PromoBody;
   const err = validatePromo(body);
-  if (err) return NextResponse.json({ error: err }, { status: 400 });
+  if (err) return errorResponse(err, 400);
 
   const promo = await prisma.promo.create({
     data: {

--- a/src/app/api/business/rates/[id]/route.ts
+++ b/src/app/api/business/rates/[id]/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -14,7 +15,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -40,7 +41,7 @@ export async function PATCH(
     });
     return NextResponse.json({ ok: true, rate });
   } catch {
-    return NextResponse.json({ error: "Rate not found" }, { status: 404 });
+    return errorResponse("Rate not found", 404);
   }
 }
 
@@ -56,19 +57,19 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
   const count = await prisma.rateConfig.count();
   if (count <= 1) {
-    return NextResponse.json({ error: "Cannot delete the only rate" }, { status: 400 });
+    return errorResponse("Cannot delete the only rate", 400);
   }
 
   try {
     await prisma.rateConfig.delete({ where: { id } });
     return NextResponse.json({ ok: true });
   } catch {
-    return NextResponse.json({ error: "Rate not found" }, { status: 404 });
+    return errorResponse("Rate not found", 404);
   }
 }

--- a/src/app/api/business/rates/route.ts
+++ b/src/app/api/business/rates/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -64,7 +65,7 @@ const DEFAULTS = [
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const existing = await prisma.rateConfig.findMany({ select: { label: true } });
@@ -107,14 +108,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = await request.json();
   const { label, ratePerHour, flatRate, hourlyDelta, percentDelta, unit, isDefault } = body;
 
   if (!label || typeof label !== "string") {
-    return NextResponse.json({ error: "label is required" }, { status: 400 });
+    return errorResponse("label is required", 400);
   }
 
   if (isDefault) {
@@ -144,7 +145,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
  */
 export async function DELETE(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   await prisma.rateConfig.deleteMany({});
   await prisma.rateConfig.createMany({ data: DEFAULTS });

--- a/src/app/api/business/sheets/import/route.ts
+++ b/src/app/api/business/sheets/import/route.ts
@@ -1,4 +1,5 @@
 import { runSheetsImport } from "@/features/business/lib/sheets-import";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -12,14 +13,14 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   try {
     const result = await runSheetsImport(true);
     return NextResponse.json(result);
   } catch (err) {
     console.error("[sheets/import] GET failed:", err);
-    return NextResponse.json({ error: "Sheet read failed" }, { status: 503 });
+    return errorResponse("Sheet read failed", 503);
   }
 }
 
@@ -30,13 +31,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   try {
     const result = await runSheetsImport(false);
     return NextResponse.json(result, { status: 201 });
   } catch (err) {
     console.error("[sheets/import] POST failed:", err);
-    return NextResponse.json({ error: "Import failed" }, { status: 503 });
+    return errorResponse("Import failed", 503);
   }
 }

--- a/src/app/api/business/sheets/invoice-counter/route.ts
+++ b/src/app/api/business/sheets/invoice-counter/route.ts
@@ -1,4 +1,5 @@
 import { getInvoiceCounter, setInvoiceCounter } from "@/features/business/lib/google-sheets";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -12,14 +13,14 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   try {
     const data = await getInvoiceCounter();
     return NextResponse.json({ ok: true, ...data });
   } catch (err) {
     console.error("[sheets/invoice-counter] GET failed:", err);
-    return NextResponse.json({ error: "Sheet unavailable" }, { status: 503 });
+    return errorResponse("Sheet unavailable", 503);
   }
 }
 
@@ -30,7 +31,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   try {
     const body = await request.json();
@@ -45,6 +46,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, written: newCount });
   } catch (err) {
     console.error("[sheets/invoice-counter] POST failed:", err);
-    return NextResponse.json({ error: "Sheet write failed" }, { status: 503 });
+    return errorResponse("Sheet write failed", 503);
   }
 }

--- a/src/app/api/business/subscriptions/[id]/record/route.ts
+++ b/src/app/api/business/subscriptions/[id]/record/route.ts
@@ -4,6 +4,7 @@ import {
   formatUTCDDMMYYYY,
 } from "@/features/business/lib/business";
 import { getSheetId, getSheetsClient } from "@/features/business/lib/google-sheets";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -21,14 +22,14 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
 
   const sub = await prisma.subscription.findUnique({ where: { id } });
   if (!sub) {
-    return NextResponse.json({ error: "Subscription not found" }, { status: 404 });
+    return errorResponse("Subscription not found", 404);
   }
 
   const today = new Date();

--- a/src/app/api/business/subscriptions/[id]/route.ts
+++ b/src/app/api/business/subscriptions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { VALID_FREQUENCIES } from "@/features/business/lib/constants";
 import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -16,7 +17,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -35,14 +36,14 @@ export async function PATCH(
   } = body;
 
   if (frequency && !(VALID_FREQUENCIES as readonly string[]).includes(frequency)) {
-    return NextResponse.json({ error: "Invalid frequency" }, { status: 400 });
+    return errorResponse("Invalid frequency", 400);
   }
 
   let safeAmount: number | undefined;
   if (amountIncl !== undefined) {
     const parsed = parseAmount(amountIncl);
     if (parsed === null) {
-      return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+      return errorResponse("Invalid amount", 400);
     }
     safeAmount = parsed;
   }
@@ -51,7 +52,7 @@ export async function PATCH(
   if (gstRate !== undefined) {
     const parsed = parseRate(gstRate);
     if (parsed === null) {
-      return NextResponse.json({ error: "Invalid GST rate" }, { status: 400 });
+      return errorResponse("Invalid GST rate", 400);
     }
     safeRate = parsed;
   }
@@ -87,7 +88,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;

--- a/src/app/api/business/subscriptions/route.ts
+++ b/src/app/api/business/subscriptions/route.ts
@@ -1,5 +1,6 @@
 import { VALID_FREQUENCIES } from "@/features/business/lib/constants";
 import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -11,7 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   const subscriptions = await prisma.subscription.findMany({
     orderBy: { nextDue: "asc" },
@@ -26,7 +27,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = await request.json();
@@ -43,19 +44,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   } = body;
 
   if (!description || !supplier || amountIncl === undefined || !frequency || !nextDue) {
-    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    return errorResponse("Missing required fields", 400);
   }
   if (!VALID_FREQUENCIES.includes(frequency)) {
-    return NextResponse.json({ error: "Invalid frequency" }, { status: 400 });
+    return errorResponse("Invalid frequency", 400);
   }
 
   const safeAmount = parseAmount(amountIncl);
   if (safeAmount === null) {
-    return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+    return errorResponse("Invalid amount", 400);
   }
   const safeRate = gstRate === undefined ? 0.15 : parseRate(gstRate);
   if (safeRate === null) {
-    return NextResponse.json({ error: "Invalid GST rate" }, { status: 400 });
+    return errorResponse("Invalid GST rate", 400);
   }
 
   const subscription = await prisma.subscription.create({

--- a/src/app/api/business/summary/route.ts
+++ b/src/app/api/business/summary/route.ts
@@ -1,4 +1,5 @@
 import { aggregateByFinancialYear } from "@/features/business/lib/financial-year";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { getIdentity } from "@/shared/lib/business-identity.server";
 import { prisma } from "@/shared/lib/prisma";
@@ -13,7 +14,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const now = new Date();

--- a/src/app/api/business/task-templates/[id]/route.ts
+++ b/src/app/api/business/task-templates/[id]/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -14,7 +15,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { id } = await params;
@@ -23,6 +24,6 @@ export async function DELETE(
     await prisma.taskTemplate.delete({ where: { id } });
     return NextResponse.json({ ok: true });
   } catch {
-    return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    return errorResponse("Template not found", 404);
   }
 }

--- a/src/app/api/business/task-templates/actions/[name]/route.ts
+++ b/src/app/api/business/task-templates/actions/[name]/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -17,13 +18,13 @@ export async function DELETE(
   { params }: { params: Promise<{ name: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { name } = await params;
   const decoded = decodeURIComponent(name).trim();
   if (!decoded) {
-    return NextResponse.json({ error: "name is required" }, { status: 400 });
+    return errorResponse("name is required", 400);
   }
 
   const result = await prisma.taskTemplate.updateMany({

--- a/src/app/api/business/task-templates/devices/[name]/route.ts
+++ b/src/app/api/business/task-templates/devices/[name]/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -16,13 +17,13 @@ export async function DELETE(
   { params }: { params: Promise<{ name: string }> },
 ): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const { name } = await params;
   const decoded = decodeURIComponent(name).trim();
   if (!decoded) {
-    return NextResponse.json({ error: "name is required" }, { status: 400 });
+    return errorResponse("name is required", 400);
   }
 
   const result = await prisma.taskTemplate.updateMany({

--- a/src/app/api/business/task-templates/route.ts
+++ b/src/app/api/business/task-templates/route.ts
@@ -1,4 +1,5 @@
 import { composeDescription } from "@/features/business/lib/business";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -27,7 +28,7 @@ function normaliseTag(raw: unknown): string | null {
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const templates = await prisma.taskTemplate.findMany({
@@ -48,7 +49,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const body = await request.json();
@@ -60,7 +61,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   };
 
   if (typeof defaultPrice !== "number" || isNaN(defaultPrice)) {
-    return NextResponse.json({ error: "defaultPrice is required" }, { status: 400 });
+    return errorResponse("defaultPrice is required", 400);
   }
 
   const normDevice = normaliseTag(device);

--- a/src/app/api/business/task-templates/taxonomy/route.ts
+++ b/src/app/api/business/task-templates/taxonomy/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -12,7 +13,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   // Pull just the two columns needed; cheaper than fetching the whole table.

--- a/src/app/api/cron/purge-price-estimates/route.ts
+++ b/src/app/api/cron/purge-price-estimates/route.ts
@@ -5,6 +5,7 @@
  * Called externally via cron-job.org (daily cadence).
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
@@ -21,7 +22,7 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {

--- a/src/app/api/cron/record-subscriptions/route.ts
+++ b/src/app/api/cron/record-subscriptions/route.ts
@@ -4,6 +4,7 @@ import {
   formatUTCDDMMYYYY,
 } from "@/features/business/lib/business";
 import { getSheetId, getSheetsClient } from "@/features/business/lib/google-sheets";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -20,7 +21,7 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   // nextDue is stored as UTC midnight (admin form + advanceNextDue), so UTC

--- a/src/app/api/cron/refresh-calendar-cache/route.ts
+++ b/src/app/api/cron/refresh-calendar-cache/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { refreshCalendarCache } from "@/features/calendar/lib/calendar-cache";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -20,7 +21,7 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {

--- a/src/app/api/cron/refresh-public-holidays/route.ts
+++ b/src/app/api/cron/refresh-public-holidays/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { HOME_REGION, NZ_REGION } from "@/features/business/lib/pricing-policy";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { google } from "googleapis";
@@ -40,7 +41,7 @@ function regionFor(description: string | null | undefined): string | null {
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   const apiKey = process.env.GOOGLE_MAPS_SERVER_KEY ?? process.env.GOOGLE_MAPS_API_KEY;

--- a/src/app/api/cron/release-holds/route.ts
+++ b/src/app/api/cron/release-holds/route.ts
@@ -5,6 +5,7 @@
  * Called externally via cron-job.org every 15 minutes.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
@@ -20,7 +21,7 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -53,6 +54,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
   } catch (error) {
     console.error("[cron/release-holds] Error:", error);
-    return NextResponse.json({ ok: false, error: "Failed to release holds" }, { status: 500 });
+    return errorResponse("Failed to release holds", 500);
   }
 }

--- a/src/app/api/cron/send-booking-reminders/route.ts
+++ b/src/app/api/cron/send-booking-reminders/route.ts
@@ -12,6 +12,7 @@
 
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
 import { sendBookingReminderEmail } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
@@ -27,7 +28,7 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {

--- a/src/app/api/cron/send-review-emails/route.ts
+++ b/src/app/api/cron/send-review-emails/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { sendCustomerReviewRequest } from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
 import { getSettings } from "@/shared/lib/settings/get-settings";
@@ -23,7 +24,7 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
 
   try {
@@ -157,6 +158,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
   } catch (error) {
     console.error("[review-email] Cron error:", error);
-    return NextResponse.json({ ok: false, error: "Failed to send review emails" }, { status: 500 });
+    return errorResponse("Failed to send review emails", 500);
   }
 }

--- a/src/app/api/cron/sync-sheets/route.ts
+++ b/src/app/api/cron/sync-sheets/route.ts
@@ -1,4 +1,5 @@
 import { runSheetsImport } from "@/features/business/lib/sheets-import";
+import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -14,13 +15,13 @@ export const maxDuration = 60;
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return errorResponse("Unauthorized", 401);
   }
   try {
     const result = await runSheetsImport(false);
     return NextResponse.json(result);
   } catch (err) {
     console.error("[cron/sync-sheets] failed:", err);
-    return NextResponse.json({ error: "Sync failed" }, { status: 503 });
+    return errorResponse("Sync failed", 503);
   }
 }

--- a/src/app/api/pricing/estimate-duration/route.ts
+++ b/src/app/api/pricing/estimate-duration/route.ts
@@ -1,4 +1,5 @@
 import { getPublicPricing } from "@/features/business/lib/pricing-policy.server";
+import { errorResponse } from "@/shared/lib/api-response";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { getSettings } from "@/shared/lib/settings/get-settings";
 import type { Benchmark } from "@/shared/lib/settings/types";
@@ -125,7 +126,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const description = (body as { description?: unknown })?.description;
 
   if (!description || typeof description !== "string" || !description.trim()) {
-    return NextResponse.json({ error: "description is required" }, { status: 400 });
+    return errorResponse("description is required", 400);
   }
 
   const trimmed = description.trim().slice(0, 500);
@@ -190,6 +191,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, result: parsed });
   } catch (err) {
     console.error("[estimate-duration] failed:", err);
-    return NextResponse.json({ error: "Could not estimate duration" }, { status: 422 });
+    return errorResponse("Could not estimate duration", 422);
   }
 }

--- a/src/app/api/pricing/log-estimate/route.ts
+++ b/src/app/api/pricing/log-estimate/route.ts
@@ -1,3 +1,4 @@
+import { errorResponse } from "@/shared/lib/api-response";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { AiEstimateCategory } from "@prisma/client";
@@ -54,12 +55,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (limited) return limited;
 
   const body = (await request.json().catch(() => null)) as LogBody | null;
-  if (!body) return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  if (!body) return errorResponse("invalid body", 400);
 
   // Sanitise the payload fields
   const description =
     typeof body.description === "string" ? body.description.trim().slice(0, 500) : "";
-  if (!description) return NextResponse.json({ error: "description required" }, { status: 400 });
+  if (!description) return errorResponse("description required", 400);
 
   const aiEstimatedMins = Math.max(0, Math.round(Number(body.aiEstimatedMins) || 0));
   // The "complex" tier was removed; every estimate logs as standard now. The
@@ -118,6 +119,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, id: created.id });
   } catch (err) {
     console.error("[log-estimate] failed:", err);
-    return NextResponse.json({ ok: false, error: "Could not log estimate" }, { status: 500 });
+    return errorResponse("Could not log estimate", 500);
   }
 }

--- a/src/app/api/pricing/travel-time/route.ts
+++ b/src/app/api/pricing/travel-time/route.ts
@@ -1,4 +1,5 @@
 import { lookupDriveDistance } from "@/features/business/lib/travel-distance";
+import { errorResponse } from "@/shared/lib/api-response";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -21,7 +22,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const raw = body.destination;
 
   if (!raw || typeof raw !== "string" || !raw.trim()) {
-    return NextResponse.json({ error: "destination is required" }, { status: 400 });
+    return errorResponse("destination is required", 400);
   }
 
   let departureTime: Date | undefined;

--- a/src/app/api/reviews/[id]/route.ts
+++ b/src/app/api/reviews/[id]/route.ts
@@ -4,6 +4,7 @@
  * @description PATCH /api/reviews/[id] - Allows a customer to edit their review (with valid customerRef), resets status to pending.
  */
 
+import { errorResponse } from "@/shared/lib/api-response";
 import { prisma } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { NextRequest, NextResponse } from "next/server";
@@ -99,6 +100,6 @@ export async function PATCH(
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
     console.error("[reviews] PATCH error:", error);
-    return NextResponse.json({ error: "Failed to update review." }, { status: 500 });
+    return errorResponse("Failed to update review.", 500);
   }
 }

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -6,6 +6,7 @@
 
 import { sendOwnerReviewNotification } from "@/features/reviews/lib/email";
 import { reviewTextError } from "@/features/reviews/lib/validation";
+import { errorResponse } from "@/shared/lib/api-response";
 import { normalisePhone } from "@/shared/lib/normalise-phone";
 import { prisma as prismaClient } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
@@ -83,7 +84,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const text = body.text?.trim() ?? "";
     const textErr = reviewTextError(text);
-    if (textErr) return NextResponse.json({ error: textErr }, { status: 400 });
+    if (textErr) return errorResponse(textErr, 400);
 
     const firstName = body.firstName?.trim() || null;
     const lastName = body.lastName?.trim() || null;
@@ -185,6 +186,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, id: review.id, verified }, { status: 201 });
   } catch (error) {
     console.error("[reviews] POST error:", error);
-    return NextResponse.json({ error: "Failed to submit review." }, { status: 500 });
+    return errorResponse("Failed to submit review.", 500);
   }
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -53,7 +53,7 @@ export default function ContactPage(): React.ReactElement {
               Get in touch
             </h1>
 
-            <p className={cn("mx-auto mb-8 max-w-2xl text-sm text-rich-black sm:text-base")}>
+            <p className={cn("mx-auto mb-8 max-w-2xl text-base text-rich-black sm:text-lg")}>
               Have a tech problem or question? Call or email and I'll help you figure it out.
             </p>
 
@@ -78,7 +78,7 @@ export default function ContactPage(): React.ReactElement {
               </Button>
             </div>
 
-            <p className={cn("mx-auto mt-6 max-w-xl text-sm text-rich-black/70 sm:text-base")}>
+            <p className={cn("mx-auto mt-6 max-w-xl text-base text-rich-black/70 sm:text-lg")}>
               I usually respond within a few hours during business days.
             </p>
           </section>
@@ -106,10 +106,10 @@ export default function ContactPage(): React.ReactElement {
                 >
                   Service area
                 </h2>
-                <p className={cn("mb-3 text-sm text-rich-black sm:text-base")}>
+                <p className={cn("mb-3 text-base text-rich-black sm:text-lg")}>
                   On-site visits across Auckland.
                 </p>
-                <p className={cn("text-sm text-rich-black/80 sm:text-base")}>
+                <p className={cn("text-base text-rich-black/80 sm:text-lg")}>
                   Remote support available for software and account issues. No travel needed.
                 </p>
               </div>
@@ -128,11 +128,11 @@ export default function ContactPage(): React.ReactElement {
               What to include when you contact me
             </h2>
 
-            <p className={cn("mb-4 text-sm text-rich-black sm:text-base")}>
+            <p className={cn("mb-4 text-base text-rich-black sm:text-lg")}>
               A few details help me give you a quick, accurate quote:
             </p>
 
-            <ul className={cn("space-y-2.5 text-sm text-rich-black sm:text-base")}>
+            <ul className={cn("space-y-2.5 text-base text-rich-black sm:text-lg")}>
               <li className={cn("flex gap-3")}>
                 <span className={cn("mt-1 text-lg text-moonstone-600")}>•</span>
                 <span>What's happening or what you want to achieve</span>
@@ -151,7 +151,7 @@ export default function ContactPage(): React.ReactElement {
               </li>
             </ul>
 
-            <p className={cn("mt-4 text-sm text-rich-black/80 sm:text-base")}>
+            <p className={cn("mt-4 text-base text-rich-black/80 sm:text-lg")}>
               Feel free to include screenshots or photos if they help explain the issue.
             </p>
           </section>
@@ -161,7 +161,7 @@ export default function ContactPage(): React.ReactElement {
             aria-label="Ready to get started"
             className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-300 text-center")}
           >
-            <p className={cn("mb-4 text-sm text-rich-black sm:text-base")}>
+            <p className={cn("mb-4 text-base text-rich-black sm:text-lg")}>
               Prefer to book directly?
             </p>
             <Button href="/booking" variant="primary" size="md">

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -324,7 +324,7 @@ export default async function FaqPage(): Promise<React.ReactElement> {
                       <details key={item.question} className={cn(SOFT_CARD, "group")}>
                         <summary
                           className={cn(
-                            "flex cursor-pointer items-center justify-between gap-3 text-sm font-semibold text-rich-black select-text sm:text-base",
+                            "flex cursor-pointer items-center justify-between gap-3 text-base font-semibold text-rich-black select-text sm:text-lg",
                             "list-none [&::-webkit-details-marker]:hidden",
                           )}
                         >
@@ -338,7 +338,7 @@ export default async function FaqPage(): Promise<React.ReactElement> {
                             ▾
                           </span>
                         </summary>
-                        <div className={cn("mt-3 text-sm text-rich-black/90 sm:text-base")}>
+                        <div className={cn("mt-3 text-base text-rich-black/90 sm:text-lg")}>
                           {item.answer}
                         </div>
                       </details>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -266,7 +266,7 @@ export default async function Home(): Promise<React.ReactElement> {
                   </span>
                   <span
                     className={cn(
-                      "line-clamp-2 text-left text-sm leading-tight font-medium text-rich-black sm:text-base",
+                      "line-clamp-2 text-left text-base leading-tight font-medium text-rich-black sm:text-lg",
                     )}
                   >
                     {label}
@@ -367,7 +367,7 @@ export default async function Home(): Promise<React.ReactElement> {
                 >
                   Know someone who needs tech help?
                 </h2>
-                <p className={cn("text-sm text-rich-black/80 sm:text-base")}>
+                <p className={cn("text-base text-rich-black/80 sm:text-lg")}>
                   Download this flyer to share with neighbours or pin to a noticeboard.
                 </p>
               </div>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -83,7 +83,7 @@ const ACCORDION_SUMMARY = cn(
   "[&::-webkit-details-marker]:hidden",
 );
 const ACCORDION_BODY = cn(
-  "text-rich-black/90 space-y-3 whitespace-pre-line px-5 pb-5 pt-1 text-sm sm:text-base",
+  "text-rich-black/90 space-y-3 whitespace-pre-line px-5 pb-5 pt-1 text-base sm:text-lg",
 );
 
 /**
@@ -118,7 +118,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
             >
               Pricing
             </h1>
-            <p className={cn("mb-4 text-sm text-rich-black sm:text-base")}>
+            <p className={cn("mb-4 text-base text-rich-black sm:text-lg")}>
               Simple, transparent pricing. You'll always know the cost before work begins, and
               there's no pressure to buy anything you don't need.
             </p>
@@ -139,7 +139,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                   <p className={cn("mb-2 text-3xl font-bold text-russian-violet sm:text-4xl")}>
                     ${applyPromoToHourlyRate(baseRate, promo).toFixed(0)}/hr
                   </p>
-                  <p className={cn("text-sm text-rich-black/80 sm:text-base")}>
+                  <p className={cn("text-base text-rich-black/80 sm:text-lg")}>
                     One rate for every job - troubleshooting, setup, software, tune-ups, Wi-Fi,
                     backups, data recovery, hardware repairs, and more.
                   </p>
@@ -150,11 +150,11 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                     "mt-4 rounded-lg bg-mustard-500 px-4 py-3 text-center text-russian-violet-500",
                   )}
                 >
-                  <p className={cn("text-sm font-bold sm:text-base")}>
+                  <p className={cn("text-base font-bold sm:text-lg")}>
                     ⚡ Limited offer: {promo.title}
                     {promo.description ? ` - ${promo.description}` : ""}
                   </p>
-                  <p className={cn("mt-1 text-sm text-russian-violet-500 sm:text-base")}>
+                  <p className={cn("mt-1 text-base text-russian-violet-500 sm:text-lg")}>
                     Until {formatDateShort(promo.endAt)}.
                   </p>
                 </div>
@@ -164,7 +164,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                 <p className={cn("mb-2 text-3xl font-bold text-russian-violet sm:text-4xl")}>
                   ${baseRate}/hr
                 </p>
-                <p className={cn("text-sm text-rich-black/80 sm:text-base")}>
+                <p className={cn("text-base text-rich-black/80 sm:text-lg")}>
                   One rate for every job - troubleshooting, setup, software, tune-ups, Wi-Fi,
                   backups, data recovery, hardware repairs, and more.
                 </p>
@@ -174,21 +174,21 @@ export default async function PricingPage(): Promise<React.ReactElement> {
             <GetEstimateButton />
 
             <div className={cn("mt-5 space-y-3")}>
-              <p className={cn("flex gap-3 text-sm text-rich-black/90 sm:text-base")}>
+              <p className={cn("flex gap-3 text-base text-rich-black/90 sm:text-lg")}>
                 <FaCheck className={cn("mt-1.5 h-4 w-4 shrink-0 text-moonstone-600")} aria-hidden />
                 <span>
                   <strong>Quick calls and emails are free.</strong> A "remote session" is when I log
                   in and start working on your machine.
                 </span>
               </p>
-              <p className={cn("flex gap-3 text-sm text-rich-black/90 sm:text-base")}>
+              <p className={cn("flex gap-3 text-base text-rich-black/90 sm:text-lg")}>
                 <FaCheck className={cn("mt-1.5 h-4 w-4 shrink-0 text-moonstone-600")} aria-hidden />
                 <span>
                   <strong>Most jobs take 1 to 2 hours.</strong> I'll give you a time estimate before
                   we start.
                 </span>
               </p>
-              <p className={cn("flex gap-3 text-sm text-rich-black/90 sm:text-base")}>
+              <p className={cn("flex gap-3 text-base text-rich-black/90 sm:text-lg")}>
                 <FaCheck className={cn("mt-1.5 h-4 w-4 shrink-0 text-moonstone-600")} aria-hidden />
                 <span>
                   <strong>Not sure which rate applies?</strong> Just ask - I'll confirm before
@@ -211,7 +211,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                 <h3 className={cn("mb-3 text-lg font-semibold text-russian-violet sm:text-xl")}>
                   On-site visits
                 </h3>
-                <ul className={cn("space-y-2.5 text-sm text-rich-black sm:text-base")}>
+                <ul className={cn("space-y-2.5 text-base text-rich-black sm:text-lg")}>
                   <li className={cn("flex gap-3")}>
                     <span className={cn("mt-1 text-lg text-moonstone-600")}>•</span>
                     <span>Hourly rate (${baseRate}/hr)</span>
@@ -238,7 +238,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                 <h3 className={cn("mb-3 text-lg font-semibold text-russian-violet sm:text-xl")}>
                   Remote support
                 </h3>
-                <ul className={cn("space-y-2.5 text-sm text-rich-black sm:text-base")}>
+                <ul className={cn("space-y-2.5 text-base text-rich-black sm:text-lg")}>
                   <li className={cn("flex gap-3")}>
                     <span className={cn("mt-1 text-lg text-moonstone-600")}>•</span>
                     <span>Discounted rate, no travel charge</span>
@@ -270,7 +270,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
               No surprises
             </h2>
 
-            <ul className={cn("mb-5 space-y-2.5 text-sm text-rich-black sm:text-base")}>
+            <ul className={cn("mb-5 space-y-2.5 text-base text-rich-black sm:text-lg")}>
               <li className={cn("flex gap-3")}>
                 <span className={cn("mt-1 text-lg text-moonstone-600")}>•</span>
                 <span>
@@ -296,7 +296,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
             <h3 className={cn("mb-3 text-lg font-bold text-russian-violet sm:text-xl")}>
               Full details
             </h3>
-            <p className={cn("mb-4 text-sm text-rich-black/70 sm:text-base")}>
+            <p className={cn("mb-4 text-base text-rich-black/70 sm:text-lg")}>
               The fine print, in plain English. Click any section to expand.
             </p>
 
@@ -413,7 +413,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
             aria-label="Next steps"
             className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-400")}
           >
-            <p className={cn("text-sm text-rich-black sm:text-base")}>
+            <p className={cn("text-base text-rich-black sm:text-lg")}>
               <Link href="/contact" className={linkStyle}>
                 Get in touch
               </Link>{" "}
@@ -435,7 +435,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
             >
               Get a rough estimate
             </h2>
-            <p className={cn("mb-5 text-sm text-rich-black/70 sm:text-base")}>
+            <p className={cn("mb-5 text-base text-rich-black/70 sm:text-lg")}>
               Answer a few quick questions to get a price range. No commitment required.
             </p>
             <PricingWizard
@@ -446,7 +446,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
           </section>
 
           {pricing.ratesUpdatedAt && (
-            <p className={cn("text-center text-xs text-rich-black/50 sm:text-sm")}>
+            <p className={cn("text-center text-sm text-rich-black/50 sm:text-base")}>
               Rates last updated on {formatDateShort(pricing.ratesUpdatedAt)}.
             </p>
           )}

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -149,7 +149,7 @@ export default async function ReviewsPage(): Promise<React.ReactElement> {
             aria-label="Leave a review"
             className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-200")}
           >
-            <p className={cn("text-sm text-rich-black sm:text-base")}>
+            <p className={cn("text-base text-rich-black sm:text-lg")}>
               Had an appointment? You'll receive a review link by email after your visit. Or{" "}
               <Link href="/booking" className={linkStyle}>
                 book now

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -171,12 +171,12 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
               Services
             </h1>
 
-            <p className={cn("mb-4 text-sm text-rich-black sm:text-base")}>
+            <p className={cn("mb-4 text-base text-rich-black sm:text-lg")}>
               I help with the everyday tech problems no matter how big or small. The goal is to get
               things working reliably and leave you with a setup you understand.
             </p>
 
-            <p className={cn("text-sm text-rich-black/90 sm:text-base")}>
+            <p className={cn("text-base text-rich-black/90 sm:text-lg")}>
               Every job includes clear explanations, and I can leave notes so you know what changed
               and how to handle things next time.
             </p>
@@ -217,7 +217,7 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
                       {area.label}
                     </h3>
                   </div>
-                  <ul className={cn("space-y-1 text-sm text-rich-black/80 sm:text-base")}>
+                  <ul className={cn("space-y-1 text-base text-rich-black/80 sm:text-lg")}>
                     {area.examples.map((example) => (
                       <li key={example} className={cn("flex gap-2")}>
                         <span className={cn("mt-0.5 text-moonstone-600")}>•</span>
@@ -229,7 +229,7 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
               ))}
             </div>
 
-            <p className={cn("mt-6 text-sm text-rich-black/90 sm:text-base")}>
+            <p className={cn("mt-6 text-base text-rich-black/90 sm:text-lg")}>
               Not sure which category your problem fits? That's fine. Just describe what's happening
               and I'll figure out the best approach.
             </p>
@@ -247,11 +247,11 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
                 For home users
               </h2>
 
-              <p className={cn("mb-3 text-sm text-rich-black sm:text-base")}>
+              <p className={cn("mb-3 text-base text-rich-black sm:text-lg")}>
                 Common home visits include:
               </p>
 
-              <ul className={cn("space-y-2 text-sm text-rich-black/90 sm:text-base")}>
+              <ul className={cn("space-y-2 text-base text-rich-black/90 sm:text-lg")}>
                 <li className={cn("flex gap-2")}>
                   <span className={cn("mt-1 text-moonstone-600")}>•</span>
                   <span>Setting up a new laptop, phone, or tablet with all your accounts</span>
@@ -290,11 +290,11 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
                 For small businesses
               </h2>
 
-              <p className={cn("mb-3 text-sm text-rich-black sm:text-base")}>
+              <p className={cn("mb-3 text-base text-rich-black sm:text-lg")}>
                 Light IT support for sole traders and small teams:
               </p>
 
-              <ul className={cn("space-y-2 text-sm text-rich-black/90 sm:text-base")}>
+              <ul className={cn("space-y-2 text-base text-rich-black/90 sm:text-lg")}>
                 <li className={cn("flex gap-2")}>
                   <span className={cn("mt-1 text-moonstone-600")}>•</span>
                   <span>Setting up workstations, email, and shared files</span>
@@ -317,7 +317,7 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
                 </li>
               </ul>
 
-              <p className={cn("mt-3 text-sm text-rich-black/90 sm:text-base")}>
+              <p className={cn("mt-3 text-base text-rich-black/90 sm:text-lg")}>
                 No ongoing contracts required. You call when you need help.
               </p>
             </section>
@@ -327,7 +327,7 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
             aria-label="Next steps"
             className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-400 text-center")}
           >
-            <p className={cn("mb-4 text-sm text-rich-black sm:text-base")}>Ready to get started?</p>
+            <p className={cn("mb-4 text-base text-rich-black sm:text-lg")}>Ready to get started?</p>
             <div className={cn("flex flex-wrap items-center justify-center gap-3")}>
               <Button href="/pricing" variant="ghost" size="md">
                 View pricing

--- a/src/features/admin/components/ContactAdminList.tsx
+++ b/src/features/admin/components/ContactAdminList.tsx
@@ -15,7 +15,7 @@ import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
 import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
-import { validatePhone } from "@/shared/lib/normalise-phone";
+import { formatNZPhone, validatePhone } from "@/shared/lib/normalise-phone";
 import type React from "react";
 import { useEffect, useState } from "react";
 
@@ -254,7 +254,7 @@ function ContactCard({
                 <div className={cn("space-y-0.5 text-slate-500")}>
                   <p>{c.name}</p>
                   {c.email && <p>{c.email}</p>}
-                  {c.phone && <p>{c.phone}</p>}
+                  {c.phone && <p>{formatNZPhone(c.phone)}</p>}
                   {c.address && <p>{c.address}</p>}
                 </div>
                 <div className={cn("flex gap-2")}>
@@ -316,7 +316,7 @@ function ContactCard({
           href={`tel:${c.phone}`}
           className={cn("text-sm text-slate-500 transition-colors hover:text-slate-700")}
         >
-          {c.phone}
+          {formatNZPhone(c.phone)}
         </a>
       )}
       {c.address && <p className={cn("text-sm wrap-break-word text-slate-500")}>{c.address}</p>}

--- a/src/features/admin/components/ContactConflictsView.tsx
+++ b/src/features/admin/components/ContactConflictsView.tsx
@@ -9,6 +9,7 @@
  */
 
 import { cn } from "@/shared/lib/cn";
+import { formatDateTimeShort } from "@/shared/lib/date-format";
 import Link from "next/link";
 import type React from "react";
 import { useState } from "react";
@@ -172,7 +173,7 @@ export function ContactConflictsView({ initial }: ContactConflictsViewProps): Re
 
               {err && <p className={cn("mt-3 text-xs text-coquelicot-500")}>{err}</p>}
               <p className={cn("mt-3 text-xs text-slate-400")}>
-                Detected {new Date(c.createdAt).toLocaleString()}
+                Detected {formatDateTimeShort(c.createdAt)}
               </p>
             </li>
           );

--- a/src/features/admin/components/ManualBookingModal.tsx
+++ b/src/features/admin/components/ManualBookingModal.tsx
@@ -13,7 +13,9 @@ import {
   splitUnitFromAddress,
   validateEmail,
 } from "@/features/booking/lib/booking";
+import { Button } from "@/shared/components/Button";
 import { EmailInput } from "@/shared/components/EmailInput";
+import { Field } from "@/shared/components/Field";
 import { PhoneInput } from "@/shared/components/PhoneInput";
 import { cn } from "@/shared/lib/cn";
 import { formatNZPhone, validatePhone } from "@/shared/lib/normalise-phone";
@@ -201,7 +203,7 @@ export function ManualBookingModal({
 
         <form onSubmit={handleSubmit} className={cn("space-y-4 px-5 py-5")}>
           <div className={cn("grid grid-cols-2 gap-3")}>
-            <Field label="Start" htmlFor="mb-start">
+            <Field label="Start" htmlFor="mb-start" required>
               <input
                 id="mb-start"
                 type="datetime-local"
@@ -224,7 +226,7 @@ export function ManualBookingModal({
             </Field>
           </div>
 
-          <Field label="Customer name" htmlFor="mb-name">
+          <Field label="Customer name" htmlFor="mb-name" required>
             <div
               ref={nameWrapRef}
               className={cn("relative")}
@@ -309,10 +311,10 @@ export function ManualBookingModal({
           </Field>
 
           <div className={cn("grid grid-cols-2 gap-3")}>
-            <Field label="Phone" htmlFor="mb-phone">
+            <Field label="Phone" htmlFor="mb-phone" optional>
               <PhoneInput id="mb-phone" value={phone} onChange={setPhone} />
             </Field>
-            <Field label="Email" htmlFor="mb-email">
+            <Field label="Email" htmlFor="mb-email" required>
               <EmailInput
                 id="mb-email"
                 value={email}
@@ -324,7 +326,7 @@ export function ManualBookingModal({
           </div>
 
           <div className={cn("grid grid-cols-3 gap-3")}>
-            <Field label="Apt / Unit" htmlFor="mb-unit">
+            <Field label="Apt / Unit" htmlFor="mb-unit" optional>
               <input
                 id="mb-unit"
                 type="text"
@@ -337,7 +339,7 @@ export function ManualBookingModal({
               />
             </Field>
             <div className={cn("col-span-2")}>
-              <Field label="Address" htmlFor="mb-address">
+              <Field label="Address" htmlFor="mb-address" optional>
                 <AddressAutocomplete
                   id="mb-address"
                   value={address}
@@ -349,7 +351,7 @@ export function ManualBookingModal({
             </div>
           </div>
 
-          <Field label="Notes" htmlFor="mb-notes">
+          <Field label="Notes" htmlFor="mb-notes" optional>
             <textarea
               id="mb-notes"
               value={notes}
@@ -382,53 +384,15 @@ export function ManualBookingModal({
           )}
 
           <div className={cn("flex justify-end gap-2 pt-2")}>
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={submitting}
-              className={cn(
-                "rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50",
-              )}
-            >
+            <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={submitting}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={submitting}
-              className={cn(
-                "rounded-md bg-russian-violet px-4 py-2 text-sm font-semibold text-white hover:bg-russian-violet/90 disabled:opacity-50",
-              )}
-            >
+            </Button>
+            <Button type="submit" variant="secondary" size="sm" disabled={submitting}>
               {submitting ? "Saving..." : "Create booking"}
-            </button>
+            </Button>
           </div>
         </form>
       </div>
-    </div>
-  );
-}
-
-interface FieldProps {
-  label: string;
-  htmlFor: string;
-  children: React.ReactNode;
-}
-
-/**
- * Renders a labelled form field with consistent spacing.
- * @param props - Field props.
- * @param props.label - Visible label text.
- * @param props.htmlFor - Input id the label associates with.
- * @param props.children - Field input element(s).
- * @returns Labelled field element.
- */
-function Field({ label, htmlFor, children }: FieldProps): React.ReactElement {
-  return (
-    <div>
-      <label htmlFor={htmlFor} className={cn("mb-1 block text-xs font-semibold text-slate-600")}>
-        {label}
-      </label>
-      {children}
     </div>
   );
 }

--- a/src/features/admin/components/ManualBookingModal.tsx
+++ b/src/features/admin/components/ManualBookingModal.tsx
@@ -8,7 +8,11 @@
  */
 
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
-import { validateEmail } from "@/features/booking/lib/booking";
+import {
+  combineUnitAndAddress,
+  splitUnitFromAddress,
+  validateEmail,
+} from "@/features/booking/lib/booking";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
 import { cn } from "@/shared/lib/cn";
@@ -52,6 +56,10 @@ export function ManualBookingModal({
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
+  // Unit kept separate from the street address, same as the public booking form:
+  // Google Places autocomplete predicts the street but rarely the apartment/unit,
+  // so without its own box the unit gets lost.
+  const [unit, setUnit] = useState("");
   const [address, setAddress] = useState("");
   const [notes, setNotes] = useState("");
   const [durationMinutes, setDurationMinutes] = useState<60 | 120>(60);
@@ -137,7 +145,7 @@ export function ManualBookingModal({
           name: name.trim(),
           email: email.trim().toLowerCase(),
           phone: phoneE164 || null,
-          address: address.trim() || null,
+          address: combineUnitAndAddress(unit, address) || null,
           notes: notes.trim(),
           startAt: startAt.toISOString(),
           durationMinutes,
@@ -270,7 +278,13 @@ export function ManualBookingModal({
                             setName(c.name);
                             setEmail(c.email ?? "");
                             setPhone(c.phone ? formatNZPhone(c.phone) : "");
-                            setAddress(c.address ?? "");
+                            // Split the stored address back into unit + street so the
+                            // dedicated unit box stays populated on edit.
+                            {
+                              const split = splitUnitFromAddress(c.address ?? "");
+                              setUnit(split.unit);
+                              setAddress(split.rest);
+                            }
                             setNameListOpen(false);
                           }}
                           className={cn(
@@ -309,15 +323,31 @@ export function ManualBookingModal({
             </Field>
           </div>
 
-          <Field label="Address" htmlFor="mb-address">
-            <AddressAutocomplete
-              id="mb-address"
-              value={address}
-              onChange={setAddress}
-              placeholder="Street address"
-              maxLength={250}
-            />
-          </Field>
+          <div className={cn("grid grid-cols-3 gap-3")}>
+            <Field label="Apt / Unit" htmlFor="mb-unit">
+              <input
+                id="mb-unit"
+                type="text"
+                value={unit}
+                onChange={(e) => setUnit(e.target.value)}
+                autoComplete="off"
+                maxLength={20}
+                placeholder="12"
+                className={textInputClasses}
+              />
+            </Field>
+            <div className={cn("col-span-2")}>
+              <Field label="Address" htmlFor="mb-address">
+                <AddressAutocomplete
+                  id="mb-address"
+                  value={address}
+                  onChange={setAddress}
+                  placeholder="Street address"
+                  maxLength={250}
+                />
+              </Field>
+            </div>
+          </div>
 
           <Field label="Notes" htmlFor="mb-notes">
             <textarea

--- a/src/features/admin/components/TravelBlockAdminList.tsx
+++ b/src/features/admin/components/TravelBlockAdminList.tsx
@@ -7,6 +7,7 @@
  */
 
 import { cn } from "@/shared/lib/cn";
+import { formatDateTimeShort } from "@/shared/lib/date-format";
 import type React from "react";
 import { useEffect, useState } from "react";
 
@@ -80,21 +81,15 @@ function formatExpiry(expiresAt: string | null): string {
  * @returns Formatted time range string.
  */
 function formatEventTime(start: string, end: string): string {
-  const fmt = new Intl.DateTimeFormat("en-NZ", {
-    timeZone: "Pacific/Auckland",
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-  return `${fmt.format(new Date(start))} \u2013 ${new Intl.DateTimeFormat("en-NZ", {
+  // Start uses the canonical "Mon 11 May, 2:30 pm" formatter; the end is
+  // time-only (no canonical formatter for that) so it stays inline.
+  const endTime = new Intl.DateTimeFormat("en-NZ", {
     timeZone: "Pacific/Auckland",
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
-  }).format(new Date(end))}`;
+  }).format(new Date(end));
+  return `${formatDateTimeShort(start)} \u2013 ${endTime}`;
 }
 
 interface TravelBlockAdminListProps {

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -767,9 +767,6 @@ export default function BookingForm({
           <label className={cn("mb-2 block text-base font-semibold text-rich-black")}>
             Choose a day
           </label>
-          <p className={cn("mb-2 text-base text-rich-black/60")}>
-            All times shown in NZ time (Auckland).
-          </p>
 
           {!availableDays.some((d) => d.hasAnySlots) ? (
             <p className={cn("text-base text-rich-black/70")}>
@@ -1378,13 +1375,7 @@ export default function BookingForm({
 
               <dt className={cn("text-rich-black/60")}>Time</dt>
               <dd className={cn("text-rich-black")}>
-                {timeLabel ? (
-                  <>
-                    {timeLabel} <span className={cn("text-sm text-rich-black/60")}>NZ time</span>
-                  </>
-                ) : (
-                  <span className={cn("text-rich-black/50")}>—</span>
-                )}
+                {timeLabel ? timeLabel : <span className={cn("text-rich-black/50")}>—</span>}
               </dd>
 
               <dt className={cn("text-rich-black/60")}>Meeting</dt>

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -9,6 +9,7 @@
 import AddressAutocomplete from "@/features/booking/components/AddressAutocomplete";
 import {
   BOOKING_FIELD_LIMITS,
+  combineUnitAndAddress,
   splitUnitFromAddress,
   SUB_SLOT_MINUTES,
   validateEmail,
@@ -72,20 +73,6 @@ export interface BookingFormInitialValues {
   meetingType: "in-person" | "remote" | "";
   address: string;
   notes: string;
-}
-
-/**
- * Combines a unit number and a street-and-rest back into the saved address
- * string ("12/160 Kepa Road Orakei"). Returns just the rest when no unit is
- * present, so non-apartment addresses are unchanged.
- * @param unit - Apartment / unit number, may be empty.
- * @param rest - Street address + suburb.
- * @returns Combined address string suitable for persistence.
- */
-function combineUnitAndAddress(unit: string, rest: string): string {
-  const u = unit.trim();
-  const r = rest.trim();
-  return u ? `${u}/${r}` : r;
 }
 
 export interface BookingFormProps {

--- a/src/features/booking/lib/booking.ts
+++ b/src/features/booking/lib/booking.ts
@@ -463,7 +463,7 @@ export function validateBookingRequest(
   calendarEvents: Array<{ id: string; start: string; end: string }>,
   now: Date,
   config: AvailabilityConfig,
-): { valid: boolean; error?: string } {
+): { valid: true } | { valid: false; error: string } {
   const [year, month, day] = dateKey.split("-").map(Number);
   if (!year || !month || !day) {
     return { valid: false, error: "Invalid date format" };

--- a/src/features/booking/lib/booking.ts
+++ b/src/features/booking/lib/booking.ts
@@ -21,6 +21,22 @@ export function splitUnitFromAddress(addr: string): { unit: string; rest: string
   return { unit: m[1], rest: m[2].trim() };
 }
 
+/**
+ * Combines a unit number and a street-and-rest back into the saved address
+ * string ("12/160 Kepa Road Orakei"). Returns just the rest when no unit is
+ * present, so non-apartment addresses are unchanged. Inverse of
+ * {@link splitUnitFromAddress}; shared so every booking entry point (public form
+ * + admin schedule modal) stores addresses identically.
+ * @param unit - Apartment / unit number, may be empty.
+ * @param rest - Street address + suburb.
+ * @returns Combined address string suitable for persistence.
+ */
+export function combineUnitAndAddress(unit: string, rest: string): string {
+  const u = unit.trim();
+  const r = rest.trim();
+  return u ? `${u}/${r}` : r;
+}
+
 export const BOOKING_CONFIG = {
   timeZone: "Pacific/Auckland",
   maxAdvanceDays: 14,

--- a/src/features/business/components/ExpensesView.tsx
+++ b/src/features/business/components/ExpensesView.tsx
@@ -3,10 +3,17 @@
 import { calcGstFromInclusive, formatNZD, todayISO } from "@/features/business/lib/business";
 import { EXPENSE_CATEGORIES, PAYMENT_METHODS } from "@/features/business/lib/constants";
 import type { ExpenseEntry } from "@/features/business/types/business";
+import { Button } from "@/shared/components/Button";
+import { Field } from "@/shared/components/Field";
 import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
 import type React from "react";
 import { useEffect, useState } from "react";
+
+const inputClasses = cn(
+  "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm",
+  "focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
+);
 
 /**
  * Client component for recording and displaying expense entries.
@@ -120,82 +127,66 @@ export function ExpensesView(): React.ReactElement {
       >
         <h2 className={cn("mb-4 text-sm font-semibold text-russian-violet")}>Add expense</h2>
         <div className={cn("grid gap-3 sm:grid-cols-2")}>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>Date</label>
+          <Field label="Date" htmlFor="exp-date" required>
             <input
+              id="exp-date"
               type="date"
               required
               value={form.date}
               onChange={(e) => setForm((p) => ({ ...p, date: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>Supplier</label>
+          </Field>
+          <Field label="Supplier" htmlFor="exp-supplier" required>
             <input
+              id="exp-supplier"
               type="text"
               required
               value={form.supplier}
               onChange={(e) => setForm((p) => ({ ...p, supplier: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Description
-            </label>
+          </Field>
+          <Field label="Description" htmlFor="exp-description" required>
             <input
+              id="exp-description"
               type="text"
               required
               value={form.description}
               onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>Category</label>
+          </Field>
+          <Field label="Category" htmlFor="exp-category">
             <select
+              id="exp-category"
               value={form.category}
               onChange={(e) => setForm((p) => ({ ...p, category: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             >
               {EXPENSE_CATEGORIES.map((c) => (
                 <option key={c}>{c}</option>
               ))}
             </select>
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Amount incl. GST
-            </label>
+          </Field>
+          <Field label="Amount incl. GST" htmlFor="exp-amount" required>
             <input
+              id="exp-amount"
               type="number"
               required
               min="0"
               step="0.01"
               value={form.amountIncl}
               onChange={(e) => setForm((p) => ({ ...p, amountIncl: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>GST rate</label>
+          </Field>
+          <Field label="GST rate" htmlFor="exp-gst">
             <select
+              id="exp-gst"
               value={form.gstRate}
               onChange={(e) => setForm((p) => ({ ...p, gstRate: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             >
               <option value="0.15">15%</option>
               <option value="0">0% (no GST)</option>
@@ -205,36 +196,28 @@ export function ExpensesView(): React.ReactElement {
                 GST: {formatNZD(previewGst)} | Excl: {formatNZD(inclNum - previewGst)}
               </p>
             )}
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Payment method
-            </label>
+          </Field>
+          <Field label="Payment method" htmlFor="exp-method">
             <select
+              id="exp-method"
               value={form.method}
               onChange={(e) => setForm((p) => ({ ...p, method: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             >
               {PAYMENT_METHODS.map((m) => (
                 <option key={m}>{m}</option>
               ))}
             </select>
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Notes (optional)
-            </label>
+          </Field>
+          <Field label="Notes" htmlFor="exp-notes" optional>
             <input
+              id="exp-notes"
               type="text"
               value={form.notes}
               onChange={(e) => setForm((p) => ({ ...p, notes: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
+          </Field>
           <div className={cn("flex items-center gap-2")}>
             <input
               type="checkbox"
@@ -249,15 +232,15 @@ export function ExpensesView(): React.ReactElement {
           </div>
         </div>
         {error && <p className={cn("mt-2 text-xs text-red-600")}>{error}</p>}
-        <button
+        <Button
           type="submit"
+          variant="secondary"
+          size="sm"
           disabled={saving}
-          className={cn(
-            "mt-4 rounded-lg bg-russian-violet px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50",
-          )}
+          className={cn("mt-4")}
         >
           {saving ? "Saving..." : "Add expense"}
-        </button>
+        </Button>
       </form>
 
       {/* Mobile card list - stacks each entry; below lg the table overflows. */}

--- a/src/features/business/components/ExpensesView.tsx
+++ b/src/features/business/components/ExpensesView.tsx
@@ -4,6 +4,7 @@ import { calcGstFromInclusive, formatNZD, todayISO } from "@/features/business/l
 import { EXPENSE_CATEGORIES, PAYMENT_METHODS } from "@/features/business/lib/constants";
 import type { ExpenseEntry } from "@/features/business/types/business";
 import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
 import type React from "react";
 import { useEffect, useState } from "react";
 
@@ -302,9 +303,7 @@ export function ExpensesView(): React.ReactElement {
                   "mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs",
                 )}
               >
-                <span className={cn("text-slate-500")}>
-                  {new Date(e.date).toLocaleDateString("en-NZ")}
-                </span>
+                <span className={cn("text-slate-500")}>{formatDateShort(e.date)}</span>
                 <button
                   onClick={() => handleDelete(e.id)}
                   className={cn(
@@ -347,7 +346,7 @@ export function ExpensesView(): React.ReactElement {
               {entries.map((e) => (
                 <tr key={e.id} className={cn("hover:bg-slate-50")}>
                   <td className={cn("px-4 py-3 text-xs whitespace-nowrap text-slate-500")}>
-                    {new Date(e.date).toLocaleDateString("en-NZ")}
+                    {formatDateShort(e.date)}
                   </td>
                   <td className={cn("px-4 py-3 font-medium text-slate-700")}>{e.supplier}</td>
                   <td className={cn("px-4 py-3 text-xs text-slate-500")}>{e.category}</td>

--- a/src/features/business/components/IncomeView.tsx
+++ b/src/features/business/components/IncomeView.tsx
@@ -3,10 +3,17 @@
 import { formatNZD, todayISO } from "@/features/business/lib/business";
 import { INCOME_METHODS } from "@/features/business/lib/constants";
 import type { IncomeEntry } from "@/features/business/types/business";
+import { Button } from "@/shared/components/Button";
+import { Field } from "@/shared/components/Field";
 import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
 import type React from "react";
 import { useEffect, useState } from "react";
+
+const inputClasses = cn(
+  "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm",
+  "focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
+);
 
 /**
  * Client component for recording and displaying income entries.
@@ -106,100 +113,80 @@ export function IncomeView(): React.ReactElement {
       >
         <h2 className={cn("mb-4 text-sm font-semibold text-russian-violet")}>Add income</h2>
         <div className={cn("grid gap-3 sm:grid-cols-2")}>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>Date</label>
+          <Field label="Date" htmlFor="inc-date" required>
             <input
+              id="inc-date"
               type="date"
               required
               value={form.date}
               onChange={(e) => setForm((p) => ({ ...p, date: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>Customer</label>
+          </Field>
+          <Field label="Customer" htmlFor="inc-customer" required>
             <input
+              id="inc-customer"
               type="text"
               required
               value={form.customer}
               onChange={(e) => setForm((p) => ({ ...p, customer: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Description
-            </label>
+          </Field>
+          <Field label="Description" htmlFor="inc-description" required>
             <input
+              id="inc-description"
               type="text"
               required
               value={form.description}
               onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Amount (NZD)
-            </label>
+          </Field>
+          <Field label="Amount (NZD)" htmlFor="inc-amount" required>
             <input
+              id="inc-amount"
               type="number"
               required
               min="0"
               step="0.01"
               value={form.amount}
               onChange={(e) => setForm((p) => ({ ...p, amount: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Payment method
-            </label>
+          </Field>
+          <Field label="Payment method" htmlFor="inc-method">
             <select
+              id="inc-method"
               value={form.method}
               onChange={(e) => setForm((p) => ({ ...p, method: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             >
               {INCOME_METHODS.map((m) => (
                 <option key={m}>{m}</option>
               ))}
             </select>
-          </div>
-          <div>
-            <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-              Notes (optional)
-            </label>
+          </Field>
+          <Field label="Notes" htmlFor="inc-notes" optional>
             <input
+              id="inc-notes"
               type="text"
               value={form.notes}
               onChange={(e) => setForm((p) => ({ ...p, notes: e.target.value }))}
-              className={cn(
-                "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-              )}
+              className={inputClasses}
             />
-          </div>
+          </Field>
         </div>
         {error && <p className={cn("mt-2 text-xs text-red-600")}>{error}</p>}
-        <button
+        <Button
           type="submit"
+          variant="secondary"
+          size="sm"
           disabled={saving}
-          className={cn(
-            "mt-4 rounded-lg bg-russian-violet px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50",
-          )}
+          className={cn("mt-4")}
         >
           {saving ? "Saving..." : "Add income"}
-        </button>
+        </Button>
       </form>
 
       {/* Mobile card list - stacks each entry so the date/amount/description

--- a/src/features/business/components/IncomeView.tsx
+++ b/src/features/business/components/IncomeView.tsx
@@ -4,6 +4,7 @@ import { formatNZD, todayISO } from "@/features/business/lib/business";
 import { INCOME_METHODS } from "@/features/business/lib/constants";
 import type { IncomeEntry } from "@/features/business/types/business";
 import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
 import type React from "react";
 import { useEffect, useState } from "react";
 
@@ -240,9 +241,7 @@ export function IncomeView(): React.ReactElement {
                   "mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs",
                 )}
               >
-                <span className={cn("text-slate-500")}>
-                  {new Date(e.date).toLocaleDateString("en-NZ")}
-                </span>
+                <span className={cn("text-slate-500")}>{formatDateShort(e.date)}</span>
                 <span className={cn("text-slate-400")}>{e.method}</span>
                 <button
                   onClick={() => handleDelete(e.id)}
@@ -286,7 +285,7 @@ export function IncomeView(): React.ReactElement {
               {entries.map((e) => (
                 <tr key={e.id} className={cn("hover:bg-slate-50")}>
                   <td className={cn("px-4 py-3 text-xs whitespace-nowrap text-slate-500")}>
-                    {new Date(e.date).toLocaleDateString("en-NZ")}
+                    {formatDateShort(e.date)}
                   </td>
                   <td className={cn("px-4 py-3 font-medium text-slate-700")}>{e.customer}</td>
                   <td className={cn("px-4 py-3 text-slate-500")}>{e.description}</td>

--- a/src/features/business/components/InvoicesListView.tsx
+++ b/src/features/business/components/InvoicesListView.tsx
@@ -3,6 +3,7 @@
 import { formatNZD } from "@/features/business/lib/business";
 import type { Invoice, InvoiceStatus } from "@/features/business/types/business";
 import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type React from "react";
@@ -213,9 +214,7 @@ export function InvoicesListView(): React.ReactElement {
                   "mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs",
                 )}
               >
-                <span className={cn("text-slate-500")}>
-                  {new Date(inv.issueDate).toLocaleDateString("en-NZ")}
-                </span>
+                <span className={cn("text-slate-500")}>{formatDateShort(inv.issueDate)}</span>
                 <span className={cn("font-semibold text-slate-700")}>{formatNZD(inv.total)}</span>
                 {inv.driveWebUrl ? (
                   <a
@@ -271,7 +270,7 @@ export function InvoicesListView(): React.ReactElement {
                   </td>
                   <td className={cn("px-4 py-3 font-medium text-slate-700")}>{inv.clientName}</td>
                   <td className={cn("px-4 py-3 text-xs whitespace-nowrap text-slate-500")}>
-                    {new Date(inv.issueDate).toLocaleDateString("en-NZ")}
+                    {formatDateShort(inv.issueDate)}
                   </td>
                   <td className={cn("px-4 py-3 font-semibold whitespace-nowrap text-slate-700")}>
                     {formatNZD(inv.total)}

--- a/src/features/business/components/SubscriptionsView.tsx
+++ b/src/features/business/components/SubscriptionsView.tsx
@@ -7,10 +7,17 @@ import {
   VALID_FREQUENCIES,
 } from "@/features/business/lib/constants";
 import type { Subscription } from "@/features/business/types/business";
+import { Button } from "@/shared/components/Button";
+import { Field } from "@/shared/components/Field";
 import { cn } from "@/shared/lib/cn";
 import { formatDateShort } from "@/shared/lib/date-format";
 import type React from "react";
 import { useCallback, useEffect, useState } from "react";
+
+const inputClasses = cn(
+  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm",
+  "focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
+);
 
 interface FormState {
   description: string;
@@ -261,42 +268,35 @@ export function SubscriptionsView(): React.ReactElement {
             {editId ? "Edit subscription" : "New subscription"}
           </h3>
           <div className={cn("grid grid-cols-2 gap-3 sm:grid-cols-3")}>
-            <div className="col-span-2 sm:col-span-2">
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                Description
-              </label>
+            <Field
+              label="Description"
+              htmlFor="sub-description"
+              required
+              className="col-span-2 sm:col-span-2"
+            >
               <input
+                id="sub-description"
                 required
                 value={form.description}
                 onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               />
-            </div>
-            <div>
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                Supplier
-              </label>
+            </Field>
+            <Field label="Supplier" htmlFor="sub-supplier" required>
               <input
+                id="sub-supplier"
                 required
                 value={form.supplier}
                 onChange={(e) => setForm((p) => ({ ...p, supplier: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               />
-            </div>
-            <div>
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                Category
-              </label>
+            </Field>
+            <Field label="Category" htmlFor="sub-category">
               <select
+                id="sub-category"
                 value={form.category}
                 onChange={(e) => setForm((p) => ({ ...p, category: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               >
                 {EXPENSE_CATEGORIES.map((c) => (
                   <option key={c} value={c}>
@@ -304,48 +304,36 @@ export function SubscriptionsView(): React.ReactElement {
                   </option>
                 ))}
               </select>
-            </div>
-            <div>
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                Amount (incl. GST)
-              </label>
+            </Field>
+            <Field label="Amount (incl. GST)" htmlFor="sub-amount" required>
               <input
+                id="sub-amount"
                 required
                 type="number"
                 min="0.01"
                 step="0.01"
                 value={form.amountIncl}
                 onChange={(e) => setForm((p) => ({ ...p, amountIncl: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               />
-            </div>
-            <div>
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                GST rate
-              </label>
+            </Field>
+            <Field label="GST rate" htmlFor="sub-gst">
               <select
+                id="sub-gst"
                 value={form.gstRate}
                 onChange={(e) => setForm((p) => ({ ...p, gstRate: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               >
                 <option value="0.15">15%</option>
                 <option value="0">No GST</option>
               </select>
-            </div>
-            <div>
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                Payment method
-              </label>
+            </Field>
+            <Field label="Payment method" htmlFor="sub-method">
               <select
+                id="sub-method"
                 value={form.method}
                 onChange={(e) => setForm((p) => ({ ...p, method: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               >
                 {PAYMENT_METHODS.map((m) => (
                   <option key={m} value={m}>
@@ -353,17 +341,13 @@ export function SubscriptionsView(): React.ReactElement {
                   </option>
                 ))}
               </select>
-            </div>
-            <div>
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                Frequency
-              </label>
+            </Field>
+            <Field label="Frequency" htmlFor="sub-frequency">
               <select
+                id="sub-frequency"
                 value={form.frequency}
                 onChange={(e) => setForm((p) => ({ ...p, frequency: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               >
                 {VALID_FREQUENCIES.map((f) => (
                   <option key={f} value={f}>
@@ -371,51 +355,33 @@ export function SubscriptionsView(): React.ReactElement {
                   </option>
                 ))}
               </select>
-            </div>
-            <div>
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>
-                {editId ? "Next due" : "First due"}
-              </label>
+            </Field>
+            <Field label={editId ? "Next due" : "First due"} htmlFor="sub-nextdue" required>
               <input
+                id="sub-nextdue"
                 required
                 type="date"
                 value={form.nextDue}
                 onChange={(e) => setForm((p) => ({ ...p, nextDue: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               />
-            </div>
-            <div className="col-span-2 sm:col-span-3">
-              <label className={cn("mb-1 block text-xs font-medium text-slate-600")}>Notes</label>
+            </Field>
+            <Field label="Notes" htmlFor="sub-notes" optional className="col-span-2 sm:col-span-3">
               <input
+                id="sub-notes"
                 value={form.notes}
                 onChange={(e) => setForm((p) => ({ ...p, notes: e.target.value }))}
-                className={cn(
-                  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:ring-2 focus:ring-russian-violet/30 focus:outline-none",
-                )}
+                className={inputClasses}
               />
-            </div>
+            </Field>
           </div>
           <div className={cn("mt-4 flex gap-2")}>
-            <button
-              type="submit"
-              disabled={saving}
-              className={cn(
-                "rounded-lg bg-russian-violet px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50",
-              )}
-            >
+            <Button type="submit" variant="secondary" size="sm" disabled={saving}>
               {saving ? "Saving..." : editId ? "Update" : "Add"}
-            </button>
-            <button
-              type="button"
-              onClick={cancelForm}
-              className={cn(
-                "rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50",
-              )}
-            >
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={cancelForm}>
               Cancel
-            </button>
+            </Button>
           </div>
         </form>
       )}

--- a/src/features/business/components/SubscriptionsView.tsx
+++ b/src/features/business/components/SubscriptionsView.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/features/business/lib/constants";
 import type { Subscription } from "@/features/business/types/business";
 import { cn } from "@/shared/lib/cn";
+import { formatDateShort } from "@/shared/lib/date-format";
 import type React from "react";
 import { useCallback, useEffect, useState } from "react";
 
@@ -39,19 +40,6 @@ function emptyForm(): FormState {
     nextDue: todayISO(),
     notes: "",
   };
-}
-
-/**
- * Formats an ISO date string as a human-readable NZ date (e.g. "03 May 2026").
- * @param iso - ISO date string
- * @returns Formatted date string
- */
-function formatNextDue(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-NZ", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
 }
 
 /**
@@ -474,7 +462,7 @@ export function SubscriptionsView(): React.ReactElement {
                             : "text-slate-500",
                       )}
                     >
-                      Due {formatNextDue(sub.nextDue)}
+                      Due {formatDateShort(sub.nextDue)}
                       {overdue && " (overdue)"}
                     </span>
                     <button
@@ -582,7 +570,7 @@ export function SubscriptionsView(): React.ReactElement {
                               : "text-slate-600",
                         )}
                       >
-                        {formatNextDue(sub.nextDue)}
+                        {formatDateShort(sub.nextDue)}
                         {overdue && <span className={cn("ml-1 text-xs")}>(overdue)</span>}
                       </td>
                       <td className={cn("px-4 py-3")}>

--- a/src/features/business/components/calculator/JobDetailsSection.tsx
+++ b/src/features/business/components/calculator/JobDetailsSection.tsx
@@ -102,9 +102,10 @@ export function JobDetailsSection({
     onDurationOverrideChange(null);
   }
 
-  /** Appends a blank slot below the existing ones. */
+  /** Appends a slot; rolling entry seeds its start from the previous slot's end. */
   function addRange(): void {
-    onTimeRangesChange([...timeRanges, { startTime: "", endTime: "" }]);
+    const prevEnd = timeRanges[timeRanges.length - 1]?.endTime ?? "";
+    onTimeRangesChange([...timeRanges, { startTime: prevEnd, endTime: "" }]);
     onDurationOverrideChange(null);
   }
 

--- a/src/shared/components/Field.tsx
+++ b/src/shared/components/Field.tsx
@@ -1,0 +1,64 @@
+// src/shared/components/Field.tsx
+/**
+ * @file Field.tsx
+ * @description Shared labelled form-field wrapper for admin/business forms. The
+ * label is associated with its input via `htmlFor`, and a consistent
+ * required/optional marker (red `*` or muted "(optional)") signals which fields
+ * are mandatory the same way the public booking/review forms do.
+ */
+
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+
+/**
+ * Props for {@link Field}.
+ */
+interface FieldProps {
+  /** Visible label text. */
+  label: string;
+  /** Input id the label associates with (must match the child input's id). */
+  htmlFor: string;
+  /** When true, appends a red `*` so the field reads as mandatory. */
+  required?: boolean;
+  /** When true, appends a muted "(optional)" marker. Ignored if `required`. */
+  optional?: boolean;
+  /** Field input element(s). */
+  children: React.ReactNode;
+  /** Optional extra classes on the wrapper (e.g. column spans in a grid). */
+  className?: string;
+}
+
+/**
+ * Renders a labelled form field with consistent spacing and a required/optional
+ * marker. Used across admin forms so every form signals mandatory fields the
+ * same way.
+ * @param props - Field props.
+ * @param props.label - Visible label text.
+ * @param props.htmlFor - Input id the label associates with.
+ * @param props.required - When true, appends a red `*`.
+ * @param props.optional - When true, appends a muted "(optional)" marker.
+ * @param props.children - Field input element(s).
+ * @param props.className - Optional extra classes on the wrapper.
+ * @returns Labelled field element.
+ */
+export function Field({
+  label,
+  htmlFor,
+  required = false,
+  optional = false,
+  children,
+  className,
+}: FieldProps): React.ReactElement {
+  return (
+    <div className={className}>
+      <label htmlFor={htmlFor} className={cn("mb-1 block text-xs font-semibold text-slate-600")}>
+        {label}
+        {required && <span className={cn("ml-0.5 text-coquelicot-500")}>*</span>}
+        {!required && optional && (
+          <span className={cn("ml-1 font-normal text-slate-400")}>(optional)</span>
+        )}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/components/NavBar.tsx
+++ b/src/shared/components/NavBar.tsx
@@ -470,7 +470,9 @@ export function NavBar(): React.ReactElement | null {
           >
             <Image
               src="/source/logo.svg"
-              alt="Logo"
+              // Decorative: the adjacent "To The Point Tech" text already names the
+              // link, so an alt here would just add "Logo" noise for screen readers.
+              alt=""
               width={40}
               height={40}
               priority

--- a/src/shared/components/PageLayout.tsx
+++ b/src/shared/components/PageLayout.tsx
@@ -12,7 +12,7 @@ export const CARD = cn(
 );
 
 export const SOFT_CARD = cn(
-  "border-seasalt-400/80 bg-seasalt-900/60 rounded-xl border p-3 text-sm sm:p-4 sm:text-base",
+  "border-seasalt-400/80 bg-seasalt-900/60 rounded-xl border p-3 text-base sm:p-4 sm:text-lg",
 );
 
 /** Props for PageShell. */

--- a/src/shared/lib/api-response.ts
+++ b/src/shared/lib/api-response.ts
@@ -11,12 +11,14 @@ import { NextResponse } from "next/server";
 
 /**
  * Builds a failed JSON response with a consistent `{ ok: false, error }` body.
+ * Generic in the response payload so it's assignable in handlers annotated with
+ * a specific `NextResponse<T>` return type; `T` infers from the return context.
  * @param message - Human-readable error message returned to the client.
  * @param status - HTTP status code (defaults to 400).
  * @returns A {@link NextResponse} carrying the error body and status.
  */
-export function errorResponse(message: string, status = 400): NextResponse {
-  return NextResponse.json({ ok: false, error: message }, { status });
+export function errorResponse<T = never>(message: string, status = 400): NextResponse<T> {
+  return NextResponse.json({ ok: false, error: message }, { status }) as NextResponse<T>;
 }
 
 /**
@@ -26,6 +28,9 @@ export function errorResponse(message: string, status = 400): NextResponse {
  * @param status - HTTP status code (defaults to 200).
  * @returns A {@link NextResponse} carrying `ok: true` plus any payload.
  */
-export function okResponse(data?: Record<string, unknown>, status = 200): NextResponse {
-  return NextResponse.json({ ok: true, ...(data ?? {}) }, { status });
+export function okResponse<T = never>(
+  data?: Record<string, unknown>,
+  status = 200,
+): NextResponse<T> {
+  return NextResponse.json({ ok: true, ...(data ?? {}) }, { status }) as NextResponse<T>;
 }

--- a/src/shared/lib/api-response.ts
+++ b/src/shared/lib/api-response.ts
@@ -1,0 +1,31 @@
+// src/shared/lib/api-response.ts
+/**
+ * @file api-response.ts
+ * @description Shared JSON response helpers so every API route returns a
+ * consistent discriminated shape. Errors are always `{ ok: false, error }` and
+ * successes always carry `ok: true`, so clients branch on `ok` instead of
+ * guessing between `{ error }` and `{ ok: false, error }`.
+ */
+
+import { NextResponse } from "next/server";
+
+/**
+ * Builds a failed JSON response with a consistent `{ ok: false, error }` body.
+ * @param message - Human-readable error message returned to the client.
+ * @param status - HTTP status code (defaults to 400).
+ * @returns A {@link NextResponse} carrying the error body and status.
+ */
+export function errorResponse(message: string, status = 400): NextResponse {
+  return NextResponse.json({ ok: false, error: message }, { status });
+}
+
+/**
+ * Builds a successful JSON response. Any extra payload is spread alongside the
+ * `ok: true` flag, e.g. `okResponse({ contacts })` > `{ ok: true, contacts }`.
+ * @param data - Optional payload object merged into the response body.
+ * @param status - HTTP status code (defaults to 200).
+ * @returns A {@link NextResponse} carrying `ok: true` plus any payload.
+ */
+export function okResponse(data?: Record<string, unknown>, status = 200): NextResponse {
+  return NextResponse.json({ ok: true, ...(data ?? {}) }, { status });
+}


### PR DESCRIPTION
Rolls up the API response/typing consolidation, a shared admin form component pass, job-calculator time-entry improvements, a booking-page copy tidy, and a11y/security fixes.

## API responses & type-safety
- Unify API error/success responses into a consistent `{ ok }` discriminated shape, plus address/unit handling and date/phone formatting tidy-up
- Make `errorResponse`/`okResponse` generic in the payload type so handlers annotated `NextResponse<T>` (e.g. `booking/hold`) compile instead of failing type-check
- Give `validateBookingRequest` a discriminated valid/invalid result so `error` is a string when invalid, fixing the `errorResponse(validation.error)` call sites

## Admin UI components
- Add a shared `Field` component with required markers and adopt the shared `Button` across admin forms

## Job calculator time entry
- Accept space- or "to"-separated start/end times when parsing a job, not just dashes
- New time slots seed their start from the previous slot's end (rolling entry)

## Booking page
- Drop the redundant "NZ time (Auckland)" labels from the day picker and booking summary; times remain NZ/Auckland under the hood

## Accessibility & security
- Enlarge public body text and make the navbar logo decorative
- Tighten CSP with `object-src 'none'`

## Verification
- Pre-push hook: production build, TypeScript type-check, and 29-page smoke test all passed
