### PR TITLE
chore(tooling): faster pre-commit hook and eslint config cleanup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,31 +63,6 @@ export default defineConfig([
     },
   },
 
-  // Test files - relax some rules but keep JSDoc for named helper functions
-  {
-    files: ["tests/**/*.{ts,tsx}"],
-    rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      // Allow @severity custom tag used in test file headers
-      "jsdoc/check-tag-names": ["error", { definedTags: ["severity"] }],
-      // Helper functions in tests don't need return type annotations
-      "@typescript-eslint/explicit-function-return-type": "off",
-      // Only require JSDoc on named function declarations (e.g. createMockReview),
-      // not on inline arrow functions used in vi.mock callbacks or object literals.
-      "jsdoc/require-jsdoc": [
-        "error",
-        {
-          require: {
-            FunctionDeclaration: true,
-            FunctionExpression: false,
-            ArrowFunctionExpression: false,
-            MethodDefinition: false,
-          },
-        },
-      ],
-    },
-  },
-
   // Tailwind class hygiene. Prettier (via prettier-plugin-tailwindcss) only
   // sorts classes; this rule collapses arbitrary values that have a scale
   // equivalent (max-w-[12rem] > max-w-48) via Tailwind v4's own
@@ -120,8 +95,10 @@ export default defineConfig([
     "coverage/**",
     ".turbo/**",
     ".eslintcache",
-    "next.config.mjs",
-    "postcss.config.js",
+    "next.config.ts",
+    "postcss.config.mjs",
+    "prettier.config.ts",
+    "prisma.config.ts",
     "eslint.config.mjs",
   ]),
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "3.123.13",
+  "version": "3.123.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "3.123.13",
+      "version": "3.123.14",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "3.123.13",
+  "version": "3.123.14",
   "private": true,
   "type": "module",
   "scripts": {
@@ -20,7 +20,7 @@
     "start": "next start"
   },
   "simple-git-hooks": {
-    "pre-commit": "npm install && git add package-lock.json && npx lint-staged",
+    "pre-commit": "npm install --package-lock-only && git add package-lock.json && npx lint-staged",
     "pre-push": "npm run lint && npm run build && npm run smoke"
   },
   "lint-staged": {


### PR DESCRIPTION
## What

- Pre-commit hook now runs `npm install --package-lock-only` instead of a full `npm install`. It keeps `package-lock.json` in sync (required by CI's `npm ci`) without writing `node_modules` or firing `postinstall: prisma generate`.
- ESLint `globalIgnores` now point at the real root config filenames (`next.config.ts`, `postcss.config.mjs`) and also exclude `prettier.config.ts` / `prisma.config.ts`. The previous `next.config.mjs` / `postcss.config.js` entries matched no files.
- Removed the dead `tests/**` ESLint override (no `tests/` directory exists and vitest is not a dependency).
- Version bump 3.123.13 > 3.123.14.

## Why

- The old pre-commit `npm install` ran on every commit (~55s) and triggered `prisma generate`, which on Windows fails with an EPERM rename lock when the dev server has the Prisma query-engine DLL open. The new flag drops commit time to ~33s and removes the lock entirely, so commits work with the dev server running. Heavy validation still runs in pre-push (`lint && build && smoke`) and CI.
- The stale ignore entries meant the lint config did not do what it appeared to; correcting them makes the intent explicit.

## Notes

- No application code changes; tooling and config only.
- Prisma client regeneration is left to CI (`npx prisma generate`), `npm run db:push`, and `postinstall`, which already cover every case that matters.