### PR TITLE
Privacy policy, contacts sync overhaul, and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "3.127.1",
+  "version": "3.127.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "3.127.1",
+      "version": "3.127.2",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "3.125.3",
+  "version": "3.126.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "3.125.3",
+      "version": "3.126.0",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",
@@ -16,7 +16,7 @@
         "clsx": "^2.1.1",
         "date-holidays": "^3.32.0",
         "googleapis": "^173.0.0",
-        "next": "^16.2.9",
+        "next": "^16.2.10",
         "openai": "^6.45.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -27,7 +27,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^9.39.4",
-        "@next/bundle-analyzer": "^16.2.9",
+        "@next/bundle-analyzer": "^16.2.10",
         "@prisma/client": "6.19.3",
         "@tailwindcss/postcss": "^4.3.2",
         "@types/google.maps": "^3.65.2",
@@ -40,7 +40,7 @@
         "canvas": "^3.2.3",
         "dotenv-cli": "^11.0.0",
         "eslint": "^9.39.4",
-        "eslint-config-next": "^16.2.9",
+        "eslint-config-next": "^16.2.10",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jsdoc": "^63.0.10",
         "eslint-plugin-prettier": "^5.5.6",
@@ -1995,9 +1995,9 @@
       }
     },
     "node_modules/@next/bundle-analyzer": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.9.tgz",
-      "integrity": "sha512-yGWyLbC8MMn+hk9j6l6GammpbUz5S3yZzl3lpoWfVXhIpJfh6kAWG7JwF4WoG3f0VnYRY959yo1QQEI8mV/+jg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.10.tgz",
+      "integrity": "sha512-KcepWhb3IVniZgm00GSSCQDEUQqZXuXtuXRh8J6e3Un342TcQ77iK4DedeEkct+fcx7yFEDL2J6z4Jeho5JDAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2005,15 +2005,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.9.tgz",
-      "integrity": "sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+      "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2021,9 +2021,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -2037,9 +2037,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
       ],
@@ -2072,9 +2072,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
       ],
@@ -2091,9 +2091,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
       ],
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
       ],
@@ -2129,9 +2129,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -5983,13 +5983,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.9.tgz",
-      "integrity": "sha512-olGtBrs07bQchpaJWeqbk9GaMoU0oGmN/pYNEBXSbfgKngb5uHnPe37X6tVeh6DJfaWFQildvinGEOrolo5fmw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.10.tgz",
+      "integrity": "sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.9",
+        "@next/eslint-plugin-next": "16.2.10",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -8985,12 +8985,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9004,14 +9004,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "3.127.0",
+  "version": "3.127.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "3.127.0",
+      "version": "3.127.1",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "3.127.2",
+  "version": "3.127.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "3.127.2",
+      "version": "3.127.3",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "3.125.2",
+  "version": "3.125.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "3.125.2",
+      "version": "3.125.3",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "3.126.0",
+  "version": "3.127.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "3.126.0",
+      "version": "3.127.0",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/helpers": "^0.5.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "3.127.1",
+  "version": "3.127.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -9,6 +9,7 @@
     "build:all": "npm run build:icons && npm run build",
     "build:icons": "tsx scripts/build-icons/index.ts",
     "build:poster": "npx tsx scripts/export-poster-screenshot.ts",
+    "db:drop-review-request": "dotenv -e .env.local -- tsx scripts/drop-review-request.ts",
     "db:push": "prisma db push",
     "dev": "next dev --turbopack",
     "format": "prettier --write \"**/*.{js,ts,jsx,tsx,mjs,css,html,md,json,yml,yaml}\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "3.125.2",
+  "version": "3.125.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -72,7 +72,7 @@
     "canvas": "^3.2.3",
     "dotenv-cli": "^11.0.0",
     "eslint": "^9.39.4",
-    "eslint-config-next": "^16.2.9",
+    "eslint-config-next": "^16.2.10",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsdoc": "^63.0.10",
     "eslint-plugin-prettier": "^5.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "3.126.0",
+  "version": "3.127.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "3.127.2",
+  "version": "3.127.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "3.127.0",
+  "version": "3.127.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "3.125.3",
+  "version": "3.126.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -48,7 +48,7 @@
     "clsx": "^2.1.1",
     "date-holidays": "^3.32.0",
     "googleapis": "^173.0.0",
-    "next": "^16.2.9",
+    "next": "^16.2.10",
     "openai": "^6.45.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^9.39.4",
-    "@next/bundle-analyzer": "^16.2.9",
+    "@next/bundle-analyzer": "^16.2.10",
     "@prisma/client": "6.19.3",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/google.maps": "^3.65.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -131,6 +131,9 @@ model Booking {
   // Review email tracking.
   reviewSentAt      DateTime? // When the review request email was sent
   reviewSubmittedAt DateTime? // When the client submitted a review
+  // Set when a send returned failure (Resend down/rate-limited) after reviewSentAt
+  // was optimistically stamped. Lets the cron attempt one capped retry next pass.
+  reviewSendFailedAt DateTime?
 
   // Reminder tracking. Stamped by /api/cron/send-booking-reminders so the
   // 24h-out email reminder fires at most once per booking.
@@ -253,6 +256,11 @@ model Contact {
   reviewLinkSentAt       DateTime?
   reviewLinkSentMode     ReviewLinkMode?
   reviewLinkSubmittedAt  DateTime?
+  // Soft-delete marker. Set by the admin delete action; every reader (list,
+  // sync, maintenance matchers, backfill) excludes rows where this is non-null.
+  // Soft (not hard) delete because backfillContacts would otherwise re-create
+  // the contact from its still-present booking on the next admin page load.
+  deletedAt       DateTime?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 

--- a/scripts/drop-review-request.ts
+++ b/scripts/drop-review-request.ts
@@ -1,0 +1,49 @@
+// scripts/drop-review-request.ts
+/**
+ * @file drop-review-request.ts
+ * @description One-off cleanup: drops the retired `ReviewRequest` MongoDB
+ * collection. Its send-state (reviewToken, reviewLinkSentAt/Mode/SubmittedAt) was
+ * long ago migrated onto Contact by the idempotent auto-maintain shim, which is
+ * being removed alongside this. Dry-run by default (prints the row count); pass
+ * `--force` to actually drop.
+ *
+ * Run: dotenv -e .env.local -- tsx scripts/drop-review-request.ts [--force]
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const db = new PrismaClient();
+
+/**
+ * Counts the ReviewRequest collection, then drops it when `--force` is passed.
+ * @returns Promise that resolves when the check/drop completes.
+ */
+async function main(): Promise<void> {
+  const force = process.argv.includes("--force");
+
+  let count: number | null = null;
+  try {
+    const res = (await db.$runCommandRaw({ count: "ReviewRequest" })) as { n?: number };
+    count = res.n ?? 0;
+  } catch {
+    console.log("ReviewRequest collection does not exist - nothing to drop.");
+    return;
+  }
+
+  console.log(`ReviewRequest has ${count} document(s).`);
+
+  if (!force) {
+    console.log("Dry run. Re-run with --force to drop the collection.");
+    return;
+  }
+
+  try {
+    await db.$runCommandRaw({ drop: "ReviewRequest" });
+    console.log("Dropped ReviewRequest.");
+  } catch (err) {
+    console.error("Failed to drop ReviewRequest:", err);
+    process.exitCode = 1;
+  }
+}
+
+main().finally(() => db.$disconnect());

--- a/src/app/admin/contacts/page.tsx
+++ b/src/app/admin/contacts/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
 export default async function AdminContactsPage(): Promise<React.ReactElement> {
   await requireAdminAuth();
 
-  const initialConflicts = await autoMaintain(prisma);
+  const initialConflicts = await autoMaintain();
 
   const pendingConflictsCount = await prisma.contactConflict.count({
     where: { resolvedAt: null },

--- a/src/app/admin/contacts/page.tsx
+++ b/src/app/admin/contacts/page.tsx
@@ -35,6 +35,7 @@ export default async function AdminContactsPage(): Promise<React.ReactElement> {
 
   const [allContacts, reviews] = await Promise.all([
     prisma.contact.findMany({
+      where: { deletedAt: null },
       orderBy: { createdAt: "desc" },
       select: {
         id: true,

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -62,12 +62,15 @@ export default async function AdminPage(): Promise<React.ReactElement> {
     prisma.review.count({ where: { status: "approved" } }),
     prisma.booking.count({ where: { status: "held" } }),
     prisma.booking.count({ where: { status: "confirmed" } }),
-    prisma.contact.count(),
+    prisma.contact.count({ where: { deletedAt: null } }),
     // MongoDB gotcha: contacts created before googleContactId existed in the
     // schema have no field at all, so `null` alone misses them. `isSet: false`
     // covers that case so the unsynced count is accurate.
     prisma.contact.count({
-      where: { OR: [{ googleContactId: null }, { googleContactId: { isSet: false } }] },
+      where: {
+        OR: [{ googleContactId: null }, { googleContactId: { isSet: false } }],
+        deletedAt: null,
+      },
     }),
     prisma.booking.findMany({
       where: { status: "confirmed", startAt: { gte: now } },
@@ -89,6 +92,7 @@ export default async function AdminPage(): Promise<React.ReactElement> {
       },
     }),
     prisma.contact.findMany({
+      where: { deletedAt: null },
       orderBy: { createdAt: "desc" },
       take: 5,
       select: { id: true, name: true, email: true, phone: true, createdAt: true },
@@ -100,10 +104,11 @@ export default async function AdminPage(): Promise<React.ReactElement> {
       select: { id: true, name: true, email: true, startAt: true, reviewSentAt: true },
     }),
     prisma.contact.findMany({
-      where: { reviewLinkSentAt: { not: null } },
+      where: { reviewLinkSentAt: { not: null }, deletedAt: null },
       select: { email: true, phone: true },
     }),
     prisma.contact.findMany({
+      where: { deletedAt: null },
       orderBy: { name: "asc" },
       select: { id: true, name: true, email: true, phone: true, address: true },
     }),

--- a/src/app/admin/promos/page.tsx
+++ b/src/app/admin/promos/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-/** Plain-data shape passed across the server -> client boundary. */
+/** Plain-data shape passed across the server > client boundary. */
 export interface PromoRow {
   id: string;
   title: string;

--- a/src/app/admin/reviews/page.tsx
+++ b/src/app/admin/reviews/page.tsx
@@ -66,7 +66,7 @@ export default async function AdminReviewsPage(): Promise<React.ReactElement> {
     // Contacts with manual review-link sends. Replaces the ReviewRequest
     // history table - one row per contact (most-recent send), not per send.
     prisma.contact.findMany({
-      where: { reviewLinkSentAt: { not: null } },
+      where: { reviewLinkSentAt: { not: null }, deletedAt: null },
       orderBy: { reviewLinkSentAt: "desc" },
       take: 1000,
       select: {
@@ -81,6 +81,7 @@ export default async function AdminReviewsPage(): Promise<React.ReactElement> {
       },
     }),
     prisma.contact.findMany({
+      where: { deletedAt: null },
       orderBy: { createdAt: "desc" },
       take: 1000,
       select: { id: true, name: true, email: true, phone: true, address: true },

--- a/src/app/api/admin/bookings/[id]/route.ts
+++ b/src/app/api/admin/bookings/[id]/route.ts
@@ -174,11 +174,12 @@ export async function PATCH(
     }
   }
 
-  // Sync contact details
+  // Sync contact details. Match case-insensitively and skip soft-deleted contacts
+  // so an edit lands on the live contact regardless of stored email casing.
   if (body.address !== undefined && booking.email) {
     try {
       await prisma.contact.updateMany({
-        where: { email: booking.email },
+        where: { email: { equals: booking.email, mode: "insensitive" }, deletedAt: null },
         data: { address: body.address.trim() || null },
       });
     } catch (err) {
@@ -189,7 +190,7 @@ export async function PATCH(
   if (body.phone !== undefined && booking.email) {
     try {
       await prisma.contact.updateMany({
-        where: { email: booking.email },
+        where: { email: { equals: booking.email, mode: "insensitive" }, deletedAt: null },
         data: { phone: toE164NZ(body.phone) || null },
       });
     } catch (err) {
@@ -233,6 +234,11 @@ export async function DELETE(
     }
   }
 
+  // Drop the dangling reference first: Review.bookingId is a bare ObjectId, not
+  // a relation, so deleting the booking would otherwise leave reviews pointing at
+  // a row that no longer exists. The review itself is kept (it stays linked to
+  // its contact via contactId/customerRef).
+  await prisma.review.updateMany({ where: { bookingId: id }, data: { bookingId: null } });
   await prisma.booking.delete({ where: { id } });
 
   revalidateTag(SCHEDULE_CALENDAR_TAG, {});

--- a/src/app/api/admin/contacts/[id]/route.ts
+++ b/src/app/api/admin/contacts/[id]/route.ts
@@ -3,7 +3,10 @@
  * @description Admin API route for updating individual contacts.
  */
 
-import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
+import {
+  deleteContactFromGoogle,
+  syncContactToGoogle,
+} from "@/features/contacts/lib/google-contacts";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { isValidPhone, normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
@@ -48,7 +51,11 @@ export async function PATCH(
     }
     if (trimmedEmail) {
       const dupe = await prisma.contact.findFirst({
-        where: { email: trimmedEmail, id: { not: id } },
+        where: {
+          email: { equals: trimmedEmail, mode: "insensitive" },
+          id: { not: id },
+          deletedAt: null,
+        },
         select: { id: true },
       });
       if (dupe) {
@@ -80,4 +87,45 @@ export async function PATCH(
   }
 
   return NextResponse.json({ ok: true, contact });
+}
+
+/**
+ * DELETE /api/admin/contacts/[id]
+ * Soft-deletes a contact by stamping `deletedAt`. Soft (not hard) delete because
+ * backfillContacts would otherwise re-create the contact from its still-present
+ * booking on the next admin page load; the stamped row suppresses that. Removes
+ * the linked Google contact best-effort. Requires X-Admin-Secret header.
+ * @param request - Incoming request.
+ * @param params - Route parameters containing the contact ID.
+ * @param params.params - Promise resolving to the dynamic route params object.
+ * @returns JSON { ok: true } on success, or error.
+ */
+export async function DELETE(
+  request: NextRequest,
+  params: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  if (!(await isAdminRequest(request))) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  const { id } = await params.params;
+
+  const contact = await prisma.contact.findUnique({
+    where: { id },
+    select: { id: true, googleContactId: true, deletedAt: true },
+  });
+  if (!contact) {
+    return errorResponse("Contact not found.", 404);
+  }
+  if (contact.deletedAt) {
+    return NextResponse.json({ ok: true, alreadyDeleted: true });
+  }
+
+  await prisma.contact.update({ where: { id }, data: { deletedAt: new Date() } });
+
+  if (contact.googleContactId) {
+    await deleteContactFromGoogle(contact.googleContactId);
+  }
+
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/contacts/[id]/route.ts
+++ b/src/app/api/admin/contacts/[id]/route.ts
@@ -121,7 +121,14 @@ export async function DELETE(
     return NextResponse.json({ ok: true, alreadyDeleted: true });
   }
 
-  await prisma.contact.update({ where: { id }, data: { deletedAt: new Date() } });
+  // Unlink the contact's reviews as we soft-delete, atomically. Otherwise they
+  // keep a contactId pointing at a now-hidden contact, and matchReviewsToContacts
+  // (which only re-homes contactId==null) would never surface them again. Nulled,
+  // they show as unlinked and can re-match to a live contact.
+  await prisma.$transaction([
+    prisma.review.updateMany({ where: { contactId: id }, data: { contactId: null } }),
+    prisma.contact.update({ where: { id }, data: { deletedAt: new Date() } }),
+  ]);
 
   if (contact.googleContactId) {
     await deleteContactFromGoogle(contact.googleContactId);

--- a/src/app/api/admin/contacts/backfill/route.ts
+++ b/src/app/api/admin/contacts/backfill/route.ts
@@ -1,67 +1,35 @@
 // src/app/api/admin/contacts/backfill/route.ts
 /**
- * @description One-time backfill: upserts a Contact for every unique email in
- * Booking history. The standalone ReviewRequest model was retired; bookings
- * are the only remaining seed for backfill.
+ * @description Admin trigger for the booking-to-contact backfill. Merges phone-only
+ * duplicate contacts, then creates a Contact for every unique booking email that has
+ * no live contact yet. The logic lives in the shared contacts maintenance module so
+ * this route and the admin-page auto-maintain can never diverge.
  */
 
-import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
+import {
+  backfillContactsFromBookings,
+  mergePhoneOnlyContacts,
+} from "@/features/contacts/lib/maintenance";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ } from "@/shared/lib/normalise-phone";
-import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;
 
 /**
- * Parse phone and address from structured booking notes.
- * @param notes - Raw booking notes string.
- * @returns Parsed phone and address fields.
- */
-function parseNotes(notes: string | null): { phone: string | null; address: string | null } {
-  if (!notes) return { phone: null, address: null };
-  const rawPhone = notes.match(/Phone:\s*(.+)/i)?.[1]?.trim() || null;
-  const phone = rawPhone ? toE164NZ(rawPhone) || rawPhone : null;
-  const address = notes.match(/Address:\s*(.+)/i)?.[1]?.trim() || null;
-  return { phone, address };
-}
-
-/**
  * POST /api/admin/contacts/backfill
- * Scans all Bookings and upserts a Contact for each unique email. For each
- * email, the most recent Booking is used as the source of truth. Existing
- * contacts are never overwritten - admin edits take precedence.
+ * Merges phone-only duplicates then upserts a Contact per unique booking email.
  * Requires X-Admin-Secret header.
  * @param request - Incoming request.
- * @returns JSON with upserted count.
+ * @returns JSON with the number of contacts created.
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!(await isAdminRequest(request))) {
     return errorResponse("Unauthorized", 401);
   }
 
-  const mergedByEmail = new Map<
-    string,
-    { name: string; email: string; phone: string | null; address: string | null }
-  >();
-
-  // Bookings sorted ascending - most recent overwrites earlier entries in the Map.
-  const bookings = await prisma.booking.findMany({
-    orderBy: { createdAt: "asc" },
-    select: { name: true, email: true, notes: true },
-  });
-  for (const b of bookings) {
-    const { phone, address } = parseNotes(b.notes);
-    mergedByEmail.set(b.email.toLowerCase(), { name: b.name, email: b.email, phone, address });
-  }
-
-  let upsertedCount = 0;
-  for (const { name, email, phone, address } of mergedByEmail.values()) {
-    const { created } = await findOrCreateContactByEmail(email, { name, phone, address });
-    if (created) upsertedCount++;
-  }
-
+  await mergePhoneOnlyContacts();
+  const upsertedCount = await backfillContactsFromBookings();
   return NextResponse.json({ ok: true, upsertedCount });
 }

--- a/src/app/api/admin/contacts/check/route.ts
+++ b/src/app/api/admin/contacts/check/route.ts
@@ -26,6 +26,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: true, exists: false });
   }
 
-  const hit = await prisma.contact.findFirst({ where: { email }, select: { id: true } });
+  const hit = await prisma.contact.findFirst({
+    where: { email: { equals: email, mode: "insensitive" }, deletedAt: null },
+    select: { id: true },
+  });
   return NextResponse.json({ ok: true, exists: Boolean(hit) });
 }

--- a/src/app/api/admin/contacts/enrich-from-reviews/route.ts
+++ b/src/app/api/admin/contacts/enrich-from-reviews/route.ts
@@ -1,41 +1,22 @@
 // src/app/api/admin/contacts/enrich-from-reviews/route.ts
 /**
- * @description Enriches Contact records by comparing them against Review data.
- * Returns a list of name conflicts where review-supplied names differ from the
- * Contact's stored name so the admin can resolve them manually. The standalone
- * ReviewRequest model has been retired, so phone-enrichment from RRs is gone -
- * bookings handle phone enrichment via auto-maintain.
+ * @description Admin trigger that returns review-sourced name conflicts (where a
+ * reviewer's full name differs from the linked Contact's stored name) for manual
+ * resolution. The comparison lives in the shared contacts maintenance module.
  */
 
+import { enrichContactsFromReviews } from "@/features/contacts/lib/maintenance";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
 export const maxDuration = 60;
 
-export interface ConflictEntry {
-  contactId: string;
-  contactName: string;
-  contactEmail: string | null;
-  contactPhone: string | null;
-  /** Where the conflicting data came from. */
-  source: "Review" | "Booking";
-  sourceId: string;
-  /** Suggested name (present when name is a conflicting field). */
-  sourceName: string | null;
-  /** Suggested phone (present when phone is a conflicting field). */
-  sourcePhone: string | null;
-  conflictFields: ("name" | "phone")[];
-}
-
 /**
  * POST /api/admin/contacts/enrich-from-reviews
- * Compares Review records against their linked Contacts and returns a name
- * conflict entry per Contact where the reviewer's displayed name differs from
- * the stored name.
- * Requires X-Admin-Secret header.
+ * Returns a name conflict per Contact whose reviewer display name differs from
+ * the stored name. Requires X-Admin-Secret header.
  * @param request - Incoming request.
  * @returns JSON with enrichedCount and conflicts array.
  */
@@ -44,52 +25,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Unauthorized", 401);
   }
 
-  const allContacts = await prisma.contact.findMany({
-    select: { id: true, name: true, email: true, phone: true, reviewToken: true },
-  });
-  const contactByToken = new Map(
-    allContacts.filter((c) => c.reviewToken).map((c) => [c.reviewToken!, c]),
-  );
-
-  const reviews = await prisma.review.findMany({
-    where: { customerRef: { not: null } },
-    orderBy: { createdAt: "desc" },
-    select: { id: true, firstName: true, lastName: true, customerRef: true },
-  });
-
-  const conflicts: ConflictEntry[] = [];
-  const seenRev = new Set<string>();
-
-  for (const review of reviews) {
-    if (!review.customerRef) continue;
-    const contact = contactByToken.get(review.customerRef);
-    if (!contact || seenRev.has(contact.id)) continue;
-    seenRev.add(contact.id);
-
-    // If the review has no last name, don't flag a name conflict - the reviewer's
-    // choice of display name (first name only) is not a suggestion to drop the
-    // contact's last name.
-    if (!review.lastName) continue;
-    const proposedName = [review.firstName, review.lastName].filter(Boolean).join(" ").trim();
-    if (!proposedName || !contact.name) continue;
-    if (proposedName.toLowerCase() === contact.name.toLowerCase()) continue;
-
-    conflicts.push({
-      contactId: contact.id,
-      contactName: contact.name,
-      contactEmail: contact.email,
-      contactPhone: contact.phone,
-      source: "Review",
-      sourceId: review.id,
-      sourceName: proposedName,
-      sourcePhone: null,
-      conflictFields: ["name"],
-    });
-  }
-
-  return NextResponse.json({
-    ok: true,
-    enrichedCount: 0,
-    conflicts,
-  });
+  const conflicts = await enrichContactsFromReviews();
+  return NextResponse.json({ ok: true, enrichedCount: 0, conflicts });
 }

--- a/src/app/api/admin/contacts/export/route.ts
+++ b/src/app/api/admin/contacts/export/route.ts
@@ -48,8 +48,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Unauthorized", 401);
   }
 
-  // Load all contacts
+  // Load all live contacts
   const contacts = await prisma.contact.findMany({
+    where: { deletedAt: null },
     orderBy: { name: "asc" },
     select: { name: true, email: true, phone: true, address: true },
   });

--- a/src/app/api/admin/contacts/merge/route.ts
+++ b/src/app/api/admin/contacts/merge/route.ts
@@ -1,0 +1,83 @@
+// src/app/api/admin/contacts/merge/route.ts
+/**
+ * @description Admin API to merge two Contact records into one. Reviews on the
+ * secondary contact are reassigned to the primary, the primary's blank fields are
+ * filled from the secondary, and the secondary is soft-deleted (its Google contact
+ * removed best-effort). Used to collapse the duplicate a person creates by booking
+ * under two different emails, which nothing merges automatically.
+ */
+
+import { deleteContactFromGoogle } from "@/features/contacts/lib/google-contacts";
+import { errorResponse } from "@/shared/lib/api-response";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { prisma } from "@/shared/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+
+// Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
+export const maxDuration = 60;
+
+interface MergeBody {
+  /** The contact to keep. Its non-blank fields win. */
+  primaryId: string;
+  /** The contact to merge away. Soft-deleted after its data/reviews move over. */
+  secondaryId: string;
+}
+
+/**
+ * POST /api/admin/contacts/merge
+ * Merges the secondary contact into the primary and soft-deletes the secondary.
+ * Requires X-Admin-Secret header.
+ * @param request - Incoming request with primaryId and secondaryId.
+ * @returns JSON { ok: true } on success, or an error response.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!(await isAdminRequest(request))) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  const { primaryId, secondaryId } = (await request.json()) as MergeBody;
+  if (!primaryId || !secondaryId) {
+    return errorResponse("Both primaryId and secondaryId are required.", 400);
+  }
+  if (primaryId === secondaryId) {
+    return errorResponse("Cannot merge a contact into itself.", 400);
+  }
+
+  const [primary, secondary] = await Promise.all([
+    prisma.contact.findUnique({ where: { id: primaryId } }),
+    prisma.contact.findUnique({ where: { id: secondaryId } }),
+  ]);
+  if (!primary || !secondary) {
+    return errorResponse("Contact not found.", 404);
+  }
+
+  // Fill only the primary's blanks from the secondary; the primary keeps its own
+  // non-blank values and its reviewToken (moved reviews resolve by contactId).
+  const fill: Record<string, string> = {};
+  if (!primary.phone && secondary.phone) fill.phone = secondary.phone;
+  if (!primary.email && secondary.email) fill.email = secondary.email;
+  if (!primary.address && secondary.address) fill.address = secondary.address;
+
+  try {
+    await prisma.$transaction([
+      prisma.review.updateMany({
+        where: { contactId: secondaryId },
+        data: { contactId: primaryId },
+      }),
+      ...(Object.keys(fill).length > 0
+        ? [prisma.contact.update({ where: { id: primaryId }, data: fill })]
+        : []),
+      prisma.contact.update({ where: { id: secondaryId }, data: { deletedAt: new Date() } }),
+    ]);
+  } catch (error) {
+    console.error("[admin/contacts/merge] POST error:", error);
+    return errorResponse("Failed to merge contacts.", 500);
+  }
+
+  // Best-effort: remove the now-defunct secondary from Google Contacts.
+  if (secondary.googleContactId) {
+    await deleteContactFromGoogle(secondary.googleContactId);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/contacts/resolve-conflict/route.ts
+++ b/src/app/api/admin/contacts/resolve-conflict/route.ts
@@ -4,10 +4,12 @@
  * the contact and the source record (Booking or Review).
  */
 
+import { splitName } from "@/features/contacts/lib/split-name";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { toE164NZ } from "@/shared/lib/normalise-phone";
+import { normaliseContactPhone } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
+import { Prisma } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 
 interface ResolveBody {
@@ -43,32 +45,41 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Missing required fields.", 400);
   }
 
+  const normalisedPhone =
+    phone !== undefined ? normaliseContactPhone(phone) || phone.trim() || null : null;
+
   const contactUpdate: Record<string, string | null> = {};
   if (name !== undefined) contactUpdate.name = name.trim();
-  if (phone !== undefined) contactUpdate.phone = toE164NZ(phone) || phone.trim() || null;
+  if (phone !== undefined) contactUpdate.phone = normalisedPhone;
 
   try {
-    await prisma.contact.update({ where: { id: contactId }, data: contactUpdate });
+    // Contact + source must move together so a partial failure can't leave the
+    // two sides disagreeing about the value the admin just chose.
+    const writes: Prisma.PrismaPromise<unknown>[] = [
+      prisma.contact.update({ where: { id: contactId }, data: contactUpdate }),
+    ];
 
     if (source === "Booking") {
       const bookingUpdate: Record<string, string | null> = {};
       if (name !== undefined) bookingUpdate.name = name.trim();
-      if (phone !== undefined) bookingUpdate.phone = toE164NZ(phone) || phone.trim() || null;
+      if (phone !== undefined) bookingUpdate.phone = normalisedPhone;
       if (Object.keys(bookingUpdate).length > 0) {
-        await prisma.booking.update({ where: { id: sourceId }, data: bookingUpdate });
+        writes.push(prisma.booking.update({ where: { id: sourceId }, data: bookingUpdate }));
       }
     } else if (source === "Review") {
       // Reviews store name as firstName/lastName - only name conflicts arise from Reviews.
       if (name !== undefined) {
-        const parts = name.trim().split(/\s+/);
-        const firstName = parts.slice(0, -1).join(" ") || parts[0] || null;
-        const lastName = parts.length > 1 ? parts[parts.length - 1] : null;
-        await prisma.review.update({
-          where: { id: sourceId },
-          data: { firstName, lastName },
-        });
+        const { givenName, familyName } = splitName(name);
+        writes.push(
+          prisma.review.update({
+            where: { id: sourceId },
+            data: { firstName: givenName || null, lastName: familyName || null },
+          }),
+        );
       }
     }
+
+    await prisma.$transaction(writes);
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/app/api/admin/contacts/route.ts
+++ b/src/app/api/admin/contacts/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   const contacts = await prisma.contact.findMany({
+    where: { deletedAt: null },
     orderBy: { createdAt: "desc" },
     select: {
       id: true,

--- a/src/app/api/admin/contacts/sync/route.ts
+++ b/src/app/api/admin/contacts/sync/route.ts
@@ -1,13 +1,11 @@
 // src/app/api/admin/contacts/sync/route.ts
 /**
- * @description Admin API route for two-way Google Contacts sync.
- * Imports all Google contacts into the local DB, then pushes all local contacts to Google.
+ * @description Admin API route for the manual full two-way Google Contacts sync.
+ * Shares {@link runContactsSync} with the cron; the button force-pushes every
+ * contact (full mode) rather than just the changed ones.
  */
 
-import {
-  importFromGoogleContacts,
-  syncAllContactsToGoogle,
-} from "@/features/contacts/lib/google-contacts";
+import { runContactsSync } from "@/features/contacts/lib/contacts-sync";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
@@ -17,8 +15,8 @@ export const maxDuration = 60;
 
 /**
  * POST /api/admin/contacts/sync
- * Two-way sync: pulls all Google contacts into the local DB, then pushes all local contacts to Google.
- * Requires X-Admin-Secret header.
+ * Full two-way sync: dedup/merge locally, push every contact to Google, then pull
+ * Google contacts back in. Requires X-Admin-Secret header.
  * @param request - Incoming request.
  * @returns JSON with importedCount and syncedCount on success, or error on failure.
  */
@@ -28,11 +26,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    // Push local contacts to Google first so local edits are not overwritten by the import.
-    const syncedCount = await syncAllContactsToGoogle();
-    // Then pull new Google contacts in (existing records only get googleContactId linked).
-    const importedCount = await importFromGoogleContacts();
-    return NextResponse.json({ ok: true, importedCount, syncedCount });
+    const { pushed, imported } = await runContactsSync({ full: true });
+    return NextResponse.json({ ok: true, importedCount: imported, syncedCount: pushed });
   } catch (error) {
     console.error("[api/admin/contacts/sync] Error:", error);
     // Generic message to the client; the OAuth / Google API detail goes only

--- a/src/app/api/admin/reviews/[id]/route.ts
+++ b/src/app/api/admin/reviews/[id]/route.ts
@@ -149,7 +149,31 @@ export async function DELETE(
   const { id } = await params;
 
   try {
+    const review = await prisma.review.findUnique({
+      where: { id },
+      select: { bookingId: true, contactId: true },
+    });
     await prisma.review.delete({ where: { id } });
+
+    // Clear the source's "submitted" flag so review-send eligibility/cooldown
+    // don't suppress the customer for a review that no longer exists - but only
+    // when no other review still references that booking/contact.
+    if (review?.bookingId) {
+      const others = await prisma.review.count({ where: { bookingId: review.bookingId } });
+      if (others === 0) {
+        await prisma.booking
+          .update({ where: { id: review.bookingId }, data: { reviewSubmittedAt: null } })
+          .catch(() => null);
+      }
+    }
+    if (review?.contactId) {
+      const others = await prisma.review.count({ where: { contactId: review.contactId } });
+      if (others === 0) {
+        await prisma.contact
+          .update({ where: { id: review.contactId }, data: { reviewLinkSubmittedAt: null } })
+          .catch(() => null);
+      }
+    }
 
     // Trigger ISR revalidation so public pages update immediately
     revalidateReviewPaths();

--- a/src/app/api/admin/reviews/match-contacts/route.ts
+++ b/src/app/api/admin/reviews/match-contacts/route.ts
@@ -1,12 +1,14 @@
 // src/app/api/admin/reviews/match-contacts/route.ts
 /**
- * @description Admin API to auto-match reviews to contacts by email or phone.
+ * @description Admin trigger to link reviews to contacts by email, phone, or token.
+ * Delegates to the shared contacts maintenance module so this route and the
+ * admin-page auto-maintain use identical matching (including the ambiguous-phone
+ * guard that skips numbers shared by more than one contact).
  */
 
+import { matchReviewsToContacts } from "@/features/contacts/lib/maintenance";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
-import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
-import { prisma } from "@/shared/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
@@ -14,10 +16,7 @@ export const maxDuration = 60;
 
 /**
  * POST /api/admin/reviews/match-contacts
- * For each review that has a bookingId but no contactId, loads the booking to
- * get the email (primary) or phone (fallback) and finds the matching Contact.
- * Also falls back to customerRef as an email if no bookingId is present.
- * Updates review.contactId when a match is found.
+ * Links reviews that have no contactId to their matching Contact.
  * Requires X-Admin-Secret header.
  * @param request - Incoming request.
  * @returns JSON with { ok: true, matchedCount } on success, or error.
@@ -28,82 +27,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    // MongoDB gotcha: `contactId: null` only matches documents where the field
-    // exists and equals null. Reviews created before contactId was added to
-    // the schema have no contactId field at all, so they need the `isSet:
-    // false` branch to be matched and eligible for linking.
-    const unmatched = await prisma.review.findMany({
-      where: { OR: [{ contactId: null }, { contactId: { isSet: false } }] },
-      select: { id: true, bookingId: true, customerRef: true },
-    });
-
-    if (unmatched.length === 0) {
-      return NextResponse.json({ ok: true, matchedCount: 0 });
-    }
-
-    // Load bookings for email/phone lookup
-    const bookingIds = unmatched.map((r) => r.bookingId).filter((id): id is string => id !== null);
-
-    const bookings =
-      bookingIds.length > 0
-        ? await prisma.booking.findMany({
-            where: { id: { in: bookingIds } },
-            select: { id: true, email: true, phone: true },
-          })
-        : [];
-
-    const bookingEmailById = new Map(bookings.map((b) => [b.id, b.email]));
-    const bookingPhoneById = new Map<string, string>();
-    for (const b of bookings) {
-      if (b.phone) {
-        const norm = normalisePhone(toE164NZ(b.phone) || b.phone);
-        if (norm) bookingPhoneById.set(b.id, norm);
-      }
-    }
-
-    // Build contact lookup maps
-    const contacts = await prisma.contact.findMany({
-      select: { id: true, email: true, phone: true, reviewToken: true },
-    });
-
-    const contactIdByEmail = new Map(
-      contacts.filter((c) => c.email).map((c) => [c.email!.toLowerCase(), c.id]),
-    );
-    const contactIdByPhone = new Map<string, string>();
-    for (const c of contacts) {
-      if (c.phone) {
-        const norm = normalisePhone(c.phone);
-        if (norm && !contactIdByPhone.has(norm)) contactIdByPhone.set(norm, c.id);
-      }
-    }
-    // Standalone reviews (no booking) carry the Contact's reviewToken in
-    // customerRef, so a token-based lookup replaces the old ReviewRequest path.
-    const contactIdByToken = new Map(
-      contacts.filter((c) => c.reviewToken).map((c) => [c.reviewToken!, c.id]),
-    );
-
-    // Link each review to its contact
-    let matchedCount = 0;
-    for (const review of unmatched) {
-      let contactId: string | undefined;
-
-      if (review.bookingId) {
-        const email = bookingEmailById.get(review.bookingId);
-        if (email) contactId = contactIdByEmail.get(email.toLowerCase());
-        if (!contactId) {
-          const phone = bookingPhoneById.get(review.bookingId);
-          if (phone) contactId = contactIdByPhone.get(phone);
-        }
-      } else if (review.customerRef) {
-        contactId = contactIdByToken.get(review.customerRef);
-      }
-
-      if (!contactId) continue;
-
-      await prisma.review.update({ where: { id: review.id }, data: { contactId } });
-      matchedCount++;
-    }
-
+    const matchedCount = await matchReviewsToContacts();
     return NextResponse.json({ ok: true, matchedCount });
   } catch (error) {
     console.error("[admin/reviews/match-contacts] POST error:", error);

--- a/src/app/api/admin/send-review-link/route.ts
+++ b/src/app/api/admin/send-review-link/route.ts
@@ -94,23 +94,32 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
     }
 
-    // Ensure the contact carries a stable review token and stamp the send.
+    // Ensure the contact carries a stable review token.
     const reviewToken = contact.reviewToken ?? randomUUID();
+    const reviewUrl = `${siteUrl}/review?token=${reviewToken}`;
+
+    if (mode === "sms") {
+      // SMS is not wired to a provider yet. Persist only the token (never the
+      // send-state) so the operator can copy the link and send it themselves.
+      // Stamping reviewLinkSentAt here would mark the customer as "review
+      // requested" and suppress them from future auto-sends while nothing was
+      // actually sent.
+      // TODO: wire a real SMS provider, then stamp send-state like the email path.
+      if (!contact.reviewToken) {
+        await prisma.contact.update({ where: { id: contact.id }, data: { reviewToken } });
+      }
+      return NextResponse.json({ ok: true, reviewUrl, copyOnly: true });
+    }
+
+    // Email path: stamp the send state and send the email.
     await prisma.contact.update({
       where: { id: contact.id },
       data: {
         reviewToken,
         reviewLinkSentAt: new Date(),
-        reviewLinkSentMode: mode === "email" ? ReviewLinkMode.email : ReviewLinkMode.sms,
+        reviewLinkSentMode: ReviewLinkMode.email,
       },
     });
-
-    // Build the link and send the email
-    const reviewUrl = `${siteUrl}/review?token=${reviewToken}`;
-
-    if (mode === "sms") {
-      return NextResponse.json({ ok: true, reviewUrl });
-    }
 
     await sendPastClientReviewRequest({
       id: contact.id,

--- a/src/app/api/booking/contact-lookup/route.ts
+++ b/src/app/api/booking/contact-lookup/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   const contact = await prisma.contact.findFirst({
-    where: { email },
+    where: { email: { equals: email, mode: "insensitive" }, deletedAt: null },
     select: { name: true, phone: true, address: true },
   });
 

--- a/src/app/api/booking/edit/route.ts
+++ b/src/app/api/booking/edit/route.ts
@@ -18,6 +18,7 @@ import {
   deleteBookingEvent,
   fetchAllCalendarEvents,
 } from "@/features/calendar/lib/google-calendar";
+import { findOrCreateContactByEmail } from "@/features/contacts/lib/find-or-create";
 import { syncContactToGoogle } from "@/features/contacts/lib/google-contacts";
 import {
   sendCustomerBookingConfirmation,
@@ -285,32 +286,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // name/phone/address stay in step with the booking so edit-form
     // corrections propagate to Google Contacts.
     try {
-      const contactEmail = booking.email.toLowerCase();
-      const existing = await prisma.contact.findFirst({ where: { email: contactEmail } });
-      let contactId: string | null = existing?.id ?? null;
-      if (existing) {
-        await prisma.contact.update({
-          where: { id: existing.id },
-          data: {
-            name: name.trim(),
-            ...(phoneE164 !== undefined ? { phone: phoneE164 } : {}),
-            ...(meetingType === "in-person" && address ? { address: address.trim() } : {}),
-          },
-        });
-      } else {
-        const created = await prisma.contact.create({
-          data: {
-            name: name.trim(),
-            email: contactEmail,
-            phone: phoneE164,
-            address: meetingType === "in-person" && address ? address.trim() : null,
-          },
-        });
-        contactId = created.id;
-      }
-      if (contactId) {
-        await syncContactToGoogle(contactId);
-      }
+      // Route through the shared helper so matching is case-insensitive and
+      // soft-delete-aware (never resurrecting a deleted contact), then keep the
+      // contact's fields in step with the edited booking.
+      const { contact } = await findOrCreateContactByEmail(booking.email, {
+        name: name.trim(),
+        phone: phoneE164 ?? null,
+        address: meetingType === "in-person" && address ? address.trim() : null,
+      });
+      await prisma.contact.update({
+        where: { id: contact.id },
+        data: {
+          name: name.trim(),
+          ...(phoneE164 !== undefined ? { phone: phoneE164 } : {}),
+          ...(meetingType === "in-person" && address ? { address: address.trim() } : {}),
+        },
+      });
+      await syncContactToGoogle(contact.id);
     } catch (contactError) {
       console.error("[booking/edit] Failed to upsert/sync contact:", contactError);
     }

--- a/src/app/api/cron/send-review-emails/route.ts
+++ b/src/app/api/cron/send-review-emails/route.ts
@@ -65,30 +65,24 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       bookingsToEmail.map((b) => ({ id: b.id, email: b.email })),
     );
 
-    if (bookingsToEmail.length === 0) {
-      return NextResponse.json({
-        ok: true,
-        found: 0,
-        suppressed: 0,
-        sent: 0,
-        failed: 0,
-        errors: [],
-      });
-    }
-
     // Deduplicate by email: skip bookings whose email already received a review request
     // (either from another booking or a manual Contact send via admin).
     // Only query emails that are actually in this batch to avoid full-table scans.
+    // Soft-deleted contacts don't count as "already emailed".
     const batchEmails = bookingsToEmail.map((b) => b.email);
     const [alreadyEmailedBookings, alreadyEmailedContacts] = await Promise.all([
-      prisma.booking.findMany({
-        where: { reviewSentAt: { not: null }, email: { in: batchEmails } },
-        select: { email: true },
-      }),
-      prisma.contact.findMany({
-        where: { reviewLinkSentAt: { not: null }, email: { in: batchEmails } },
-        select: { email: true },
-      }),
+      batchEmails.length > 0
+        ? prisma.booking.findMany({
+            where: { reviewSentAt: { not: null }, email: { in: batchEmails } },
+            select: { email: true },
+          })
+        : Promise.resolve([] as { email: string }[]),
+      batchEmails.length > 0
+        ? prisma.contact.findMany({
+            where: { reviewLinkSentAt: { not: null }, email: { in: batchEmails }, deletedAt: null },
+            select: { email: true },
+          })
+        : Promise.resolve([] as { email: string | null }[]),
     ]);
     const reviewedEmails = new Set([
       ...alreadyEmailedBookings.map((b) => b.email.toLowerCase()),
@@ -127,19 +121,25 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     for (const booking of toSend) {
       try {
-        // Mark as sent FIRST to prevent duplicate emails if send fails after DB update.
-        // Trade-off: a failed send stays marked (no retry), but this prevents spam.
+        // Mark as sent FIRST so a crash between the write and the send can never
+        // double-email. If the send itself reports failure we stamp
+        // reviewSendFailedAt so the retry pass below gives it exactly one more go.
         await prisma.booking.update({
           where: { id: booking.id },
-          data: {
-            reviewSentAt: now,
-          },
+          data: { reviewSentAt: now },
         });
 
-        // Send email SECOND (best-effort delivery; failures are logged)
-        await sendCustomerReviewRequest(booking);
-
-        results.sent++;
+        const ok = await sendCustomerReviewRequest(booking);
+        if (ok) {
+          results.sent++;
+        } else {
+          await prisma.booking.update({
+            where: { id: booking.id },
+            data: { reviewSendFailedAt: now },
+          });
+          results.failed++;
+          results.errors.push(`Booking ${booking.id}: send failed (will retry once)`);
+        }
       } catch (error) {
         console.error(`[review-email] Failed for booking ${booking.id}:`, error);
         results.failed++;
@@ -147,13 +147,36 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }
     }
 
+    // Retry pass: bookings whose previous send reported failure get one more
+    // attempt. The flag is cleared either way (cap of one retry) so a persistent
+    // failure gives up rather than emailing forever.
+    const failedBookings = await prisma.booking.findMany({
+      where: { reviewSendFailedAt: { not: null } },
+      select: { id: true, name: true, email: true, reviewToken: true },
+    });
+    let retried = 0;
+    for (const booking of failedBookings) {
+      const ok = await sendCustomerReviewRequest(booking);
+      await prisma.booking.update({
+        where: { id: booking.id },
+        data: { reviewSendFailedAt: null },
+      });
+      if (ok) {
+        retried++;
+        results.sent++;
+      } else {
+        console.warn(`[review-email] Giving up on booking ${booking.id} after one retry.`);
+      }
+    }
+
     console.log(
-      `[cron/send-review-emails] done: sent=${results.sent} suppressed=${results.suppressed} failed=${results.failed}`,
+      `[cron/send-review-emails] done: sent=${results.sent} suppressed=${results.suppressed} failed=${results.failed} retried=${retried}`,
     );
 
     return NextResponse.json({
       ok: true,
       ...results,
+      retried,
     });
   } catch (error) {
     console.error("[review-email] Cron error:", error);

--- a/src/app/api/cron/sync-contacts/route.ts
+++ b/src/app/api/cron/sync-contacts/route.ts
@@ -1,0 +1,35 @@
+// src/app/api/cron/sync-contacts/route.ts
+/**
+ * @description Cron endpoint (Bearer-authorised) that runs the incremental two-way
+ * Google Contacts sync via {@link runContactsSync}: local dedup/merge first, then
+ * push the changed contacts, then pull Google's changes back. Designed to run every
+ * few hours via cron-job.org and returns 503 when the sync throws.
+ */
+
+import { runContactsSync } from "@/features/contacts/lib/contacts-sync";
+import { errorResponse } from "@/shared/lib/api-response";
+import { isCronAuthorized } from "@/shared/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+
+// Raise the serverless ceiling so a slow upstream call (Google People API) cannot 504 on the default timeout.
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/sync-contacts
+ * Runs an incremental two-way Google Contacts sync.
+ * Run every few hours via cron-job.org with Authorization: Bearer <CRON_SECRET>.
+ * @param request - Incoming cron request.
+ * @returns JSON with pushed/imported/conflicts/skipped counts.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!isCronAuthorized(request)) {
+    return errorResponse("Unauthorized", 401);
+  }
+  try {
+    const result = await runContactsSync({});
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    console.error("[cron/sync-contacts] failed:", err);
+    return errorResponse("Contact sync failed", 503);
+  }
+}

--- a/src/app/api/pricing/estimate-duration/route.ts
+++ b/src/app/api/pricing/estimate-duration/route.ts
@@ -193,7 +193,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     parsed.tasks = rebalanceTasks(cleanTasks, parsed.estimatedMins, incrementMins);
 
-    // Coerce confidence to a known value; anything unexpected -> "medium".
+    // Coerce confidence to a known value; anything unexpected > "medium".
     parsed.confidence =
       parsed.confidence === "high" || parsed.confidence === "low" ? parsed.confidence : "medium";
 

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -6,7 +6,7 @@
 import { sendOwnerReviewNotification } from "@/features/reviews/lib/email";
 import { reviewTextError } from "@/features/reviews/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
-import { normalisePhone } from "@/shared/lib/normalise-phone";
+import { normaliseContactPhone } from "@/shared/lib/normalise-phone";
 import { prisma as prismaClient } from "@/shared/lib/prisma";
 import { rateLimitOrReject } from "@/shared/lib/rate-limit";
 import { getSettings } from "@/shared/lib/settings/get-settings";
@@ -111,10 +111,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         verified = true;
         bookingId = booking.id;
         customerRef = booking.reviewToken;
-        // Auto-link to Contact by booking email - best effort, never fails the submission.
+        // Auto-link to Contact by booking email - best effort, never fails the
+        // submission. Case-insensitive and skips soft-deleted contacts; when no
+        // live contact is found the review keeps its bookingId + customerRef so
+        // matchReviewsToContacts can link it later.
         try {
           const contact = await prisma.contact.findFirst({
-            where: { email: booking.email.toLowerCase() },
+            where: {
+              email: { equals: booking.email.toLowerCase(), mode: "insensitive" },
+              deletedAt: null,
+            },
             select: { id: true },
           });
           if (contact) autoContactId = contact.id;
@@ -125,6 +131,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           where: { id: booking.id },
           data: { reviewSubmittedAt: new Date() },
         });
+      } else {
+        // Token supplied but the booking is gone - keep the token so the review
+        // is still identifiable, and log rather than silently dropping it.
+        customerRef = body.reviewToken;
+        console.warn(
+          `[reviews] booking-token submission matched no booking (bookingId=${body.bookingId}); review kept with customerRef.`,
+        );
       }
     }
 
@@ -132,10 +145,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (!verified && body.contactId && body.reviewToken) {
       const contact = await prisma.contact.findFirst({
         where: { id: body.contactId, reviewToken: body.reviewToken },
-        select: { id: true, email: true, phone: true },
+        select: { id: true, email: true, phone: true, deletedAt: true },
       });
 
-      if (contact) {
+      if (contact && !contact.deletedAt) {
         verified = true;
         customerRef = body.reviewToken;
         autoContactId = contact.id;
@@ -143,13 +156,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         // Fill blanks on the Contact from any details the customer typed,
         // never overwriting an existing value.
         const submittedEmail = body.contactEmail?.trim().toLowerCase() || null;
-        const submittedPhone = body.contactPhone ? normalisePhone(body.contactPhone) : null;
+        const submittedPhone = normaliseContactPhone(body.contactPhone);
         const contactUpdate: { email?: string; phone?: string; reviewLinkSubmittedAt: Date } = {
           reviewLinkSubmittedAt: new Date(),
         };
         if (!contact.email && submittedEmail) contactUpdate.email = submittedEmail;
         if (!contact.phone && submittedPhone) contactUpdate.phone = submittedPhone;
         await prisma.contact.update({ where: { id: contact.id }, data: contactUpdate });
+      } else if (contact) {
+        // The token is valid but the contact was soft-deleted/merged away. Keep
+        // the token (so the review re-links if the contact returns) but don't
+        // mark it verified or link it to a dead row.
+        customerRef = body.reviewToken;
+        console.warn(
+          `[reviews] contact-token submission matched a soft-deleted contact (contactId=${body.contactId}); review kept with customerRef for later re-link.`,
+        );
       }
     }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -319,7 +319,7 @@ aside.app-admin-drawer {
 }
 
 .animate-marquee {
-  animation: marquee 120s linear infinite;
+  animation: marquee 190s linear infinite;
   will-change: transform;
 }
 
@@ -327,6 +327,28 @@ aside.app-admin-drawer {
 .animate-marquee:hover,
 .animate-marquee:focus-within {
   animation-play-state: paused;
+}
+
+/* Soft-fade the carousel viewport so cards dissolve as they reach the edges
+   instead of being hard-clipped. --marquee-fade sets how far in from each edge
+   the fade runs; a smaller value makes cards disappear closer to the edge.
+   Prefixed copy kept for WebKit; Firefox uses the unprefixed property. */
+.marquee-fade {
+  --marquee-fade: 3rem;
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black var(--marquee-fade),
+    black calc(100% - var(--marquee-fade)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black var(--marquee-fade),
+    black calc(100% - var(--marquee-fade)),
+    transparent 100%
+  );
 }
 
 @keyframes fadeIn {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { GoogleTag } from "@/shared/components/GoogleTag";
 import { MetaPixel } from "@/shared/components/MetaPixel";
 import { NavBar } from "@/shared/components/NavBar";
 import { PromoBanner } from "@/shared/components/PromoBanner";
+import { SiteFooter } from "@/shared/components/SiteFooter";
 import { getSettings } from "@/shared/lib/settings/get-settings";
 import { getSiteUrl } from "@/shared/lib/site-url";
 import { Analytics } from "@vercel/analytics/next";
@@ -372,6 +373,7 @@ export default async function RootLayout({
         <PromoBanner />
         <NavBar />
         {children}
+        <SiteFooter />
 
         <Analytics />
         <SpeedInsights />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -195,7 +195,7 @@ export default async function Home(): Promise<React.ReactElement> {
                 Proudly Local
               </h3>
               <p className="text-base text-rich-black/80 sm:text-lg">
-                Born and raised here, serving the community
+                Auckland born and raised, on-site across the city
               </p>
             </div>
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,277 @@
+// src/app/privacy/page.tsx
+/**
+ * @description Privacy policy: what we collect, how we use it, the analytics/ad
+ * tools we run (Google, Meta Pixel incl. hashed advanced matching), and the
+ * visitor's rights under the NZ Privacy Act 2020.
+ */
+
+import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
+import { cn } from "@/shared/lib/cn";
+import type { Metadata } from "next";
+import type React from "react";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "How To The Point Tech collects, uses and protects your information, the analytics and advertising tools we use, and your rights under the NZ Privacy Act 2020.",
+  alternates: { canonical: "/privacy" },
+  openGraph: {
+    title: "Privacy Policy - To The Point Tech",
+    description: "What we collect, how we use it, and your privacy choices.",
+    url: "/privacy",
+  },
+};
+
+/** Plain hyphen, NZ English. Last reviewed date shown to visitors. */
+const LAST_UPDATED = "2 July 2026";
+
+const H2 = "mb-3 text-xl font-bold text-russian-violet sm:text-2xl";
+const P = "text-base text-rich-black/90 sm:text-lg";
+const LI = "flex gap-3 text-base text-rich-black/90 sm:text-lg";
+const DOT = "mt-1 shrink-0 text-lg text-moonstone-600";
+const LINK = "font-semibold text-russian-violet underline hover:text-coquelicot-500";
+
+/**
+ * Privacy policy page.
+ * @returns React element for the privacy page.
+ */
+export default function PrivacyPage(): React.ReactElement {
+  return (
+    <PageShell>
+      <BreadcrumbJsonLd
+        crumbs={[
+          { name: "Home", path: "/" },
+          { name: "Privacy", path: "/privacy" },
+        ]}
+      />
+      <FrostedSection maxWidth="clamp(60rem, 70vw, 90rem)">
+        <div className="flex flex-col gap-6 sm:gap-8">
+          {/* Header */}
+          <section className={cn(CARD, "animate-fade-in")}>
+            <h1 className="mb-2 text-2xl font-extrabold text-russian-violet sm:text-3xl md:text-4xl">
+              Privacy Policy
+            </h1>
+            <p className="mb-4 text-sm text-rich-black/60">Last updated: {LAST_UPDATED}</p>
+            <p className={P}>
+              To The Point Tech ("we", "us", "our") provides computer and IT support across
+              Auckland. We respect your privacy and only collect what we need to help you. This
+              policy explains what information we collect, how we use it, who we share it with, and
+              the choices you have. If you have any questions, email{" "}
+              <a href="mailto:harrison@tothepoint.co.nz" className={LINK}>
+                harrison@tothepoint.co.nz
+              </a>
+              .
+            </p>
+          </section>
+
+          {/* Content */}
+          <section className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-100")}>
+            <div className="flex flex-col gap-8">
+              <div>
+                <h2 className={H2}>Information we collect</h2>
+                <p className={cn(P, "mb-3")}>
+                  When you book an appointment or get in touch, we collect the details you give us:
+                </p>
+                <ul className="flex flex-col gap-2.5">
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>Your name, email address and phone number</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>Your address, when a visit is on-site</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>Details about the device or problem you need help with</span>
+                  </li>
+                </ul>
+                <p className={cn(P, "mt-3")}>
+                  We also collect some information automatically when you use the site - such as the
+                  pages you view, your device and browser type, and general location - using cookies
+                  and similar technologies (see below).
+                </p>
+              </div>
+
+              <div>
+                <h2 className={H2}>How we use your information</h2>
+                <ul className="flex flex-col gap-2.5">
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>To arrange, provide and follow up on your tech support</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>To send booking confirmations, calendar invites and reminders</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>To reply to your enquiries and, after a job, invite a review</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>To improve the website and measure how well our advertising works</span>
+                  </li>
+                </ul>
+              </div>
+
+              <div>
+                <h2 className={H2}>Cookies, analytics and advertising</h2>
+                <p className={cn(P, "mb-3")}>
+                  We use cookies and small tracking scripts ("pixels") to understand how the site is
+                  used and to measure our advertising. These include:
+                </p>
+                <ul className="flex flex-col gap-2.5">
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>
+                      <strong>Google Analytics</strong> - to see how visitors use the site.
+                    </span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>
+                      <strong>Google Ads</strong> and the{" "}
+                      <strong>Meta (Facebook/Instagram) Pixel</strong> - to measure ad performance
+                      and show relevant ads.
+                    </span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>
+                      <strong>Meta advanced matching:</strong> when you submit your booking or
+                      contact details, a scrambled (hashed, one-way) version of information like
+                      your email or phone number may be shared with Meta to match up ad results.
+                      This is not shared as readable text and can't be reversed by us.
+                    </span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>
+                      <strong>Vercel Analytics</strong> - privacy-friendly performance statistics.
+                    </span>
+                  </li>
+                </ul>
+                <p className={cn(P, "mt-3")}>
+                  You can control or block cookies in your browser settings, use a tracker/ad
+                  blocker, or adjust your ad preferences at{" "}
+                  <a
+                    href="https://adssettings.google.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={LINK}
+                  >
+                    Google Ad Settings
+                  </a>{" "}
+                  and{" "}
+                  <a
+                    href="https://www.facebook.com/adpreferences"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={LINK}
+                  >
+                    Meta Ad Preferences
+                  </a>
+                  .
+                </p>
+              </div>
+
+              <div>
+                <h2 className={H2}>Who we share it with</h2>
+                <p className={cn(P, "mb-3")}>
+                  We do not sell your personal information. We share it only with the service
+                  providers that help us run the business:
+                </p>
+                <ul className="flex flex-col gap-2.5">
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>Google (Analytics, Ads, Maps and Calendar)</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>Meta Platforms (advertising pixel)</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>Our email provider, for booking and review emails</span>
+                  </li>
+                  <li className={LI}>
+                    <span className={DOT}>&bull;</span>
+                    <span>Our website hosting and database providers</span>
+                  </li>
+                </ul>
+                <p className={cn(P, "mt-3")}>
+                  Some of these providers are based overseas, so your information may be stored or
+                  processed outside New Zealand. They handle it on our behalf under their own
+                  privacy and security terms.
+                </p>
+              </div>
+
+              <div>
+                <h2 className={H2}>How long we keep it</h2>
+                <p className={P}>
+                  We keep booking and contact records only as long as we need them - to provide the
+                  service, for our own records, and to meet legal and tax obligations - after which
+                  we delete them.
+                </p>
+              </div>
+
+              <div>
+                <h2 className={H2}>Your rights</h2>
+                <p className={P}>
+                  Under the New Zealand Privacy Act 2020 you can ask to see the personal information
+                  we hold about you and request corrections. Email{" "}
+                  <a href="mailto:harrison@tothepoint.co.nz" className={LINK}>
+                    harrison@tothepoint.co.nz
+                  </a>{" "}
+                  and we'll help. If you're not satisfied, you can contact the{" "}
+                  <a
+                    href="https://www.privacy.org.nz"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={LINK}
+                  >
+                    Office of the Privacy Commissioner
+                  </a>
+                  .
+                </p>
+              </div>
+
+              <div>
+                <h2 className={H2}>Security</h2>
+                <p className={P}>
+                  We take reasonable steps to protect your information, but no method of storage or
+                  transmission over the internet is completely secure.
+                </p>
+              </div>
+
+              <div>
+                <h2 className={H2}>Changes to this policy</h2>
+                <p className={P}>
+                  We may update this policy from time to time. The "last updated" date at the top
+                  shows when it last changed.
+                </p>
+              </div>
+
+              <div>
+                <h2 className={H2}>Contact us</h2>
+                <p className={P}>
+                  Questions about your privacy? Email{" "}
+                  <a href="mailto:harrison@tothepoint.co.nz" className={LINK}>
+                    harrison@tothepoint.co.nz
+                  </a>{" "}
+                  or call{" "}
+                  <a href="tel:+64212971237" className={LINK}>
+                    021 297 1237
+                  </a>
+                  .
+                </p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </FrostedSection>
+    </PageShell>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,8 +1,9 @@
 // src/app/privacy/page.tsx
 /**
- * @description Privacy policy: what we collect, how we use it, the analytics/ad
- * tools we run (Google, Meta Pixel incl. hashed advanced matching), and the
- * visitor's rights under the NZ Privacy Act 2020.
+ * @description Privacy policy: what the site collects, how it is used, the
+ * analytics/ad tools it runs (Google, Meta Pixel incl. hashed advanced
+ * matching), sharing, retention, and visitors' rights under the NZ Privacy
+ * Act 2020.
  */
 
 import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
@@ -23,7 +24,7 @@ export const metadata: Metadata = {
   },
 };
 
-/** Plain hyphen, NZ English. Last reviewed date shown to visitors. */
+/** Date this policy was last reviewed; shown to visitors in the header. */
 const LAST_UPDATED = "2 July 2026";
 
 const H2 = "mb-3 text-xl font-bold text-russian-violet sm:text-2xl";

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Tech Support Services - To The Point Tech",
     description:
-      "Computer repair, Wi-Fi setup, data recovery, smart home, printers, email and more across Auckland's Inner West.",
+      "Computer repair, Wi-Fi setup, data recovery, smart home, printers, email and more across Auckland.",
     url: "/services",
   },
 };

--- a/src/features/admin/components/ContactAdminList.tsx
+++ b/src/features/admin/components/ContactAdminList.tsx
@@ -53,6 +53,13 @@ interface EditFormState {
   cancel: () => void;
 }
 
+/**
+ * A card's role in an in-progress merge: "idle" (no merge running), "source"
+ * (this card is the one being merged away), or "target" (a candidate to merge
+ * the source into and keep).
+ */
+type MergeRole = "idle" | "source" | "target";
+
 interface ContactCardProps {
   c: ContactRow;
   /** Non-null only when this card is the one being edited. */
@@ -60,11 +67,20 @@ interface ContactCardProps {
   isSyncing: boolean;
   isConfirmingSync: boolean;
   isReviewsExpanded: boolean;
+  isConfirmingDelete: boolean;
+  isDeleting: boolean;
+  mergeRole: MergeRole;
   onStartEdit: () => void;
   onRequestSync: () => void;
   onConfirmSync: () => void;
   onCancelSync: () => void;
   onToggleReviews: () => void;
+  onRequestDelete: () => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+  onStartMerge: () => void;
+  onMergeHere: () => void;
+  onCancelMerge: () => void;
 }
 
 interface FieldRenderProps {
@@ -157,11 +173,20 @@ const CONTACT_EDIT_FIELDS: ReadonlyArray<ContactEditField> = [
  * @param props.isSyncing - True while this contact is mid-sync to Google.
  * @param props.isConfirmingSync - True when the sync confirmation panel is open.
  * @param props.isReviewsExpanded - True when the linked-reviews panel is open.
+ * @param props.isConfirmingDelete - True when the delete confirmation panel is open.
+ * @param props.isDeleting - True while this contact is mid-delete.
+ * @param props.mergeRole - This card's role in an in-progress merge (idle/source/target).
  * @param props.onStartEdit - Opens the edit form for this contact.
  * @param props.onRequestSync - Opens the sync-to-Google confirmation.
  * @param props.onConfirmSync - Confirms and runs the sync.
  * @param props.onCancelSync - Cancels the pending sync confirmation.
  * @param props.onToggleReviews - Toggles the linked-reviews panel.
+ * @param props.onRequestDelete - Opens the delete confirmation for this contact.
+ * @param props.onConfirmDelete - Confirms and runs the soft-delete.
+ * @param props.onCancelDelete - Cancels the pending delete confirmation.
+ * @param props.onStartMerge - Selects this contact as the one to merge away.
+ * @param props.onMergeHere - Merges the selected source contact into this one.
+ * @param props.onCancelMerge - Cancels the in-progress merge.
  * @returns Contact card element.
  */
 function ContactCard({
@@ -170,11 +195,20 @@ function ContactCard({
   isSyncing,
   isConfirmingSync,
   isReviewsExpanded,
+  isConfirmingDelete,
+  isDeleting,
+  mergeRole,
   onStartEdit,
   onRequestSync,
   onConfirmSync,
   onCancelSync,
   onToggleReviews,
+  onRequestDelete,
+  onConfirmDelete,
+  onCancelDelete,
+  onStartMerge,
+  onMergeHere,
+  onCancelMerge,
 }: ContactCardProps): React.ReactElement {
   if (edit) {
     return (
@@ -265,14 +299,64 @@ function ContactCard({
           {c.googleContactId && (
             <span className="rounded px-1.5 py-0.5 text-xs text-slate-400">Synced</span>
           )}
-          <button
-            onClick={onStartEdit}
-            className="rounded px-1.5 py-0.5 text-xs font-medium text-russian-violet/70 transition-colors hover:text-russian-violet"
-          >
-            Edit
-          </button>
+          {mergeRole === "target" ? (
+            <button
+              onClick={onMergeHere}
+              className="rounded bg-russian-violet px-1.5 py-0.5 text-xs font-semibold text-white transition-colors hover:bg-russian-violet/90"
+            >
+              Keep this one
+            </button>
+          ) : mergeRole === "source" ? (
+            <button
+              onClick={onCancelMerge}
+              className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-700 transition-colors hover:bg-amber-200"
+            >
+              Merging - cancel
+            </button>
+          ) : (
+            <>
+              <button
+                onClick={onStartEdit}
+                className="rounded px-1.5 py-0.5 text-xs font-medium text-russian-violet/70 transition-colors hover:text-russian-violet"
+              >
+                Edit
+              </button>
+              <button
+                onClick={onStartMerge}
+                className="rounded px-1.5 py-0.5 text-xs font-medium text-slate-400 transition-colors hover:text-russian-violet"
+              >
+                Merge
+              </button>
+              <button
+                onClick={onRequestDelete}
+                className="rounded px-1.5 py-0.5 text-xs font-medium text-slate-400 transition-colors hover:text-coquelicot-600"
+              >
+                Delete
+              </button>
+            </>
+          )}
         </div>
       </div>
+      {isConfirmingDelete && (
+        <div className="bg-coquelicot-50 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-coquelicot-200 px-3 py-2 text-xs">
+          <span className="font-medium text-coquelicot-700">Delete {c.name}?</span>
+          <span className="text-slate-500">Linked reviews are kept.</span>
+          <button
+            onClick={onConfirmDelete}
+            disabled={isDeleting}
+            className="ml-auto rounded bg-coquelicot-600 px-2 py-0.5 font-semibold text-white transition-colors hover:bg-coquelicot-700 disabled:opacity-50"
+          >
+            {isDeleting ? "Deleting…" : "Delete"}
+          </button>
+          <button
+            onClick={onCancelDelete}
+            disabled={isDeleting}
+            className="rounded bg-slate-100 px-2 py-0.5 font-semibold text-slate-600 transition-colors hover:bg-slate-200 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
       {c.email ? (
         <a
           href={`mailto:${c.email}`}
@@ -372,6 +456,11 @@ export function ContactAdminList({
   const [expandedReviewsId, setExpandedReviewsId] = useState<string | null>(null);
   const [syncedOpen, setSyncedOpen] = useState(true);
   const [query, setQuery] = useState("");
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  // Contact currently selected to merge away; while set, every other card offers
+  // to become the survivor. Null when no merge is in progress.
+  const [mergeSourceId, setMergeSourceId] = useState<string | null>(null);
 
   const NEW_CONTACT_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -571,6 +660,54 @@ export function ContactAdminList({
   }
 
   /**
+   * Soft-deletes a contact via the admin API and drops it from the list.
+   * @param id - Contact ID to delete.
+   */
+  async function deleteContact(id: string): Promise<void> {
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/admin/contacts/${id}`, { method: "DELETE", headers: {} });
+      const data = (await res.json()) as { ok: boolean };
+      if (data.ok) {
+        setContacts((prev) => prev.filter((c) => c.id !== id));
+      }
+    } catch (err) {
+      console.error("[ContactAdminList] Delete error:", err);
+    } finally {
+      setDeletingId(null);
+      setDeleteConfirmId(null);
+    }
+  }
+
+  /**
+   * Merges the selected source contact into the chosen primary, then drops the
+   * source (now soft-deleted) from the list.
+   * @param primaryId - The contact to keep.
+   */
+  async function mergeInto(primaryId: string): Promise<void> {
+    const secondaryId = mergeSourceId;
+    if (!secondaryId || secondaryId === primaryId) {
+      setMergeSourceId(null);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/admin/contacts/merge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ primaryId, secondaryId }),
+      });
+      const data = (await res.json()) as { ok: boolean };
+      if (data.ok) {
+        setContacts((prev) => prev.filter((c) => c.id !== secondaryId));
+      }
+    } catch (err) {
+      console.error("[ContactAdminList] Merge error:", err);
+    } finally {
+      setMergeSourceId(null);
+    }
+  }
+
+  /**
    * Wraps saveEdit to return void for use as an event handler.
    * @param id - Contact ID to save.
    */
@@ -594,6 +731,22 @@ export function ContactAdminList({
   }
 
   /**
+   * Wraps deleteContact to return void for use as an event handler.
+   * @param id - Contact ID to delete.
+   */
+  function handleDeleteContact(id: string): void {
+    void deleteContact(id);
+  }
+
+  /**
+   * Wraps mergeInto to return void for use as an event handler.
+   * @param id - Contact ID to keep (the merge target).
+   */
+  function handleMergeInto(id: string): void {
+    void mergeInto(id);
+  }
+
+  /**
    * Builds the per-card props (everything except `c` itself).
    * @param c - Contact row this card is for.
    * @returns Card props excluding `c`.
@@ -614,11 +767,20 @@ export function ContactAdminList({
       isSyncing: syncingId === c.id,
       isConfirmingSync: confirmSyncId === c.id,
       isReviewsExpanded: expandedReviewsId === c.id,
+      isConfirmingDelete: deleteConfirmId === c.id,
+      isDeleting: deletingId === c.id,
+      mergeRole: mergeSourceId === null ? "idle" : mergeSourceId === c.id ? "source" : "target",
       onStartEdit: startEdit.bind(null, c),
       onRequestSync: setConfirmSyncId.bind(null, c.id),
       onConfirmSync: handleConfirmSyncToGoogle.bind(null, c.id),
       onCancelSync: handleCancelSyncToGoogle,
       onToggleReviews: toggleReviews.bind(null, c.id),
+      onRequestDelete: setDeleteConfirmId.bind(null, c.id),
+      onConfirmDelete: handleDeleteContact.bind(null, c.id),
+      onCancelDelete: setDeleteConfirmId.bind(null, null),
+      onStartMerge: setMergeSourceId.bind(null, c.id),
+      onMergeHere: handleMergeInto.bind(null, c.id),
+      onCancelMerge: setMergeSourceId.bind(null, null),
     };
   }
 
@@ -632,6 +794,23 @@ export function ContactAdminList({
 
   return (
     <div className="flex flex-col gap-6">
+      {mergeSourceId && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <span>
+            Merging{" "}
+            <strong>{contacts.find((c) => c.id === mergeSourceId)?.name ?? "contact"}</strong> -
+            pick the contact to keep by clicking &ldquo;Keep this one&rdquo;. Its reviews move over
+            and this duplicate is removed.
+          </span>
+          <button
+            onClick={() => setMergeSourceId(null)}
+            className="ml-auto font-semibold text-amber-700 underline underline-offset-2 hover:text-amber-900"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
       {/* Search + export row */}
       <div className="flex items-center gap-3">
         <input

--- a/src/features/admin/components/ContactsAdminView.tsx
+++ b/src/features/admin/components/ContactsAdminView.tsx
@@ -5,7 +5,7 @@
  * conflicts for one-click resolution and drives the Google Contacts sync
  * (import + push) with a confirmation step and result message.
  */
-import type { ConflictEntry } from "@/app/api/admin/contacts/enrich-from-reviews/route";
+import type { ConflictEntry } from "@/features/contacts/lib/maintenance";
 import { cn } from "@/shared/lib/cn";
 import { useRouter } from "next/navigation";
 import type React from "react";

--- a/src/features/admin/components/settings/BenchmarkListField.tsx
+++ b/src/features/admin/components/settings/BenchmarkListField.tsx
@@ -14,7 +14,7 @@ import type React from "react";
 
 interface Props {
   benchmarks: Benchmark[];
-  /** Field path -> message, e.g. "benchmarks.2.mins". */
+  /** Field path > message, e.g. "benchmarks.2.mins". */
   fieldErrors: Record<string, string>;
   onChange: (next: Benchmark[]) => void;
 }

--- a/src/features/admin/components/settings/useSettingsForm.ts
+++ b/src/features/admin/components/settings/useSettingsForm.ts
@@ -24,7 +24,7 @@ export interface SettingsFormApi<G extends SettingsGroup> {
   setDraft: React.Dispatch<React.SetStateAction<Settings[G]>>;
   dirty: boolean;
   saving: boolean;
-  /** Field path -> message for inline errors. */
+  /** Field path > message for inline errors. */
   fieldErrors: Record<string, string>;
   /** Guardrail BLOCK messages (save refused). */
   blocks: string[];

--- a/src/features/admin/lib/auto-maintain.ts
+++ b/src/features/admin/lib/auto-maintain.ts
@@ -1,29 +1,39 @@
 // src/features/admin/lib/auto-maintain.ts
 /**
  * @description Server-side maintenance tasks that run on every admin page load.
- * Operations are idempotent and fast when there is nothing to do.
+ * Operations are idempotent and fast when there is nothing to do. The contact
+ * dedup/backfill/matching/enrich steps live in {@link module:features/contacts/lib/maintenance}
+ * so this page load and the standalone admin routes share one implementation;
+ * only the legacy ReviewRequest migration is unique to this entry point.
  */
 
-import type { ConflictEntry } from "@/app/api/admin/contacts/enrich-from-reviews/route";
-import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import {
+  backfillContactsFromBookings,
+  type ConflictEntry,
+  enrichContactsFromBookings,
+  matchReviewsToContacts,
+  mergePhoneOnlyContacts,
+} from "@/features/contacts/lib/maintenance";
+import { normaliseContactPhone } from "@/shared/lib/normalise-phone";
 import type { PrismaClient } from "@prisma/client";
 
 /**
  * Runs all maintenance tasks in order:
  * 1. Migrates legacy ReviewRequest send state onto Contact (one-shot per row, idempotent).
- * 2. Creates Contact records for any booking email not yet in the DB.
+ * 2. Merges phone-only duplicate contacts, then creates Contacts for any booking email not in the DB.
  * 3. Links Review records to their matching Contact by email or phone.
  * 4. Auto-fills missing contact fields from bookings.
- * Returns conflict entries (differing values) for the admin to resolve.
+ * Returns booking-sourced conflict entries (differing values) for the admin to resolve.
  * @param prisma - Prisma client instance.
  * @returns Array of conflict entries for admin resolution.
  */
 export async function autoMaintain(prisma: PrismaClient): Promise<ConflictEntry[]> {
   // Migration runs first so subsequent steps see the unified Contact state.
   await migrateReviewRequestsToContacts(prisma);
-  await backfillContacts(prisma);
-  await matchReviewContacts(prisma);
-  return autoEnrich(prisma);
+  await mergePhoneOnlyContacts();
+  await backfillContactsFromBookings();
+  await matchReviewsToContacts();
+  return enrichContactsFromBookings();
 }
 
 /**
@@ -78,10 +88,8 @@ async function migrateReviewRequestsToContacts(prisma: PrismaClient): Promise<vo
   );
   const contactByPhone = new Map<string, (typeof contacts)[number]>();
   for (const c of contacts) {
-    if (c.phone) {
-      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
-      if (norm) contactByPhone.set(norm, c);
-    }
+    const norm = normaliseContactPhone(c.phone);
+    if (norm) contactByPhone.set(norm, c);
   }
 
   /**
@@ -112,9 +120,7 @@ async function migrateReviewRequestsToContacts(prisma: PrismaClient): Promise<vo
     const contact = rrContactId
       ? contactById.get(rrContactId)
       : ((rr.email ? contactByEmail.get(rr.email.toLowerCase()) : undefined) ??
-        (rr.phone
-          ? contactByPhone.get(normalisePhone(toE164NZ(rr.phone) || rr.phone) ?? "")
-          : undefined));
+        (rr.phone ? contactByPhone.get(normaliseContactPhone(rr.phone) ?? "") : undefined));
     if (!contact) continue;
 
     const createdAt = unwrapDate(rr.createdAt);
@@ -143,337 +149,4 @@ async function migrateReviewRequestsToContacts(prisma: PrismaClient): Promise<vo
 
     await prisma.contact.update({ where: { id: contact.id }, data: update }).catch(() => null);
   }
-}
-
-/**
- * Creates a Contact for every unique email found in Booking records that does
- * not already have a corresponding Contact. Also merges phone-only contacts
- * into their email-based counterpart when both share the same phone number.
- * Existing contacts are never overwritten - admin edits are the source of truth.
- * @param prisma - Prisma client instance.
- */
-async function backfillContacts(prisma: PrismaClient): Promise<void> {
-  const [bookings, allContacts] = await Promise.all([
-    prisma.booking.findMany({
-      orderBy: { createdAt: "asc" },
-      select: { name: true, email: true, phone: true, notes: true },
-    }),
-    prisma.contact.findMany({ select: { id: true, email: true, phone: true, name: true } }),
-  ]);
-
-  // --- Step 1: Merge phone-only contacts into their email-based counterpart ---
-  // Build buckets keyed by normalised phone: { withEmail, phoneOnly[] }
-  const phoneBuckets = new Map<
-    string,
-    {
-      withEmail: (typeof allContacts)[number] | null;
-      phoneOnly: (typeof allContacts)[number][];
-    }
-  >();
-  for (const c of allContacts) {
-    if (!c.phone) continue;
-    const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
-    if (!norm) continue;
-    if (!phoneBuckets.has(norm)) phoneBuckets.set(norm, { withEmail: null, phoneOnly: [] });
-    const bucket = phoneBuckets.get(norm)!;
-    if (c.email) bucket.withEmail ??= c;
-    else bucket.phoneOnly.push(c);
-  }
-
-  const deletedIds = new Set<string>();
-  for (const { withEmail, phoneOnly } of phoneBuckets.values()) {
-    if (!withEmail || phoneOnly.length === 0) continue;
-    for (const dup of phoneOnly) {
-      await prisma.review
-        .updateMany({ where: { contactId: dup.id }, data: { contactId: withEmail.id } })
-        .catch(() => null);
-      await prisma.contact.delete({ where: { id: dup.id } }).catch(() => null);
-      deletedIds.add(dup.id);
-    }
-  }
-
-  // Work with the post-merge contact list so the sets below are accurate
-  const existing = allContacts.filter((c) => !deletedIds.has(c.id));
-
-  const existingEmails = new Set(
-    existing.filter((c) => c.email).map((c) => c.email!.toLowerCase()),
-  );
-  // Remaining phone-only contacts (post-merge) - used to merge-on-create below
-  const phoneOnlyByNorm = new Map<string, (typeof existing)[number]>();
-  for (const c of existing) {
-    if (!c.email && c.phone) {
-      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
-      if (norm) phoneOnlyByNorm.set(norm, c);
-    }
-  }
-
-  const toCreateByEmail = new Map<
-    string,
-    { name: string; email: string; phone: string | null; address: string | null }
-  >();
-
-  // Bookings sorted asc - most recent overwrites earlier entries in the Map
-  for (const b of bookings) {
-    const email = b.email.toLowerCase();
-    if (existingEmails.has(email)) continue;
-    const address = b.notes?.match(/Address:\s*(.+)/i)?.[1]?.trim() ?? null;
-    toCreateByEmail.set(email, { name: b.name, email, phone: b.phone ?? null, address });
-  }
-
-  if (toCreateByEmail.size === 0) return;
-
-  await Promise.all(
-    [...toCreateByEmail.values()].map(async (d) => {
-      // If a phone-only contact already has this phone, merge email into it rather than
-      // creating a duplicate contact.
-      if (d.phone) {
-        const norm = normalisePhone(toE164NZ(d.phone) || d.phone);
-        const phoneOnlyMatch = norm ? phoneOnlyByNorm.get(norm) : undefined;
-        if (phoneOnlyMatch) {
-          const updates: { email: string; name?: string; address?: string } = { email: d.email };
-          if (d.name.toLowerCase().startsWith(phoneOnlyMatch.name.toLowerCase() + " ")) {
-            updates.name = d.name;
-          }
-          if (d.address) updates.address = d.address;
-          return prisma.contact
-            .update({ where: { id: phoneOnlyMatch.id }, data: updates })
-            .catch(() => null);
-        }
-      }
-      return prisma.contact
-        .findFirst({ where: { email: d.email } })
-        .then((exists) => (exists ? null : prisma.contact.create({ data: d })))
-        .catch(() => null);
-    }),
-  );
-}
-
-/**
- * Links Review records that have no contactId to their matching Contact.
- * Booking-linked reviews resolve via the booking's email/phone; standalone
- * reviews resolve by their customerRef matching Contact.reviewToken.
- * @param prisma - Prisma client instance.
- */
-async function matchReviewContacts(prisma: PrismaClient): Promise<void> {
-  // MongoDB gotcha: `contactId: null` only matches documents where the field
-  // exists and equals null. Reviews created before contactId was added to the
-  // schema have no contactId field at all, so they need the `isSet: false`
-  // branch to be matched and eligible for auto-linking.
-  const unlinked = await prisma.review.findMany({
-    where: { OR: [{ contactId: null }, { contactId: { isSet: false } }] },
-    select: { id: true, bookingId: true, customerRef: true },
-  });
-
-  if (unlinked.length === 0) return;
-
-  const bookingIds = unlinked.map((r) => r.bookingId).filter((id): id is string => id !== null);
-
-  // Fetch related bookings and contacts
-  const [bookingRows, contacts] = await Promise.all([
-    bookingIds.length > 0
-      ? prisma.booking.findMany({
-          where: { id: { in: bookingIds } },
-          select: { id: true, email: true, phone: true },
-        })
-      : Promise.resolve([]),
-    prisma.contact.findMany({
-      select: { id: true, email: true, phone: true, reviewToken: true },
-    }),
-  ]);
-
-  // Build lookup maps
-  const bookingEmailById = new Map(bookingRows.map((b) => [b.id, b.email.toLowerCase()]));
-  const bookingPhoneById = new Map<string, string>();
-  for (const b of bookingRows) {
-    if (b.phone) {
-      const norm = normalisePhone(toE164NZ(b.phone) || b.phone);
-      if (norm) bookingPhoneById.set(b.id, norm);
-    }
-  }
-
-  const contactIdByEmail = new Map(
-    contacts.filter((c) => c.email).map((c) => [c.email!.toLowerCase(), c.id]),
-  );
-  const contactIdByPhone = new Map<string, string>();
-  for (const c of contacts) {
-    if (c.phone) {
-      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
-      if (norm && !contactIdByPhone.has(norm)) contactIdByPhone.set(norm, c.id);
-    }
-  }
-  const contactIdByToken = new Map(
-    contacts.filter((c) => c.reviewToken).map((c) => [c.reviewToken!, c.id]),
-  );
-
-  // Link each review to its contact
-  await Promise.all(
-    unlinked.map(async (r) => {
-      let contactId: string | undefined;
-
-      if (r.bookingId) {
-        const email = bookingEmailById.get(r.bookingId);
-        if (email) contactId = contactIdByEmail.get(email);
-        if (!contactId) {
-          const phone = bookingPhoneById.get(r.bookingId);
-          if (phone) contactId = contactIdByPhone.get(phone);
-        }
-      } else if (r.customerRef) {
-        contactId = contactIdByToken.get(r.customerRef);
-      }
-
-      if (!contactId) return;
-      await prisma.review.update({ where: { id: r.id }, data: { contactId } }).catch(() => null);
-    }),
-  );
-}
-
-/**
- * Auto-fills missing contact fields (phone, address) from the most recent
- * matching Booking. Returns a list of conflicts where existing contact data
- * differs from the source data.
- * @param prisma - Prisma client instance.
- * @returns Array of conflicts for admin resolution.
- */
-async function autoEnrich(prisma: PrismaClient): Promise<ConflictEntry[]> {
-  const [contacts, bookings] = await Promise.all([
-    prisma.contact.findMany({
-      select: { id: true, name: true, email: true, phone: true, address: true },
-    }),
-    prisma.booking.findMany({
-      orderBy: { createdAt: "desc" },
-      select: { id: true, name: true, email: true, phone: true, notes: true },
-    }),
-  ]);
-
-  // Build contact lookup maps
-  const contactByEmail = new Map(
-    contacts.filter((c) => c.email).map((c) => [c.email!.toLowerCase(), c]),
-  );
-  const contactByPhone = new Map<string, (typeof contacts)[0]>();
-  for (const c of contacts) {
-    if (c.phone) {
-      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
-      if (norm && !contactByPhone.has(norm)) contactByPhone.set(norm, c);
-    }
-  }
-
-  /**
-   * Finds a contact by email (primary) or normalised phone (fallback).
-   * @param email - Email to look up.
-   * @param phone - Phone to fall back to.
-   * @returns Matching contact or undefined.
-   */
-  function findContact(
-    email: string | null | undefined,
-    phone: string | null | undefined,
-  ): (typeof contacts)[0] | undefined {
-    if (email) {
-      const c = contactByEmail.get(email.toLowerCase());
-      if (c) return c;
-    }
-    if (phone) {
-      const norm = normalisePhone(toE164NZ(phone) || phone);
-      if (norm) return contactByPhone.get(norm);
-    }
-    return undefined;
-  }
-
-  // Update and conflict accumulators
-  const conflicts: ConflictEntry[] = [];
-  const conflictSeen = new Set<string>();
-  const phoneFilled = new Set<string>();
-  const nameFilled = new Set<string>();
-  const addressFilled = new Set<string>();
-  const phoneUpdates = new Map<string, string>();
-  const nameUpdates = new Map<string, string>();
-  const addressUpdates = new Map<string, string>();
-
-  // Bookings - newest first per contact: fill phone + address, detect conflicts
-  for (const booking of bookings) {
-    const contact = findContact(booking.email, booking.phone);
-    if (!contact) continue;
-
-    const proposedPhoneRaw = booking.phone?.trim() ?? null;
-    const proposedPhone = proposedPhoneRaw ? normalisePhone(proposedPhoneRaw) : null;
-    const existingPhone = contact.phone ? normalisePhone(contact.phone) : null;
-    const address = booking.notes?.match(/Address:\s*(.+)/i)?.[1]?.trim() ?? null;
-
-    if (proposedPhone && !existingPhone && !phoneFilled.has(contact.id)) {
-      phoneFilled.add(contact.id);
-      phoneUpdates.set(contact.id, toE164NZ(proposedPhoneRaw!) || proposedPhoneRaw!);
-    }
-
-    if (address && !contact.address && !addressFilled.has(contact.id)) {
-      addressFilled.add(contact.id);
-      addressUpdates.set(contact.id, address);
-    }
-
-    // Auto-fill name when contact has only a first name and source provides full name.
-    const proposedNameBooking = booking.name.trim();
-    if (
-      proposedNameBooking &&
-      contact.name &&
-      !nameFilled.has(contact.id) &&
-      proposedNameBooking.toLowerCase().startsWith(contact.name.toLowerCase() + " ")
-    ) {
-      nameFilled.add(contact.id);
-      nameUpdates.set(contact.id, proposedNameBooking);
-    }
-
-    if (!conflictSeen.has(contact.id)) {
-      conflictSeen.add(contact.id);
-      const conflictFields: ("name" | "phone")[] = [];
-      const proposedName = proposedNameBooking;
-      const contactNameLower = contact.name.toLowerCase();
-      const proposedNameLower = proposedName.toLowerCase();
-      // Only flag a name conflict when the proposed name is genuinely different -
-      // not when it is simply the contact's first name without the last name.
-      if (
-        proposedName &&
-        contact.name &&
-        proposedNameLower !== contactNameLower &&
-        !contactNameLower.startsWith(proposedNameLower + " ") &&
-        !proposedNameLower.startsWith(contactNameLower + " ")
-      ) {
-        conflictFields.push("name");
-      }
-      if (proposedPhone && existingPhone && proposedPhone !== existingPhone) {
-        conflictFields.push("phone");
-      }
-      if (conflictFields.length > 0) {
-        conflicts.push({
-          contactId: contact.id,
-          contactName: contact.name,
-          contactEmail: contact.email,
-          contactPhone: contact.phone,
-          source: "Booking",
-          sourceId: booking.id,
-          sourceName: conflictFields.includes("name") ? proposedName : null,
-          sourcePhone: conflictFields.includes("phone") ? proposedPhoneRaw : null,
-          conflictFields,
-        });
-      }
-    }
-  }
-
-  // Merge per-field updates by contact id so each contact gets at most one
-  // write (instead of up to three round-trips when phone/name/address all
-  // changed in the same pass).
-  const mergedUpdates = new Map<string, { phone?: string; name?: string; address?: string }>();
-  for (const [id, phone] of phoneUpdates) {
-    mergedUpdates.set(id, { ...mergedUpdates.get(id), phone });
-  }
-  for (const [id, name] of nameUpdates) {
-    mergedUpdates.set(id, { ...mergedUpdates.get(id), name });
-  }
-  for (const [id, address] of addressUpdates) {
-    mergedUpdates.set(id, { ...mergedUpdates.get(id), address });
-  }
-  await Promise.all(
-    [...mergedUpdates.entries()].map(([id, data]) =>
-      prisma.contact.update({ where: { id }, data }),
-    ),
-  );
-
-  return conflicts;
 }

--- a/src/features/admin/lib/auto-maintain.ts
+++ b/src/features/admin/lib/auto-maintain.ts
@@ -3,8 +3,7 @@
  * @description Server-side maintenance tasks that run on every admin page load.
  * Operations are idempotent and fast when there is nothing to do. The contact
  * dedup/backfill/matching/enrich steps live in {@link module:features/contacts/lib/maintenance}
- * so this page load and the standalone admin routes share one implementation;
- * only the legacy ReviewRequest migration is unique to this entry point.
+ * so this page load and the standalone admin routes share one implementation.
  */
 
 import {
@@ -14,139 +13,18 @@ import {
   matchReviewsToContacts,
   mergePhoneOnlyContacts,
 } from "@/features/contacts/lib/maintenance";
-import { normaliseContactPhone } from "@/shared/lib/normalise-phone";
-import type { PrismaClient } from "@prisma/client";
 
 /**
  * Runs all maintenance tasks in order:
- * 1. Migrates legacy ReviewRequest send state onto Contact (one-shot per row, idempotent).
- * 2. Merges phone-only duplicate contacts, then creates Contacts for any booking email not in the DB.
- * 3. Links Review records to their matching Contact by email or phone.
- * 4. Auto-fills missing contact fields from bookings.
+ * 1. Merges phone-only duplicate contacts, then creates Contacts for any booking email not in the DB.
+ * 2. Links Review records to their matching Contact by email or phone.
+ * 3. Auto-fills missing contact fields from bookings.
  * Returns booking-sourced conflict entries (differing values) for the admin to resolve.
- * @param prisma - Prisma client instance.
  * @returns Array of conflict entries for admin resolution.
  */
-export async function autoMaintain(prisma: PrismaClient): Promise<ConflictEntry[]> {
-  // Migration runs first so subsequent steps see the unified Contact state.
-  await migrateReviewRequestsToContacts(prisma);
+export async function autoMaintain(): Promise<ConflictEntry[]> {
   await mergePhoneOnlyContacts();
   await backfillContactsFromBookings();
   await matchReviewsToContacts();
   return enrichContactsFromBookings();
-}
-
-/**
- * Lifts ReviewRequest state onto Contact. The ReviewRequest model is no
- * longer in the Prisma schema, so the orphaned collection is read via raw
- * MongoDB to bridge any pre-retirement rows into Contact fields. For each
- * row with a resolvable contact, sets
- * Contact.reviewToken (only if null), Contact.reviewLinkSentAt (only if
- * older or null), Contact.reviewLinkSentMode (when missing), and
- * Contact.reviewLinkSubmittedAt (when newer or null). Idempotent.
- * @param prisma - Prisma client instance.
- */
-async function migrateReviewRequestsToContacts(prisma: PrismaClient): Promise<void> {
-  interface OrphanedRR {
-    _id: { $oid: string } | string;
-    contactId?: { $oid: string } | string | null;
-    email?: string | null;
-    phone?: string | null;
-    reviewToken: string;
-    reviewSubmittedAt?: { $date: string } | Date | null;
-    createdAt: { $date: string } | Date;
-  }
-
-  // Read orphaned ReviewRequest rows
-  let rrs: OrphanedRR[] = [];
-  try {
-    const result = (await prisma.$runCommandRaw({
-      find: "ReviewRequest",
-      filter: {},
-    })) as { cursor?: { firstBatch?: OrphanedRR[] } };
-    rrs = result.cursor?.firstBatch ?? [];
-  } catch {
-    // Collection doesn't exist (fresh DB or already cleaned up) - nothing to do.
-    return;
-  }
-  if (rrs.length === 0) return;
-
-  // Build contact lookup maps
-  const contacts = await prisma.contact.findMany({
-    select: {
-      id: true,
-      email: true,
-      phone: true,
-      reviewToken: true,
-      reviewLinkSentAt: true,
-      reviewLinkSubmittedAt: true,
-    },
-  });
-  const contactById = new Map(contacts.map((c) => [c.id, c]));
-  const contactByEmail = new Map(
-    contacts.filter((c) => c.email).map((c) => [c.email!.toLowerCase(), c]),
-  );
-  const contactByPhone = new Map<string, (typeof contacts)[number]>();
-  for (const c of contacts) {
-    const norm = normaliseContactPhone(c.phone);
-    if (norm) contactByPhone.set(norm, c);
-  }
-
-  /**
-   * Pulls an ObjectId hex string out of the extended-JSON shape Mongo's raw
-   * cursor returns. The driver sometimes returns `{ $oid: "..." }` and
-   * sometimes the bare string, depending on the call site.
-   * @param v - Raw value from the cursor (string, extended-JSON object, or null).
-   * @returns The hex id, or null when the input is missing.
-   */
-  function unwrapOid(v: OrphanedRR["contactId"]): string | null {
-    if (!v) return null;
-    if (typeof v === "string") return v;
-    return v.$oid;
-  }
-  /**
-   * Coerces an extended-JSON date (or already-Date) into a Date object.
-   * @param v - Raw date value from the cursor.
-   * @returns Date instance.
-   */
-  function unwrapDate(v: OrphanedRR["createdAt"]): Date {
-    if (v instanceof Date) return v;
-    return new Date(v.$date);
-  }
-
-  // Lift each row's send state onto its contact
-  for (const rr of rrs) {
-    const rrContactId = unwrapOid(rr.contactId ?? null);
-    const contact = rrContactId
-      ? contactById.get(rrContactId)
-      : ((rr.email ? contactByEmail.get(rr.email.toLowerCase()) : undefined) ??
-        (rr.phone ? contactByPhone.get(normaliseContactPhone(rr.phone) ?? "") : undefined));
-    if (!contact) continue;
-
-    const createdAt = unwrapDate(rr.createdAt);
-    const submittedAt = rr.reviewSubmittedAt ? unwrapDate(rr.reviewSubmittedAt) : null;
-
-    const update: {
-      reviewToken?: string;
-      reviewLinkSentAt?: Date;
-      reviewLinkSentMode?: "email" | "sms";
-      reviewLinkSubmittedAt?: Date;
-    } = {};
-
-    if (!contact.reviewToken && rr.reviewToken) update.reviewToken = rr.reviewToken;
-    if (!contact.reviewLinkSentAt || contact.reviewLinkSentAt < createdAt) {
-      update.reviewLinkSentAt = createdAt;
-      update.reviewLinkSentMode = rr.email ? "email" : rr.phone ? "sms" : undefined;
-    }
-    if (
-      submittedAt &&
-      (!contact.reviewLinkSubmittedAt || contact.reviewLinkSubmittedAt < submittedAt)
-    ) {
-      update.reviewLinkSubmittedAt = submittedAt;
-    }
-
-    if (Object.keys(update).length === 0) continue;
-
-    await prisma.contact.update({ where: { id: contact.id }, data: update }).catch(() => null);
-  }
 }

--- a/src/features/business/lib/contact-review-token.ts
+++ b/src/features/business/lib/contact-review-token.ts
@@ -65,7 +65,7 @@ export async function resolveInvoiceReviewUrl({
   if (trimmedEmail) {
     try {
       const match = await prisma.contact.findFirst({
-        where: { email: { equals: trimmedEmail, mode: "insensitive" } },
+        where: { email: { equals: trimmedEmail, mode: "insensitive" }, deletedAt: null },
         select: { id: true, reviewToken: true },
       });
       if (match) {
@@ -170,6 +170,7 @@ export async function getInvoiceReviewEligibility({
           where: {
             email: { equals: trimmedEmail, mode: "insensitive" },
             reviewLinkSentAt: { gte: cooldownStart },
+            deletedAt: null,
           },
           select: { reviewLinkSentAt: true },
           orderBy: { reviewLinkSentAt: "desc" },

--- a/src/features/business/lib/prompts/parse-job.ts
+++ b/src/features/business/lib/prompts/parse-job.ts
@@ -58,7 +58,7 @@ DEVICE vocabulary (suggested, but extensible — invent a similarly short generi
 - "Email account" = email service (Gmail, Outlook, iCloud Mail).
 - "Social media account" = social profile (Facebook, Instagram, WhatsApp).
 - "Streaming account" = streaming / music service (Netflix, Spotify, Disney+).
-- "Cloud storage" = cloud file storage / backup (iCloud, Dropbox, OneDrive, Google Drive).
+- "Cloud storage" = cloud file storage / backup (iCloud Drive, Dropbox, OneDrive, Google Drive) - use ONLY when the work is about files, backup, sync, or storage space. The Apple ID / Google account ITSELF (the login governing App Store / Play Store sign-in, purchases, or device activation) is NOT cloud storage even though the same login also unlocks iCloud/Drive - tag account-level work "Software" and put the account brand in details ("Apple ID, App Store"). Only tag "Cloud storage" when the customer's actual files or backup are the subject.
 - "Software" = an app or program not tied to one physical device (ChatGPT, Excel, Word, Finder, web browser).
 - "Banking" = online banking / payments (internet banking, bank login).
 - "Other" = genuine catch-all when nothing above fits; use sparingly.
@@ -99,6 +99,8 @@ EXAMPLES — multi-task splitting + specific actions + details:
   Tasks: [{device: "Laptop", action: "Driver repair", details: "Dell, blue screen"}]
 - Input: "explained and guided how to use ChatGPT, Excel, iCloud, Finder and more"  (general app tuition → one Software task, NOT "Other")
   Tasks: [{device: "Software", action: "Training", details: "ChatGPT, Excel, iCloud, Finder"}]
+- Input: "Apple App Store iCloud account fix"  (the Apple account/login itself - App Store sign-in + iCloud login - NOT file storage; do NOT tag Cloud storage)
+  Tasks: [{device: "Software", action: "Account recovery", details: "iCloud, App Store"}]
 - Input: "email not working - diagnosed delivery issues, fixed DNS/routing records across multiple providers, reconfigured Outlook POP3/SMTP for multiple accounts, fixed Gmail rejecting outbound mail due to missing SPF/DKIM"  (4 distinct services - do NOT collapse; Network for DNS work; DNS/POP3/SMTP are fine in output details; SPF/DKIM/MX appear in the input but stay out of output details per JARGON BAN; domain names and registrar names are forbidden; use positive outcome language not failure phrases)
   Tasks: [{device: "Email account", action: "Diagnosis", details: "not sending, not receiving"}, {device: "Network", action: "Configuration", details: "DNS, multiple providers"}, {device: "Email account", action: "Configuration", details: "Outlook, POP3/SMTP, multiple accounts"}, {device: "Email account", action: "Security", details: "Gmail, outbound mail"}]
 

--- a/src/features/contacts/lib/contacts-sync.ts
+++ b/src/features/contacts/lib/contacts-sync.ts
@@ -1,0 +1,87 @@
+// src/features/contacts/lib/contacts-sync.ts
+// Orchestrates a two-way Google Contacts sync. Runs the local dedup/merge
+// maintenance FIRST so duplicates are never propagated up to Google, then pushes
+// only the contacts that actually changed (the dirty set), then pulls Google's
+// changes back in. Reuses the per-contact merge/conflict engine in
+// google-contacts.ts unchanged - this module only decides what to sync and when.
+
+import { prisma } from "@/shared/lib/prisma";
+import { importFromGoogleContacts, syncContactToGoogle } from "./google-contacts";
+import {
+  backfillContactsFromBookings,
+  matchReviewsToContacts,
+  mergePhoneOnlyContacts,
+} from "./maintenance";
+
+/** Outcome counts from a {@link runContactsSync} pass. */
+export interface ContactsSyncResult {
+  /** Contacts pushed to Google this run. */
+  pushed: number;
+  /** Contacts pulled/linked from Google this run. */
+  imported: number;
+  /** Unresolved contact conflicts remaining after the run. */
+  conflicts: number;
+  /** Contacts skipped because they have an unresolved conflict. */
+  skipped: number;
+}
+
+/**
+ * Runs a two-way contacts sync.
+ *
+ * Order matters: local maintenance (phone-only merge, booking backfill, review
+ * linking) runs first so the push never sends duplicate rows to Google. The push
+ * then targets only the "dirty" set - contacts with no googleContactId (never
+ * synced, e.g. those created from bookings), no lastSyncedAt, or a local change
+ * since the last sync - unless `full` forces every email-bearing contact. Contacts
+ * with an unresolved conflict are skipped so a pending admin decision isn't
+ * clobbered. Phone-only contacts (no email) are pull-only, as in the manual flow.
+ * @param options - Sync options.
+ * @param options.full - Push every email-bearing contact instead of just the dirty set.
+ * @returns Counts of pushed, imported, remaining conflicts, and skipped contacts.
+ */
+export async function runContactsSync({
+  full = false,
+}: { full?: boolean } = {}): Promise<ContactsSyncResult> {
+  // 1. Clean up locally so duplicates never propagate to Google.
+  await mergePhoneOnlyContacts();
+  await backfillContactsFromBookings();
+  await matchReviewsToContacts();
+
+  // 2. Build the push set from live, email-bearing contacts.
+  const contacts = await prisma.contact.findMany({
+    where: { deletedAt: null, email: { not: null } },
+    select: { id: true, updatedAt: true, lastSyncedAt: true, googleContactId: true },
+  });
+
+  const pendingConflicts = await prisma.contactConflict.findMany({
+    where: { resolvedAt: null },
+    select: { contactId: true },
+  });
+  const conflictedIds = new Set(pendingConflicts.map((c) => c.contactId));
+
+  const dirty = contacts.filter((c) => {
+    if (conflictedIds.has(c.id)) return false;
+    if (full) return true;
+    if (!c.googleContactId) return true;
+    if (!c.lastSyncedAt) return true;
+    return c.updatedAt.getTime() > c.lastSyncedAt.getTime();
+  });
+
+  let pushed = 0;
+  for (const c of dirty) {
+    try {
+      await syncContactToGoogle(c.id);
+      pushed++;
+    } catch (err) {
+      // syncContactToGoogle already swallows its own errors; this guards against
+      // anything unexpected so one bad contact can't abort the whole run.
+      console.error(`[contacts-sync] push failed for ${c.id}:`, err);
+    }
+  }
+
+  // 3. Pull Google's changes back in.
+  const imported = await importFromGoogleContacts();
+
+  const conflicts = await prisma.contactConflict.count({ where: { resolvedAt: null } });
+  return { pushed, imported, conflicts, skipped: conflictedIds.size };
+}

--- a/src/features/contacts/lib/find-or-create.ts
+++ b/src/features/contacts/lib/find-or-create.ts
@@ -9,12 +9,13 @@
  * create pattern below is the canonical replacement.
  */
 
+import { normaliseContactPhone } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
 import type { Contact } from "@prisma/client";
 
 /**
- * Fields used when creating a Contact. Caller is responsible for any
- * normalisation (trim, lowercase email, E.164 phone) before passing in.
+ * Fields used when creating a Contact. The helpers normalise the match key
+ * themselves, so callers may pass raw or pre-normalised values.
  */
 export interface ContactSeed {
   name: string;
@@ -30,10 +31,12 @@ export interface FindOrCreateResult {
 }
 
 /**
- * Finds a Contact by email, creating one with `seed` if none exists. The
- * email passed in is also written to the created row, overriding any email
- * present on `seed`.
- * @param email - Normalised (trimmed, lowercased) email to match on.
+ * Finds a Contact by email, creating one with `seed` if none exists. Matching is
+ * case-insensitive and the email is stored lowercased, so callers can't create a
+ * duplicate just by varying case. Soft-deleted contacts are ignored (a fresh row
+ * is created). The email passed in is written to the created row, overriding any
+ * email present on `seed`.
+ * @param email - Email to match on (normalised internally).
  * @param seed - Fields used if a new row is created.
  * @returns The contact and whether it was newly created.
  */
@@ -41,12 +44,15 @@ export async function findOrCreateContactByEmail(
   email: string,
   seed: ContactSeed,
 ): Promise<FindOrCreateResult> {
-  const existing = await prisma.contact.findFirst({ where: { email } });
+  const normalisedEmail = email.trim().toLowerCase();
+  const existing = await prisma.contact.findFirst({
+    where: { email: { equals: normalisedEmail, mode: "insensitive" }, deletedAt: null },
+  });
   if (existing) return { contact: existing, created: false };
   const contact = await prisma.contact.create({
     data: {
       name: seed.name,
-      email,
+      email: normalisedEmail,
       phone: seed.phone ?? null,
       address: seed.address ?? null,
       googleContactId: seed.googleContactId ?? null,
@@ -56,10 +62,11 @@ export async function findOrCreateContactByEmail(
 }
 
 /**
- * Finds a Contact by phone, creating one with `seed` if none exists. The
- * phone passed in is also written to the created row, overriding any phone
- * present on `seed`.
- * @param phone - Normalised (E.164) phone number to match on.
+ * Finds a Contact by phone, creating one with `seed` if none exists. The phone
+ * is normalised to its canonical E.164 key for matching and storage, so callers
+ * can pass raw input. Soft-deleted contacts are ignored. The phone passed in is
+ * written to the created row, overriding any phone present on `seed`.
+ * @param phone - Phone number to match on (normalised internally).
  * @param seed - Fields used if a new row is created.
  * @returns The contact and whether it was newly created.
  */
@@ -67,13 +74,16 @@ export async function findOrCreateContactByPhone(
   phone: string,
   seed: ContactSeed,
 ): Promise<FindOrCreateResult> {
-  const existing = await prisma.contact.findFirst({ where: { phone } });
+  const normalisedPhone = normaliseContactPhone(phone) ?? phone;
+  const existing = await prisma.contact.findFirst({
+    where: { phone: normalisedPhone, deletedAt: null },
+  });
   if (existing) return { contact: existing, created: false };
   const contact = await prisma.contact.create({
     data: {
       name: seed.name,
       email: seed.email ?? null,
-      phone,
+      phone: normalisedPhone,
       address: seed.address ?? null,
       googleContactId: seed.googleContactId ?? null,
     },

--- a/src/features/contacts/lib/google-contacts.ts
+++ b/src/features/contacts/lib/google-contacts.ts
@@ -8,10 +8,11 @@
  */
 
 import { getOAuth2Client } from "@/features/calendar/lib/google-calendar";
-import { normalisePhone, toE164NZ } from "@/shared/lib/normalise-phone";
+import { normaliseContactPhone, toE164NZ } from "@/shared/lib/normalise-phone";
 import { prisma } from "@/shared/lib/prisma";
 import { google } from "googleapis";
 import { clearContactConflict, recordContactConflict } from "./contact-conflicts";
+import { splitName } from "./split-name";
 
 /**
  * Returns an authenticated Google People API client.
@@ -20,6 +21,20 @@ import { clearContactConflict, recordContactConflict } from "./contact-conflicts
 function getPeopleClient(): ReturnType<typeof google.people> {
   const auth = getOAuth2Client();
   return google.people({ version: "v1", auth });
+}
+
+/**
+ * Best-effort deletion of a Google contact by resource name. Used when a local
+ * contact is deleted or merged away so the Google side doesn't keep a stale row.
+ * Never throws - a failure here must not fail the local operation.
+ * @param resourceName - Google People API resource name (e.g. "people/c123").
+ */
+export async function deleteContactFromGoogle(resourceName: string): Promise<void> {
+  try {
+    await getPeopleClient().people.deleteContact({ resourceName });
+  } catch (err) {
+    console.error(`[google-contacts] deleteContactFromGoogle failed for ${resourceName}:`, err);
+  }
 }
 
 /**
@@ -36,12 +51,12 @@ export async function importFromGoogleContacts(): Promise<number> {
     // contacts can be matched to a known email and imported.
     const contactEmailByPhone = new Map<string, string>();
     const contactRows = await prisma.contact.findMany({
-      where: { phone: { not: null }, email: { not: null } },
+      where: { phone: { not: null }, email: { not: null }, deletedAt: null },
       select: { phone: true, email: true },
     });
     for (const c of contactRows) {
       if (!c.phone || !c.email) continue;
-      const norm = normalisePhone(toE164NZ(c.phone) || c.phone);
+      const norm = normaliseContactPhone(c.phone);
       if (norm && !contactEmailByPhone.has(norm)) contactEmailByPhone.set(norm, c.email);
     }
 
@@ -80,7 +95,7 @@ export async function importFromGoogleContacts(): Promise<number> {
         const emailEntry = person.emailAddresses?.[0]?.value?.trim().toLowerCase() ?? null;
         const rawPhone = person.phoneNumbers?.[0]?.value?.trim() ?? null;
         const phone = rawPhone ? toE164NZ(rawPhone) || rawPhone : null;
-        const normPhone = rawPhone ? normalisePhone(toE164NZ(rawPhone) || rawPhone) : null;
+        const normPhone = normaliseContactPhone(rawPhone);
         const name =
           person.names?.[0]?.displayName?.trim() ??
           person.names?.[0]?.givenName?.trim() ??
@@ -104,13 +119,13 @@ export async function importFromGoogleContacts(): Promise<number> {
       const [emailMatches, phoneMatches] = await Promise.all([
         emailsToCheck.length > 0
           ? prisma.contact.findMany({
-              where: { email: { in: emailsToCheck } },
+              where: { email: { in: emailsToCheck }, deletedAt: null },
               select: { id: true, email: true, name: true },
             })
           : Promise.resolve([] as { id: string; email: string | null; name: string }[]),
         phonesToCheck.length > 0
           ? prisma.contact.findMany({
-              where: { phone: { in: phonesToCheck } },
+              where: { phone: { in: phonesToCheck }, deletedAt: null },
               select: { id: true, phone: true, name: true },
             })
           : Promise.resolve([] as { id: string; phone: string | null; name: string }[]),
@@ -225,37 +240,6 @@ export async function importFromGoogleContacts(): Promise<number> {
 }
 
 /**
- * Splits a full display name into given (first) and family (last) name parts.
- * @param fullName - Full display name.
- * @returns Object with givenName and familyName strings.
- */
-function splitName(fullName: string): { givenName: string; familyName: string } {
-  const parts = (fullName ?? "").trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return { givenName: "", familyName: "" };
-  if (parts.length === 1) return { givenName: parts[0], familyName: "" };
-  return { givenName: parts.slice(0, -1).join(" "), familyName: parts[parts.length - 1] };
-}
-
-/**
- * Pushes every local contact to Google Contacts and returns the number synced.
- * Errors on individual contacts are logged and skipped.
- * @returns Number of contacts successfully synced.
- */
-export async function syncAllContactsToGoogle(): Promise<number> {
-  const contacts = await prisma.contact.findMany({ select: { id: true } });
-  let count = 0;
-  for (const { id } of contacts) {
-    try {
-      await syncContactToGoogle(id);
-      count++;
-    } catch (err) {
-      console.error(`[google-contacts] syncAllContactsToGoogle: failed for ${id}:`, err);
-    }
-  }
-  return count;
-}
-
-/**
  * Compares site + Google values of a single-value field, considering which
  * sides changed since the last sync, and returns the action the sync should
  * take. See file header for the policy.
@@ -299,14 +283,14 @@ function mergePhones(sitePhone: string | null, googlePhones: string[]): string[]
   for (const raw of googlePhones) {
     const trimmed = raw?.trim();
     if (!trimmed) continue;
-    const key = normalisePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
+    const key = normaliseContactPhone(trimmed) ?? trimmed;
     if (seen.has(key)) continue;
     seen.add(key);
     result.push(trimmed);
   }
   if (sitePhone?.trim()) {
     const trimmed = sitePhone.trim();
-    const key = normalisePhone(toE164NZ(trimmed) || trimmed) ?? trimmed;
+    const key = normaliseContactPhone(trimmed) ?? trimmed;
     if (!seen.has(key)) {
       seen.add(key);
       result.push(trimmed);

--- a/src/features/contacts/lib/maintenance.ts
+++ b/src/features/contacts/lib/maintenance.ts
@@ -65,11 +65,22 @@ export async function mergePhoneOnlyContacts(): Promise<Set<string>> {
   for (const { withEmail, phoneOnly } of phoneBuckets.values()) {
     if (!withEmail || phoneOnly.length === 0) continue;
     for (const dup of phoneOnly) {
-      await prisma.review
-        .updateMany({ where: { contactId: dup.id }, data: { contactId: withEmail.id } })
-        .catch(() => null);
-      await prisma.contact.delete({ where: { id: dup.id } }).catch(() => null);
-      deletedIds.add(dup.id);
+      // Reassign-then-delete must be atomic: a hard delete without the review
+      // reassignment would orphan the phone-only contact's reviews onto a
+      // now-missing contactId (Review.contactId is a bare ObjectId, not a
+      // relation, so nothing cleans it up).
+      try {
+        await prisma.$transaction([
+          prisma.review.updateMany({
+            where: { contactId: dup.id },
+            data: { contactId: withEmail.id },
+          }),
+          prisma.contact.delete({ where: { id: dup.id } }),
+        ]);
+        deletedIds.add(dup.id);
+      } catch (err) {
+        console.error(`[contacts/maintenance] phone-only merge failed for ${dup.id}:`, err);
+      }
     }
   }
   return deletedIds;

--- a/src/features/contacts/lib/maintenance.ts
+++ b/src/features/contacts/lib/maintenance.ts
@@ -1,0 +1,431 @@
+// src/features/contacts/lib/maintenance.ts
+// Single source of truth for contact maintenance: backfilling contacts from
+// bookings, merging phone-only duplicates, linking reviews to contacts, and
+// surfacing field conflicts for the admin to resolve. Both the admin page load
+// (auto-maintain) and the standalone admin routes call these - keeping the logic
+// here is what stops the two paths from drifting apart. Every reader excludes
+// soft-deleted contacts (deletedAt != null).
+
+import { normaliseContactPhone } from "@/shared/lib/normalise-phone";
+import { prisma } from "@/shared/lib/prisma";
+
+/** A single field divergence between a Contact and a source record (Booking or Review). */
+export interface ConflictEntry {
+  contactId: string;
+  contactName: string;
+  contactEmail: string | null;
+  contactPhone: string | null;
+  /** Where the conflicting data came from. */
+  source: "Review" | "Booking";
+  sourceId: string;
+  /** Suggested name (present when name is a conflicting field). */
+  sourceName: string | null;
+  /** Suggested phone (present when phone is a conflicting field). */
+  sourcePhone: string | null;
+  conflictFields: ("name" | "phone")[];
+}
+
+/**
+ * Address is stored in booking notes as "Address: ...". Pulls the value or null.
+ * @param notes - Raw booking notes string (may be null).
+ * @returns The parsed address, or null when absent.
+ */
+function parseAddressFromNotes(notes: string | null): string | null {
+  return notes?.match(/Address:\s*(.+)/i)?.[1]?.trim() ?? null;
+}
+
+/**
+ * Merges phone-only contacts into their email-bearing counterpart when both
+ * share the same normalised phone: migrates the phone-only contact's reviews
+ * onto the email contact, then deletes the phone-only row. Runs before backfill
+ * so the post-merge contact set is accurate.
+ * @returns The set of contact ids that were merged away (deleted).
+ */
+export async function mergePhoneOnlyContacts(): Promise<Set<string>> {
+  const contacts = await prisma.contact.findMany({
+    where: { deletedAt: null },
+    select: { id: true, email: true, phone: true, name: true },
+  });
+
+  // Bucket by normalised phone: one email-bearing "keeper" + any phone-only dups.
+  const phoneBuckets = new Map<
+    string,
+    { withEmail: (typeof contacts)[number] | null; phoneOnly: (typeof contacts)[number][] }
+  >();
+  for (const c of contacts) {
+    const norm = normaliseContactPhone(c.phone);
+    if (!norm) continue;
+    if (!phoneBuckets.has(norm)) phoneBuckets.set(norm, { withEmail: null, phoneOnly: [] });
+    const bucket = phoneBuckets.get(norm)!;
+    if (c.email) bucket.withEmail ??= c;
+    else bucket.phoneOnly.push(c);
+  }
+
+  const deletedIds = new Set<string>();
+  for (const { withEmail, phoneOnly } of phoneBuckets.values()) {
+    if (!withEmail || phoneOnly.length === 0) continue;
+    for (const dup of phoneOnly) {
+      await prisma.review
+        .updateMany({ where: { contactId: dup.id }, data: { contactId: withEmail.id } })
+        .catch(() => null);
+      await prisma.contact.delete({ where: { id: dup.id } }).catch(() => null);
+      deletedIds.add(dup.id);
+    }
+  }
+  return deletedIds;
+}
+
+/**
+ * Creates a Contact for every unique booking email that has no live Contact yet.
+ * A soft-deleted contact for that email suppresses re-creation (otherwise a
+ * deleted contact would resurrect on the next run). When a booking's phone
+ * matches an existing phone-only contact, the email is merged into it instead
+ * of creating a duplicate.
+ * @returns The number of contacts created.
+ */
+export async function backfillContactsFromBookings(): Promise<number> {
+  const [bookings, allContacts] = await Promise.all([
+    prisma.booking.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { name: true, email: true, phone: true, notes: true },
+    }),
+    prisma.contact.findMany({ select: { id: true, email: true, phone: true, deletedAt: true } }),
+  ]);
+
+  const live = allContacts.filter((c) => !c.deletedAt);
+  const liveEmails = new Set(live.filter((c) => c.email).map((c) => c.email!.toLowerCase()));
+  // Emails belonging to a soft-deleted contact - do NOT recreate these.
+  const suppressedEmails = new Set(
+    allContacts.filter((c) => c.deletedAt && c.email).map((c) => c.email!.toLowerCase()),
+  );
+
+  const phoneOnlyByNorm = new Map<string, (typeof live)[number]>();
+  for (const c of live) {
+    if (c.email) continue;
+    const norm = normaliseContactPhone(c.phone);
+    if (norm) phoneOnlyByNorm.set(norm, c);
+  }
+
+  // Newest booking wins per email (Map overwrite as we iterate ascending).
+  const toCreateByEmail = new Map<
+    string,
+    { name: string; email: string; phone: string | null; address: string | null }
+  >();
+  for (const b of bookings) {
+    const email = b.email.toLowerCase();
+    if (liveEmails.has(email) || suppressedEmails.has(email)) continue;
+    toCreateByEmail.set(email, {
+      name: b.name,
+      email,
+      phone: b.phone ?? null,
+      address: parseAddressFromNotes(b.notes),
+    });
+  }
+
+  if (toCreateByEmail.size === 0) return 0;
+
+  let created = 0;
+  await Promise.all(
+    [...toCreateByEmail.values()].map(async (d) => {
+      // Merge the email into a matching phone-only contact rather than duplicating.
+      const norm = normaliseContactPhone(d.phone);
+      const phoneOnlyMatch = norm ? phoneOnlyByNorm.get(norm) : undefined;
+      if (phoneOnlyMatch) {
+        const updates: { email: string; address?: string } = { email: d.email };
+        if (d.address) updates.address = d.address;
+        await prisma.contact
+          .update({ where: { id: phoneOnlyMatch.id }, data: updates })
+          .catch(() => null);
+        return;
+      }
+      const exists = await prisma.contact.findFirst({
+        where: { email: { equals: d.email, mode: "insensitive" }, deletedAt: null },
+        select: { id: true },
+      });
+      if (!exists) {
+        await prisma.contact
+          .create({ data: d })
+          .then(() => (created += 1))
+          .catch(() => null);
+      }
+    }),
+  );
+  return created;
+}
+
+/**
+ * Links reviews with no contactId to their matching Contact. Booking-linked
+ * reviews resolve via the booking's email (primary) or phone (fallback);
+ * standalone reviews resolve by customerRef matching Contact.reviewToken.
+ *
+ * Ambiguous-phone guard: if a normalised phone maps to more than one live
+ * contact, phone matching is skipped for that number (the review is left
+ * unlinked) and the collision is logged, because silently linking to whichever
+ * contact loaded first attaches the review to a possibly-wrong person.
+ * @returns The number of reviews newly linked.
+ */
+export async function matchReviewsToContacts(): Promise<number> {
+  // MongoDB gotcha: `contactId: null` only matches documents where the field
+  // exists and equals null; pre-schema rows have no field at all, hence the OR.
+  const unlinked = await prisma.review.findMany({
+    where: { OR: [{ contactId: null }, { contactId: { isSet: false } }] },
+    select: { id: true, bookingId: true, customerRef: true },
+  });
+  if (unlinked.length === 0) return 0;
+
+  const bookingIds = unlinked.map((r) => r.bookingId).filter((id): id is string => id !== null);
+  const [bookingRows, contacts] = await Promise.all([
+    bookingIds.length > 0
+      ? prisma.booking.findMany({
+          where: { id: { in: bookingIds } },
+          select: { id: true, email: true, phone: true },
+        })
+      : Promise.resolve([]),
+    prisma.contact.findMany({
+      where: { deletedAt: null },
+      select: { id: true, email: true, phone: true, reviewToken: true },
+    }),
+  ]);
+
+  const bookingEmailById = new Map(bookingRows.map((b) => [b.id, b.email.toLowerCase()]));
+  const bookingPhoneById = new Map<string, string>();
+  for (const b of bookingRows) {
+    const norm = normaliseContactPhone(b.phone);
+    if (norm) bookingPhoneById.set(b.id, norm);
+  }
+
+  const contactIdByEmail = new Map(
+    contacts.filter((c) => c.email).map((c) => [c.email!.toLowerCase(), c.id]),
+  );
+  // Collect ALL contact ids per phone so shared numbers can be flagged ambiguous.
+  const contactIdsByPhone = new Map<string, string[]>();
+  for (const c of contacts) {
+    const norm = normaliseContactPhone(c.phone);
+    if (!norm) continue;
+    const list = contactIdsByPhone.get(norm) ?? [];
+    list.push(c.id);
+    contactIdsByPhone.set(norm, list);
+  }
+  const contactIdByToken = new Map(
+    contacts.filter((c) => c.reviewToken).map((c) => [c.reviewToken!, c.id]),
+  );
+
+  let linked = 0;
+  await Promise.all(
+    unlinked.map(async (r) => {
+      let contactId: string | undefined;
+      if (r.bookingId) {
+        const email = bookingEmailById.get(r.bookingId);
+        if (email) contactId = contactIdByEmail.get(email);
+        if (!contactId) {
+          const phone = bookingPhoneById.get(r.bookingId);
+          if (phone) {
+            const candidates = contactIdsByPhone.get(phone);
+            if (candidates && candidates.length > 1) {
+              console.warn(
+                `[contacts/maintenance] Ambiguous phone ${phone} for review ${r.id}: ` +
+                  `${candidates.length} contacts share it (${candidates.join(", ")}). ` +
+                  `Left unlinked - merge the duplicates to resolve.`,
+              );
+            } else if (candidates) {
+              contactId = candidates[0];
+            }
+          }
+        }
+      } else if (r.customerRef) {
+        contactId = contactIdByToken.get(r.customerRef);
+      }
+      if (!contactId) return;
+      await prisma.review
+        .update({ where: { id: r.id }, data: { contactId } })
+        .then(() => (linked += 1))
+        .catch(() => null);
+    }),
+  );
+  return linked;
+}
+
+/**
+ * Auto-fills missing contact fields (phone, address, full name) from the most
+ * recent matching Booking and returns booking-sourced field conflicts for the
+ * admin to resolve. Only touches live contacts.
+ * @returns Booking-sourced conflict entries.
+ */
+export async function enrichContactsFromBookings(): Promise<ConflictEntry[]> {
+  const [contacts, bookings] = await Promise.all([
+    prisma.contact.findMany({
+      where: { deletedAt: null },
+      select: { id: true, name: true, email: true, phone: true, address: true },
+    }),
+    prisma.booking.findMany({
+      orderBy: { createdAt: "desc" },
+      select: { id: true, name: true, email: true, phone: true, notes: true },
+    }),
+  ]);
+
+  const contactByEmail = new Map(
+    contacts.filter((c) => c.email).map((c) => [c.email!.toLowerCase(), c]),
+  );
+  const contactByPhone = new Map<string, (typeof contacts)[0]>();
+  for (const c of contacts) {
+    const norm = normaliseContactPhone(c.phone);
+    if (norm && !contactByPhone.has(norm)) contactByPhone.set(norm, c);
+  }
+
+  /**
+   * Finds a contact by email (primary) or normalised phone (fallback).
+   * @param email - Email to look up.
+   * @param phone - Phone to fall back to.
+   * @returns Matching contact or undefined.
+   */
+  function findContact(
+    email: string | null | undefined,
+    phone: string | null | undefined,
+  ): (typeof contacts)[0] | undefined {
+    if (email) {
+      const c = contactByEmail.get(email.toLowerCase());
+      if (c) return c;
+    }
+    const norm = normaliseContactPhone(phone);
+    if (norm) return contactByPhone.get(norm);
+    return undefined;
+  }
+
+  const conflicts: ConflictEntry[] = [];
+  const conflictSeen = new Set<string>();
+  const phoneFilled = new Set<string>();
+  const nameFilled = new Set<string>();
+  const addressFilled = new Set<string>();
+  const phoneUpdates = new Map<string, string>();
+  const nameUpdates = new Map<string, string>();
+  const addressUpdates = new Map<string, string>();
+
+  for (const booking of bookings) {
+    const contact = findContact(booking.email, booking.phone);
+    if (!contact) continue;
+
+    const proposedPhone = normaliseContactPhone(booking.phone);
+    const existingPhone = normaliseContactPhone(contact.phone);
+    const address = parseAddressFromNotes(booking.notes);
+
+    if (proposedPhone && !existingPhone && !phoneFilled.has(contact.id)) {
+      phoneFilled.add(contact.id);
+      phoneUpdates.set(contact.id, proposedPhone);
+    }
+    if (address && !contact.address && !addressFilled.has(contact.id)) {
+      addressFilled.add(contact.id);
+      addressUpdates.set(contact.id, address);
+    }
+
+    // Fill name when contact has only a first name and the booking has the full one.
+    const proposedName = booking.name.trim();
+    if (
+      proposedName &&
+      contact.name &&
+      !nameFilled.has(contact.id) &&
+      proposedName.toLowerCase().startsWith(contact.name.toLowerCase() + " ")
+    ) {
+      nameFilled.add(contact.id);
+      nameUpdates.set(contact.id, proposedName);
+    }
+
+    if (!conflictSeen.has(contact.id)) {
+      conflictSeen.add(contact.id);
+      const conflictFields: ("name" | "phone")[] = [];
+      const contactNameLower = contact.name.toLowerCase();
+      const proposedNameLower = proposedName.toLowerCase();
+      // Only a genuine difference is a conflict - not merely a missing last name.
+      if (
+        proposedName &&
+        contact.name &&
+        proposedNameLower !== contactNameLower &&
+        !contactNameLower.startsWith(proposedNameLower + " ") &&
+        !proposedNameLower.startsWith(contactNameLower + " ")
+      ) {
+        conflictFields.push("name");
+      }
+      if (proposedPhone && existingPhone && proposedPhone !== existingPhone) {
+        conflictFields.push("phone");
+      }
+      if (conflictFields.length > 0) {
+        conflicts.push({
+          contactId: contact.id,
+          contactName: contact.name,
+          contactEmail: contact.email,
+          contactPhone: contact.phone,
+          source: "Booking",
+          sourceId: booking.id,
+          sourceName: conflictFields.includes("name") ? proposedName : null,
+          sourcePhone: conflictFields.includes("phone") ? (booking.phone?.trim() ?? null) : null,
+          conflictFields,
+        });
+      }
+    }
+  }
+
+  // One write per contact - merge the per-field updates first.
+  const mergedUpdates = new Map<string, { phone?: string; name?: string; address?: string }>();
+  for (const [id, phone] of phoneUpdates)
+    mergedUpdates.set(id, { ...mergedUpdates.get(id), phone });
+  for (const [id, name] of nameUpdates) mergedUpdates.set(id, { ...mergedUpdates.get(id), name });
+  for (const [id, address] of addressUpdates)
+    mergedUpdates.set(id, { ...mergedUpdates.get(id), address });
+  await Promise.all(
+    [...mergedUpdates.entries()].map(([id, data]) =>
+      prisma.contact.update({ where: { id }, data }).catch(() => null),
+    ),
+  );
+
+  return conflicts;
+}
+
+/**
+ * Compares reviews against their linked Contact and returns a name conflict per
+ * contact where the reviewer's full name differs from the stored name. Only
+ * reviews carrying a customerRef (standalone/contact-token reviews) are checked;
+ * a review with only a first name is not treated as a suggestion to drop the
+ * contact's last name.
+ * @returns Review-sourced conflict entries.
+ */
+export async function enrichContactsFromReviews(): Promise<ConflictEntry[]> {
+  const contacts = await prisma.contact.findMany({
+    where: { deletedAt: null },
+    select: { id: true, name: true, email: true, phone: true, reviewToken: true },
+  });
+  const contactByToken = new Map(
+    contacts.filter((c) => c.reviewToken).map((c) => [c.reviewToken!, c]),
+  );
+
+  const reviews = await prisma.review.findMany({
+    where: { customerRef: { not: null } },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, firstName: true, lastName: true, customerRef: true },
+  });
+
+  const conflicts: ConflictEntry[] = [];
+  const seen = new Set<string>();
+  for (const review of reviews) {
+    if (!review.customerRef) continue;
+    const contact = contactByToken.get(review.customerRef);
+    if (!contact || seen.has(contact.id)) continue;
+    seen.add(contact.id);
+
+    if (!review.lastName) continue;
+    const proposedName = [review.firstName, review.lastName].filter(Boolean).join(" ").trim();
+    if (!proposedName || !contact.name) continue;
+    if (proposedName.toLowerCase() === contact.name.toLowerCase()) continue;
+
+    conflicts.push({
+      contactId: contact.id,
+      contactName: contact.name,
+      contactEmail: contact.email,
+      contactPhone: contact.phone,
+      source: "Review",
+      sourceId: review.id,
+      sourceName: proposedName,
+      sourcePhone: null,
+      conflictFields: ["name"],
+    });
+  }
+  return conflicts;
+}

--- a/src/features/contacts/lib/split-name.ts
+++ b/src/features/contacts/lib/split-name.ts
@@ -1,0 +1,18 @@
+// src/features/contacts/lib/split-name.ts
+
+/**
+ * Splits a full display name into given (first) and family (last) parts. The
+ * last whitespace-separated token becomes the family name and everything before
+ * it the given name, so "Mary Jane Watson" > given "Mary Jane", family "Watson".
+ * A single token has no family name; blank input yields two empty strings.
+ * Returns empty strings (never null) so it can feed the Google People API
+ * directly; callers that store nullable first/last names coerce "" to null.
+ * @param fullName - Full display name (may be blank).
+ * @returns Given and family name parts, each "" when absent.
+ */
+export function splitName(fullName: string): { givenName: string; familyName: string } {
+  const parts = (fullName ?? "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { givenName: "", familyName: "" };
+  if (parts.length === 1) return { givenName: parts[0], familyName: "" };
+  return { givenName: parts.slice(0, -1).join(" "), familyName: parts[parts.length - 1] };
+}

--- a/src/features/reviews/components/Reviews.tsx
+++ b/src/features/reviews/components/Reviews.tsx
@@ -118,7 +118,9 @@ export default function Reviews({ items = [] }: ReviewsProps): React.ReactElemen
   if (items.length > 3) {
     const track = [...items, ...items];
     return (
-      <section aria-labelledby="reviews-section" className="mx-auto w-full max-w-6xl">
+      // Full-width (no max-w cap) so the carousel edges line up with the
+      // full-width content column above rather than sitting in a narrower box.
+      <section aria-labelledby="reviews-section" className="w-full">
         <h2
           id="reviews-section"
           className="mb-2 text-center text-xl font-semibold text-rich-black sm:text-2xl"
@@ -128,10 +130,11 @@ export default function Reviews({ items = [] }: ReviewsProps): React.ReactElemen
 
         <div
           className={cn(
-            // Bleed all the way to the FrostedSection edge so the carousel sits flush against the page chrome.
-            "relative -mx-8 w-[calc(100%+4rem)] overflow-hidden rounded-xl",
-            "sm:-mx-12 sm:w-[calc(100%+6rem)]",
-            "md:-mx-16 md:w-[calc(100%+8rem)]",
+            // Sit within the FrostedSection padding so the carousel's edges line up
+            // with the content column above (hero, cards) instead of bleeding wider.
+            "relative w-full overflow-hidden rounded-xl",
+            // Dissolve cards near the left/right edges instead of hard-clipping them.
+            "marquee-fade",
           )}
         >
           <ul className="marquee-track animate-marquee flex w-max gap-3">

--- a/src/features/reviews/lib/email.ts
+++ b/src/features/reviews/lib/email.ts
@@ -442,15 +442,16 @@ export interface ReviewRequestData {
  * Sends a review request email to a customer shortly after their appointment.
  * Failures are caught and logged - never throws.
  * @param booking - Booking details for the customer.
- * @returns Promise that resolves when the email is sent (or silently fails).
+ * @returns True when the email was sent (or intentionally skipped because Resend
+ *   is not configured); false when the send failed and should be retried.
  */
-export async function sendCustomerReviewRequest(booking: ReviewRequestData): Promise<void> {
+export async function sendCustomerReviewRequest(booking: ReviewRequestData): Promise<boolean> {
   const from = process.env.EMAIL_FROM;
   const siteUrl = getSiteUrl();
 
   if (!from || !process.env.RESEND_API_KEY) {
     console.warn("[email] Resend not configured - skipping customer review request.");
-    return;
+    return true;
   }
 
   const identity = await getIdentity();
@@ -484,8 +485,10 @@ ${await buildEmailSignature(siteUrl)}
       subject: `Thanks for having me, ${firstName} - how did everything go?`,
       html,
     });
+    return true;
   } catch (error) {
     console.error(`[email] Failed to send review request for booking ${booking.id}:`, error);
+    return false;
   }
 }
 
@@ -526,15 +529,16 @@ ${await buildEmailSignature(siteUrl)}
  * Tone is tailored for clients who were seen days/weeks ago, mentioning
  * the site update and asking for a review. Failures are caught and logged.
  * @param booking - Past client details.
- * @returns Promise that resolves when the email is sent (or silently fails).
+ * @returns True when the email was sent (or intentionally skipped because Resend
+ *   is not configured); false when the send failed.
  */
-export async function sendPastClientReviewRequest(booking: ReviewRequestData): Promise<void> {
+export async function sendPastClientReviewRequest(booking: ReviewRequestData): Promise<boolean> {
   const from = process.env.EMAIL_FROM;
   const siteUrl = getSiteUrl();
 
   if (!from || !process.env.RESEND_API_KEY) {
     console.warn("[email] Resend not configured - skipping past client review request.");
-    return;
+    return true;
   }
 
   const reviewUrl = `${siteUrl}/review?token=${encodeURIComponent(booking.reviewToken)}`;
@@ -549,11 +553,13 @@ export async function sendPastClientReviewRequest(booking: ReviewRequestData): P
       subject: `Hi ${firstName}, it's Harrison from To The Point Tech`,
       html,
     });
+    return true;
   } catch (error) {
     console.error(
       `[email] Failed to send past client review request for request ${booking.id}:`,
       error,
     );
+    return false;
   }
 }
 

--- a/src/shared/components/SiteFooter.tsx
+++ b/src/shared/components/SiteFooter.tsx
@@ -1,0 +1,64 @@
+"use client";
+// src/shared/components/SiteFooter.tsx
+/**
+ * @description Site-wide footer with quick links, the privacy policy link, and
+ * copyright. Hidden on the admin area and the print-only poster, matching the
+ * NavBar's hidden paths. A direct child of <body>, so it is the page's single
+ * contentinfo landmark (the homepage's contact bar lives inside <main>).
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type React from "react";
+
+/** Exact paths that hide the footer (print-only poster). */
+const HIDDEN_PATHS: ReadonlyArray<string> = ["/poster"];
+/** Path prefixes that hide the footer (admin has its own chrome). */
+const HIDDEN_PREFIXES: ReadonlyArray<string> = ["/admin"];
+
+const LINKS: ReadonlyArray<{ label: string; href: string }> = [
+  { label: "Services", href: "/services" },
+  { label: "Pricing", href: "/pricing" },
+  { label: "About", href: "/about" },
+  { label: "FAQ", href: "/faq" },
+  { label: "Reviews", href: "/reviews" },
+  { label: "Contact", href: "/contact" },
+  { label: "Book", href: "/booking" },
+  { label: "Privacy", href: "/privacy" },
+];
+
+/**
+ * Footer shown at the bottom of every public page.
+ * @returns The footer element, or null on hidden paths.
+ */
+export function SiteFooter(): React.ReactElement | null {
+  const pathname = usePathname();
+  if (HIDDEN_PATHS.includes(pathname)) return null;
+  if (HIDDEN_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) return null;
+
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="mx-auto mt-8 mb-6 w-full max-w-[min(100vw-2rem,clamp(90rem,75vw,140rem))] px-4">
+      <div className="flex flex-col items-center gap-4 rounded-2xl border border-seasalt-400/40 bg-seasalt-800/70 p-6 shadow-lg backdrop-blur-md sm:p-8">
+        <nav
+          aria-label="Footer"
+          className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2"
+        >
+          {LINKS.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="text-base font-semibold text-rich-black transition-colors hover:text-coquelicot-500"
+            >
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+        <p className="text-center text-sm text-rich-black/70 sm:text-base">
+          {`© ${year} To The Point Tech - friendly computer & IT support across Auckland.`}
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/shared/lib/normalise-phone.ts
+++ b/src/shared/lib/normalise-phone.ts
@@ -86,6 +86,22 @@ export function toE164NZ(raw: string): string {
 }
 
 /**
+ * Canonical matching key for a contact/booking phone. Runs the raw value through
+ * E.164 conversion first (so "021 123 4567" and "+64211234567" collapse to the
+ * same key) then strips formatting. Returns null for blank/unparseable input so
+ * callers can skip it. This is the ONE normaliser every phone-based lookup must
+ * use - reimplementing the `toE164NZ` + `normalisePhone` combo inline is what let
+ * the site and Google matchers drift apart.
+ * @param raw - Raw phone input (may be null/undefined).
+ * @returns Normalised E.164 digit key, or null when there is nothing to match on.
+ */
+export function normaliseContactPhone(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const key = normalisePhone(toE164NZ(raw) || raw);
+  return key || null;
+}
+
+/**
  * Returns true when a normalised phone string looks like a valid phone number.
  * Requires 7-15 digits (E.164 max). The leading '+' is ignored for the count.
  * @param normalised - Already-normalised phone string (from {@link normalisePhone}).


### PR DESCRIPTION
Integrates the current dev work into main.

## Privacy
- New `/privacy` page: data collected, analytics/advertising (Google, Meta Pixel incl. hashed advanced matching), sharing, retention, and rights under the NZ Privacy Act 2020
- New site-wide footer (quick links + Privacy + copyright), hidden on admin/poster

## Contacts
- Incremental two-way Google Contacts sync cron + contact/review matching overhaul
- Repair cross-model desync on delete/merge
- Drop the retired ReviewRequest collection and migration shim

## Fixes / content
- Reviews: slow the home marquee, fade its edges, align to content width
- Invoice: keep Apple ID / App Store account work off the Cloud storage tag
- Content: broaden service-area copy from local suburb to Auckland-wide