### PR TITLE
fix(ui): suppress browser autocomplete on address inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "1.114.1",
+  "version": "1.114.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "1.114.1",
+      "version": "1.114.2",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "1.114.1",
+  "version": "1.114.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/admin/components/TravelBlockAdminList.tsx
+++ b/src/features/admin/components/TravelBlockAdminList.tsx
@@ -311,6 +311,7 @@ export function TravelBlockAdminList({
                     <input
                       type="text"
                       value={originInput}
+                      autoComplete="off"
                       onChange={(e) => setOriginInput(e.target.value)}
                       placeholder={b.detectedOrigin ?? "Enter address…"}
                       className="w-full rounded-lg border border-slate-300 px-2.5 py-1.5 text-xs focus:border-slate-400 focus:outline-none"

--- a/src/features/business/components/CalculatorView.tsx
+++ b/src/features/business/components/CalculatorView.tsx
@@ -437,13 +437,14 @@ export function CalculatorView({ identity, pricing }: CalculatorViewProps): Reac
     const apiKey = process.env.GOOGLE_MAPS_API_KEY;
     if (!apiKey || !addressInputRef.current) return;
 
+    const inputEl = addressInputRef.current;
     let cancelled = false;
     let listener: google.maps.MapsEventListener | null = null;
 
     loadPlacesLibrary(apiKey)
       .then(() => {
-        if (cancelled || !addressInputRef.current) return;
-        const autocomplete = new google.maps.places.Autocomplete(addressInputRef.current, {
+        if (cancelled || !inputEl) return;
+        const autocomplete = new google.maps.places.Autocomplete(inputEl, {
           componentRestrictions: { country: "nz" },
           fields: ["formatted_address", "address_components"],
           types: ["geocode"],

--- a/src/features/business/components/calculator/TravelSection.tsx
+++ b/src/features/business/components/calculator/TravelSection.tsx
@@ -83,6 +83,7 @@ export function TravelSection({
           type="text"
           placeholder="Client address or suburb"
           value={jobAddress}
+          autoComplete="off"
           onChange={(e) => onJobAddressChange(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {


### PR DESCRIPTION
## Summary

- Add `autoComplete="off"` to the calculator travel address input (`TravelSection`) so the browser's native dropdown no longer suppresses the Google Places pac-container
- Add `autoComplete="off"` to the travel-block origin address input (`TravelBlockAdminList`) for the same reason
- Capture `addressInputRef.current` into a local variable before calling `loadPlacesLibrary` in `CalculatorView` so the ref stays stable if the component remounts during script load

## Test plan

- [ ] Type a partial NZ address in the calculator travel field - Google suggestions dropdown should appear
- [ ] Type in the travel-block origin field on `/admin/travel` - no browser autocomplete overlay