### PR TITLE
v4.7.0: business support - /business page, enquiry intake, retainers, site notes, quotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "4.5.1",
+      "version": "4.6.0",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "6.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "6.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "6.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "4.4.1",
+      "version": "4.5.0",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "6.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -283,6 +283,22 @@ model Contact {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
+  // Retainer arrangement (null tier = not a retainer client). Marketing tiers
+  // live on /business; these fields record the AGREED deal per client. Billing
+  // stays manual - the dashboard "Retainers due" panel derives invoiced-this-
+  // month from invoices linked by contactId with a "retainer" line item.
+  retainerTier  String?
+  retainerPrice Float?
+  // Included support hours per month (0 = none included, e.g. Essentials).
+  retainerHours Float?
+  retainerSince DateTime?
+  retainerNotes String?
+
+  // Operator's environment notes for repeat/business clients (router model,
+  // ISP, M365 tenant, where the NAS lives). Never passwords - it renders in
+  // the admin UI and has no extra protection. Not synced to Google.
+  siteNotes String?
+
   // Admin reviews tab: list send history sorted by most-recent send.
   @@index([reviewLinkSentAt])
 }
@@ -466,6 +482,14 @@ model Invoice {
   // the Mongo no-backfill rule; readers treat null count as 0.
   reminderLastSentAt DateTime?
   reminderCount      Int?
+  // Quote mode: true = this row is a QUOTE (Q- number, QUOTE watermark, no
+  // payment/income until converted). Convert-to-invoice allocates a real
+  // invoice number, clears the flag, and restamps issue/due dates. Nullable
+  // per the Mongo no-backfill rule; readers treat null as false.
+  isQuote          Boolean?
+  // Quote validity end (shown on the PDF); past this date the quote renders
+  // as expired in the admin UI. Null = no stated expiry.
+  quoteValidUntil  DateTime?
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -160,7 +160,8 @@ export default function AboutPage(): React.ReactElement {
               <li className="flex gap-3">
                 <span className="mt-1 text-lg text-moonstone-600">•</span>
                 <span>
-                  Sole traders and small teams who need occasional IT support without a contract.
+                  Sole traders and small teams who need occasional IT help, or ongoing cover with a
+                  simple monthly retainer.
                 </span>
               </li>
             </ul>

--- a/src/app/admin/(shell)/business/invoices/[id]/InvoiceActions.tsx
+++ b/src/app/admin/(shell)/business/invoices/[id]/InvoiceActions.tsx
@@ -21,6 +21,7 @@ import { formatNZD } from "@/features/business/lib/business";
 import type { InvoiceReviewEligibility } from "@/features/business/lib/contact-review-token";
 import {
   DEFAULT_INVOICE_EMAIL_BODY,
+  DEFAULT_QUOTE_EMAIL_BODY,
   DEFAULT_VOID_EMAIL_BODY,
 } from "@/features/business/lib/invoice-email-defaults";
 import { cn } from "@/shared/lib/cn";
@@ -58,6 +59,8 @@ interface InvoiceActionsProps {
   isOverdue?: boolean;
   /** Reminders already sent (null reads as 0); shown in the confirm copy. */
   reminderCount?: number | null;
+  /** True when the row is a quote - swaps email copy, hides payment actions, adds Convert. */
+  isQuote?: boolean;
 }
 
 const INPUT_CLS = cn(
@@ -85,6 +88,7 @@ const headers = { "Content-Type": "application/json" };
  * @param props.autoOpenSend - Open the send preview on mount when true.
  * @param props.isOverdue - Whether the invoice is SENT and past due.
  * @param props.reminderCount - Reminders already sent (null reads as 0).
+ * @param props.isQuote - Whether the row is a quote.
  * @returns Invoice actions element with its modals.
  */
 export function InvoiceActions({
@@ -102,6 +106,7 @@ export function InvoiceActions({
   autoOpenSend = false,
   isOverdue = false,
   reminderCount = null,
+  isQuote = false,
 }: InvoiceActionsProps): React.ReactElement {
   const router = useRouter();
   const { toast } = useToast();
@@ -120,8 +125,14 @@ export function InvoiceActions({
   const [currentStatus, setCurrentStatus] = useState(status);
   // Operator-typed greeting override. Empty = use the first word of clientName.
   const [greetingName, setGreetingName] = useState("");
-  // Editable email body, pre-populated with the default copy.
-  const [customBody, setCustomBody] = useState(DEFAULT_INVOICE_EMAIL_BODY);
+  // Editable email body, pre-populated with the default copy (quote wording
+  // when the row is a quote).
+  const [customBody, setCustomBody] = useState(
+    isQuote ? DEFAULT_QUOTE_EMAIL_BODY : DEFAULT_INVOICE_EMAIL_BODY,
+  );
+  // Convert-to-invoice confirm + busy flags.
+  const [converting, setConverting] = useState(false);
+  const [confirmConvertOpen, setConfirmConvertOpen] = useState(false);
   // Review-link inclusion. Defaults to whatever eligibility says when the modal opens.
   const [includeReview, setIncludeReview] = useState(true);
   const [eligibility, setEligibility] = useState<InvoiceReviewEligibility | null>(null);
@@ -361,6 +372,34 @@ export function InvoiceActions({
   }
 
   /**
+   * Promotes the quote to a real invoice: the server allocates the next TTP
+   * number, clears the quote flag, and restamps issue/due dates from today.
+   * The page refreshes in place - same row, new number.
+   */
+  async function convertToInvoice(): Promise<void> {
+    setConverting(true);
+    try {
+      const res = await fetch(`/api/business/invoices/${invoiceId}/convert`, {
+        method: "POST",
+        headers,
+      });
+      const d = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        invoice?: { number: string };
+        error?: string;
+      };
+      if (!res.ok || !d.ok) throw new Error(d.error ?? "Convert failed");
+      toast(`Quote converted to invoice ${d.invoice?.number ?? ""}.`, { tone: "success" });
+      setConfirmConvertOpen(false);
+      router.refresh();
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Could not convert", { tone: "error" });
+    } finally {
+      setConverting(false);
+    }
+  }
+
+  /**
    * Opens the send modal and fetches the rendered email preview. Only spins on
    * the FIRST load so edit re-fetches keep the preview visible.
    * @param forceAdopt - Re-adopt the server's fresh eligibility verdict (and sync
@@ -513,12 +552,12 @@ export function InvoiceActions({
         )}
         {isDraft && (
           <AdminButton variant="danger" onClick={() => setConfirmDeleteOpen(true)} busy={deleting}>
-            Delete draft
+            {isQuote ? "Delete quote" : "Delete draft"}
           </AdminButton>
         )}
         {!isDraft && !isPaid && !isVoided && (
           <AdminButton variant="secondary" onClick={openVoidModal} busy={voiding}>
-            Void invoice
+            {isQuote ? "Void quote" : "Void invoice"}
           </AdminButton>
         )}
         {isVoided && clientEmail && (
@@ -526,9 +565,14 @@ export function InvoiceActions({
             Resend void notification
           </AdminButton>
         )}
-        {!isPaid && !isVoided && (
+        {!isPaid && !isVoided && !isQuote && (
           <AdminButton variant="secondary" onClick={() => setPayOpen(true)}>
             Mark as paid
+          </AdminButton>
+        )}
+        {isQuote && !isVoided && (
+          <AdminButton onClick={() => setConfirmConvertOpen(true)} busy={converting}>
+            Convert to invoice
           </AdminButton>
         )}
         {isOverdue && !isPaid && !isVoided && clientEmail && (
@@ -557,10 +601,21 @@ export function InvoiceActions({
         )}
       </div>
 
+      {/* Convert-to-invoice confirm. */}
+      <ConfirmDialog
+        open={confirmConvertOpen}
+        title={`Convert ${invoiceNumber} to an invoice?`}
+        body="Allocates the next invoice number and starts the payment clock from today. The quote number is retired; this can't be undone."
+        confirmLabel="Convert"
+        busy={converting}
+        onConfirm={() => void convertToInvoice()}
+        onCancel={() => setConfirmConvertOpen(false)}
+      />
+
       {/* Delete-draft confirm. */}
       <ConfirmDialog
         open={confirmDeleteOpen}
-        title={`Delete invoice ${invoiceNumber}?`}
+        title={`Delete ${isQuote ? "quote" : "invoice"} ${invoiceNumber}?`}
         body="This cannot be undone."
         confirmLabel="Delete"
         tone="danger"

--- a/src/app/admin/(shell)/business/invoices/[id]/page.tsx
+++ b/src/app/admin/(shell)/business/invoices/[id]/page.tsx
@@ -312,6 +312,7 @@ export default async function InvoiceViewPage({
             autoOpenSend={send === "1"}
             isOverdue={isInvoiceOverdue(invoice)}
             reminderCount={invoice.reminderCount}
+            isQuote={invoice.isQuote === true}
           />
         }
       />
@@ -332,7 +333,7 @@ export default async function InvoiceViewPage({
             />
             <div className="text-right">
               <p className="text-xl leading-none font-extrabold text-russian-violet sm:text-2xl">
-                {identity.gstNumber ? "TAX INVOICE" : "INVOICE"}
+                {invoice.isQuote ? "QUOTE" : identity.gstNumber ? "TAX INVOICE" : "INVOICE"}
               </p>
               <p className="mt-2 font-mono text-sm font-semibold text-slate-700">
                 {invoice.number}
@@ -342,14 +343,20 @@ export default async function InvoiceViewPage({
                   "mt-1 text-xs",
                   invoice.status === "PAID"
                     ? "font-semibold text-green-600"
-                    : invoice.status === "SENT"
-                      ? "font-semibold text-blue-600"
-                      : invoice.status === "VOIDED"
-                        ? "font-semibold text-[#5a2a82] line-through"
-                        : "text-slate-400",
+                    : invoice.isQuote && invoice.status !== "VOIDED"
+                      ? "font-semibold text-russian-violet"
+                      : invoice.status === "SENT"
+                        ? "font-semibold text-blue-600"
+                        : invoice.status === "VOIDED"
+                          ? "font-semibold text-[#5a2a82] line-through"
+                          : "text-slate-400",
                 )}
               >
-                {invoice.status}
+                {invoice.isQuote && invoice.status !== "VOIDED"
+                  ? invoice.quoteValidUntil
+                    ? `Valid until ${formatDateShort(invoice.quoteValidUntil)}`
+                    : "QUOTE"
+                  : invoice.status}
               </p>
               {invoice.status === "VOIDED" && invoice.voidedAt && (
                 <p className="mt-0.5 text-xs text-slate-400">

--- a/src/app/admin/(shell)/business/page.tsx
+++ b/src/app/admin/(shell)/business/page.tsx
@@ -17,6 +17,7 @@ import { SheetImportButton } from "@/features/business/components/SheetImportBut
 import { TaxPlannerSection } from "@/features/business/components/TaxPlannerSection";
 import { listFinancialYears } from "@/features/business/lib/financial-year";
 import { listSpreadsheetsInFolder } from "@/features/business/lib/google-drive";
+import { NOT_A_QUOTE_FILTER } from "@/features/business/lib/invoice-status";
 import { getFySheetIdForDate } from "@/features/business/lib/sheets-sync";
 import {
   clearTaxCache,
@@ -191,6 +192,9 @@ export default async function BusinessPage({
       },
     }),
     prisma.invoice.findMany({
+      // Quotes are excluded: this feed drives FY revenue aggregates and a
+      // quoted total is not revenue.
+      where: { ...NOT_A_QUOTE_FILTER },
       orderBy: { issueDate: "desc" },
       select: {
         id: true,

--- a/src/app/admin/(shell)/contacts/[id]/page.tsx
+++ b/src/app/admin/(shell)/contacts/[id]/page.tsx
@@ -138,6 +138,12 @@ export default async function ContactDetailPage({
             phone={contact.phone}
             address={contact.address}
             googleContactId={contact.googleContactId}
+            retainerTier={contact.retainerTier}
+            retainerPrice={contact.retainerPrice}
+            retainerHours={contact.retainerHours}
+            retainerSince={contact.retainerSince?.toISOString().slice(0, 10) ?? null}
+            retainerNotes={contact.retainerNotes}
+            siteNotes={contact.siteNotes}
           />
         }
       />
@@ -221,6 +227,45 @@ export default async function ContactDetailPage({
               <InfoRow label="Added">{formatDateShort(contact.createdAt.toISOString())}</InfoRow>
             </dl>
           </Card>
+
+          {contact.siteNotes && (
+            <Card>
+              <CardHeader title="Site notes" description="Environment details from past visits." />
+              <p className="text-sm font-medium whitespace-pre-wrap text-admin-text">
+                {contact.siteNotes}
+              </p>
+            </Card>
+          )}
+
+          {contact.retainerTier && (
+            <Card>
+              <CardHeader title="Retainer" />
+              <dl className="space-y-2 text-sm">
+                <InfoRow label="Tier">
+                  <StatusPill tone="violet">{contact.retainerTier}</StatusPill>
+                </InfoRow>
+                <InfoRow label="Monthly">
+                  {contact.retainerPrice !== null ? formatNZD(contact.retainerPrice) : NONE}
+                </InfoRow>
+                <InfoRow label="Included hrs">
+                  {contact.retainerHours !== null ? `${contact.retainerHours}h/month` : NONE}
+                </InfoRow>
+                <InfoRow label="Since">
+                  {contact.retainerSince
+                    ? formatDateShort(contact.retainerSince.toISOString())
+                    : NONE}
+                </InfoRow>
+                {contact.retainerNotes && (
+                  <div>
+                    <dt className="text-admin-muted">Notes</dt>
+                    <dd className="mt-1 font-medium whitespace-pre-wrap text-admin-text">
+                      {contact.retainerNotes}
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </Card>
+          )}
 
           <Card>
             <CardHeader title="Review link" />

--- a/src/app/admin/(shell)/contacts/page.tsx
+++ b/src/app/admin/(shell)/contacts/page.tsx
@@ -52,6 +52,7 @@ export default async function AdminContactsPage(): Promise<React.ReactElement> {
         address: true,
         createdAt: true,
         googleContactId: true,
+        retainerTier: true,
       },
     }),
     prisma.review.findMany({
@@ -101,6 +102,7 @@ export default async function AdminContactsPage(): Promise<React.ReactElement> {
     address: c.address ?? null,
     createdAt: c.createdAt.toISOString(),
     googleContactId: c.googleContactId ?? null,
+    retainerTier: c.retainerTier ?? null,
     reviews: reviewsByContactId.get(c.id) ?? [],
   }));
 

--- a/src/app/admin/(shell)/page.tsx
+++ b/src/app/admin/(shell)/page.tsx
@@ -11,6 +11,7 @@ import { PageHeader } from "@/features/admin/components/ui/PageHeader";
 import { StatCard } from "@/features/admin/components/ui/StatCard";
 import { StatusPill } from "@/features/admin/components/ui/StatusPill";
 import { formatNZD } from "@/features/business/lib/business";
+import { NOT_A_QUOTE_FILTER } from "@/features/business/lib/invoice-status";
 import { requireAdminAuth } from "@/shared/lib/auth";
 import { cn } from "@/shared/lib/cn";
 import { formatDateShort, formatDateTimeShort } from "@/shared/lib/date-format";
@@ -131,6 +132,7 @@ export default async function AdminPage(): Promise<React.ReactElement> {
     outstandingInvoices,
     recentInvoices,
     latestCacheEntry,
+    retainerContacts,
   ] = await Promise.all([
     prisma.review.count({ where: { status: "pending" } }),
     prisma.review.count({ where: { status: "approved" } }),
@@ -209,8 +211,9 @@ export default async function AdminPage(): Promise<React.ReactElement> {
       _sum: { amount: true },
     }),
     // Outstanding (DRAFT or SENT). Overdue flagged separately on the card.
+    // Quotes ride on DRAFT/SENT but aren't money owed - excluded.
     prisma.invoice.findMany({
-      where: { status: { in: ["DRAFT", "SENT"] } },
+      where: { status: { in: ["DRAFT", "SENT"] }, ...NOT_A_QUOTE_FILTER },
       orderBy: { dueDate: "asc" },
       select: {
         id: true,
@@ -231,6 +234,7 @@ export default async function AdminPage(): Promise<React.ReactElement> {
         clientName: true,
         total: true,
         status: true,
+        isQuote: true,
         createdAt: true,
       },
     }),
@@ -239,7 +243,39 @@ export default async function AdminPage(): Promise<React.ReactElement> {
       orderBy: { fetchedAt: "desc" },
       select: { fetchedAt: true },
     }),
+    // Retainer clients - feeds the "Retainers due" panel. isSet guards rows
+    // created before the field existed (MongoDB gotcha, as above).
+    prisma.contact.findMany({
+      where: { deletedAt: null, retainerTier: { isSet: true, not: null } },
+      orderBy: { name: "asc" },
+      select: { id: true, name: true, retainerTier: true, retainerPrice: true },
+    }),
   ]);
+
+  // --- Retainers due this month ---
+  // A retainer client counts as invoiced once an invoice linked by contactId,
+  // issued this month, carries a line item mentioning "retainer". lineItems is
+  // an embedded composite type, so the text match runs in JS - the Mongo
+  // connector can't regex-filter composite string content.
+  let retainersDue: typeof retainerContacts = [];
+  if (retainerContacts.length > 0) {
+    const monthInvoices = await prisma.invoice.findMany({
+      where: {
+        contactId: { in: retainerContacts.map((r) => r.id) },
+        issueDate: { gte: monthStart },
+        status: { not: "VOIDED" },
+        // A QUOTE for a retainer must not count as invoiced.
+        ...NOT_A_QUOTE_FILTER,
+      },
+      select: { contactId: true, lineItems: true },
+    });
+    const invoicedIds = new Set(
+      monthInvoices
+        .filter((inv) => inv.lineItems.some((li) => /retainer/i.test(li.description)))
+        .map((inv) => inv.contactId),
+    );
+    retainersDue = retainerContacts.filter((r) => !invoicedIds.has(r.id));
+  }
 
   // --- Review-link coverage ---
   const sentEmails = new Set<string>([
@@ -295,8 +331,10 @@ export default async function AdminPage(): Promise<React.ReactElement> {
     ...recentInvoices.map((inv) => ({
       kind: "invoice" as const,
       timestamp: inv.createdAt,
-      title: `Invoice ${inv.number}: ${inv.clientName}`,
-      detail: `${inv.status} - ${inv.total < 0 ? "-" : ""}$${Math.abs(inv.total).toFixed(2)}`,
+      title: `${inv.isQuote ? "Quote" : "Invoice"} ${inv.number}: ${inv.clientName}`,
+      detail: inv.isQuote
+        ? `QUOTE - ${inv.total < 0 ? "-" : ""}$${Math.abs(inv.total).toFixed(2)}`
+        : `${inv.status} - ${inv.total < 0 ? "-" : ""}$${Math.abs(inv.total).toFixed(2)}`,
     })),
   ]
     .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
@@ -480,6 +518,42 @@ export default async function AdminPage(): Promise<React.ReactElement> {
             </ul>
           )}
         </Panel>
+
+        {/* Retainers due - retainer clients with no "retainer" invoice issued
+            this month. Hidden entirely until at least one retainer client exists. */}
+        {retainerContacts.length > 0 && (
+          <Panel
+            title="Retainers due"
+            badge={
+              retainersDue.length > 0 ? (
+                <StatusPill tone="warning">{retainersDue.length}</StatusPill>
+              ) : undefined
+            }
+            action={{ label: "New invoice", href: "/admin/business/calculator" }}
+            empty="All retainers invoiced this month."
+          >
+            {retainersDue.length === 0 ? null : (
+              <ul className="divide-y divide-admin-border">
+                {retainersDue.map((r) => (
+                  <li key={r.id}>
+                    <Link
+                      href={`/admin/contacts/${r.id}`}
+                      className="flex items-start justify-between gap-3 px-5 py-3 transition-colors hover:bg-admin-bg"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium text-admin-text">{r.name}</p>
+                        <p className="truncate text-xs text-admin-faint">{r.retainerTier}</p>
+                      </div>
+                      <p className="shrink-0 text-right text-xs text-admin-muted">
+                        {r.retainerPrice !== null ? formatNZD(r.retainerPrice) : ""}
+                      </p>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Panel>
+        )}
 
         {/* Recent activity - unified timeline of bookings, reviews, contacts, invoices. */}
         <Panel title="Recent activity" empty="No activity yet.">

--- a/src/app/api/admin/contacts/[id]/route.ts
+++ b/src/app/api/admin/contacts/[id]/route.ts
@@ -18,12 +18,22 @@ interface ContactPatchBody {
   email?: string;
   phone?: string;
   address?: string;
+  /** Retainer tier label, or null/"" to clear the retainer arrangement. */
+  retainerTier?: string | null;
+  retainerPrice?: number | null;
+  retainerHours?: number | null;
+  /** ISO date string (yyyy-mm-dd) or null. */
+  retainerSince?: string | null;
+  retainerNotes?: string | null;
+  /** Operator environment notes (router, ISP, tenant); never passwords. */
+  siteNotes?: string | null;
 }
 
 /**
  * PATCH /api/admin/contacts/[id]
- * Updates a contact's name, phone, and/or address in the local DB,
- * then best-effort syncs the updated contact to Google Contacts.
+ * Updates a contact's name, phone, address, and/or retainer arrangement in the
+ * local DB, then best-effort syncs the updated contact to Google Contacts
+ * (retainer fields stay local - the Google mapping doesn't carry them).
  * Requires X-Admin-Secret header.
  * @param request - Incoming request with optional name, phone, address fields.
  * @param params - Route parameters containing the contact ID.
@@ -92,16 +102,55 @@ export async function PATCH(
     return errorResponse("Please enter a valid phone number.", 400);
   }
 
-  const updateData: Record<string, string | null> = {};
+  // Numeric retainer fields must be finite (NaN from an empty form field must
+  // not persist); dates must parse.
+  for (const key of ["retainerPrice", "retainerHours"] as const) {
+    const val = body[key];
+    if (val !== undefined && val !== null && (typeof val !== "number" || !Number.isFinite(val))) {
+      return errorResponse(`Invalid ${key}.`, 400);
+    }
+  }
+  if (
+    body.retainerSince !== undefined &&
+    body.retainerSince !== null &&
+    body.retainerSince !== "" &&
+    Number.isNaN(new Date(body.retainerSince).getTime())
+  ) {
+    return errorResponse("Invalid retainerSince date.", 400);
+  }
+
+  const updateData: Record<string, string | number | Date | null> = {};
   if (body.name !== undefined) updateData.name = body.name.trim();
   if (body.email !== undefined) updateData.email = body.email.trim().toLowerCase() || null;
   if (body.phone !== undefined) updateData.phone = toE164NZ(body.phone) || null;
   if (body.address !== undefined) updateData.address = body.address.trim() || null;
+  if (body.retainerTier !== undefined) updateData.retainerTier = body.retainerTier?.trim() || null;
+  if (body.retainerPrice !== undefined) updateData.retainerPrice = body.retainerPrice;
+  if (body.retainerHours !== undefined) updateData.retainerHours = body.retainerHours;
+  if (body.retainerSince !== undefined) {
+    updateData.retainerSince = body.retainerSince ? new Date(body.retainerSince) : null;
+  }
+  if (body.retainerNotes !== undefined) {
+    updateData.retainerNotes = body.retainerNotes?.trim() || null;
+  }
+  if (body.siteNotes !== undefined) updateData.siteNotes = body.siteNotes?.trim() || null;
 
   const contact = await prisma.contact.update({
     where: { id },
     data: updateData,
-    select: { id: true, name: true, email: true, phone: true, address: true },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      address: true,
+      retainerTier: true,
+      retainerPrice: true,
+      retainerHours: true,
+      retainerSince: true,
+      retainerNotes: true,
+      siteNotes: true,
+    },
   });
 
   // Best-effort Google Contacts sync - never fail the request if it errors.

--- a/src/app/api/admin/contacts/merge/route.ts
+++ b/src/app/api/admin/contacts/merge/route.ts
@@ -67,6 +67,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     email?: string;
     address?: string;
     reviewToken?: string;
+    retainerTier?: string;
+    retainerPrice?: number;
+    retainerHours?: number;
+    retainerSince?: Date;
+    retainerNotes?: string;
+    siteNotes?: string;
     altEmails: { set: string[] };
     altPhones: { set: string[] };
     altReviewTokens: { set: string[] };
@@ -75,6 +81,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!primary.email && secondary.email) data.email = secondary.email;
   if (!primary.address && secondary.address) data.address = secondary.address;
   if (!primary.reviewToken && secondary.reviewToken) data.reviewToken = secondary.reviewToken;
+  if (!primary.siteNotes && secondary.siteNotes) data.siteNotes = secondary.siteNotes;
+  // Retainer arrangement survives a merge: when only the secondary is the
+  // retainer client, its whole arrangement moves over as a unit (gated on the
+  // primary's tier so a partial mix of two arrangements can't result).
+  if (!primary.retainerTier && secondary.retainerTier) {
+    data.retainerTier = secondary.retainerTier;
+    if (secondary.retainerPrice !== null) data.retainerPrice = secondary.retainerPrice;
+    if (secondary.retainerHours !== null) data.retainerHours = secondary.retainerHours;
+    if (secondary.retainerSince !== null) data.retainerSince = secondary.retainerSince;
+    if (secondary.retainerNotes !== null) data.retainerNotes = secondary.retainerNotes;
+  }
 
   // Fold every email both contacts know into altEmails (minus the surviving
   // primary address). This is what stops the pair re-splitting: a future booking

--- a/src/app/api/business/invoices/[id]/convert/route.ts
+++ b/src/app/api/business/invoices/[id]/convert/route.ts
@@ -1,0 +1,111 @@
+// src/app/api/business/invoices/[id]/convert/route.ts
+/**
+ * @description Converts an accepted quote into a real invoice: allocates the
+ * next TTP number (quote counter untouched), clears the quote flag, restamps
+ * issue/due dates from today, and re-syncs the PDF to Drive under the new
+ * number. The row keeps its id, so links and history carry over.
+ */
+
+import { syncInvoicePdfToDriveById } from "@/features/business/lib/invoice-drive-sync";
+import {
+  getNextInvoiceNumber,
+  writeBackInvoiceCounter,
+} from "@/features/business/lib/invoice-numbering";
+import { errorResponse } from "@/shared/lib/api-response";
+import { isAdminRequest } from "@/shared/lib/auth";
+import { getIdentity } from "@/shared/lib/business-identity.server";
+import { prisma } from "@/shared/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+
+// Raise the serverless ceiling: the awaited Drive re-upload can be slow.
+export const maxDuration = 60;
+
+/**
+ * POST /api/business/invoices/[id]/convert - promotes a quote to an invoice.
+ * @param request - Incoming Next.js request.
+ * @param params - Route parameters containing the invoice ID.
+ * @param params.params - Promise resolving to the dynamic route params object.
+ * @returns JSON with the converted invoice, its previous Q- number, and an
+ * optional sheet sync warning.
+ */
+export async function POST(
+  request: NextRequest,
+  params: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  if (!(await isAdminRequest(request))) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  const { id } = await params.params;
+  let existing;
+  try {
+    existing = await prisma.invoice.findUnique({ where: { id } });
+  } catch {
+    // Malformed ObjectId throws P2023; treat as not found.
+    return errorResponse("Invoice not found.", 404);
+  }
+  if (!existing) return errorResponse("Invoice not found.", 404);
+  if (!existing.isQuote) {
+    return errorResponse("This is already an invoice.", 409);
+  }
+  if (existing.status === "VOIDED") {
+    return errorResponse("A voided quote can't be converted.", 409);
+  }
+
+  const previousNumber = existing.number;
+  const identity = await getIdentity();
+  const now = new Date();
+  const dueDate = new Date(now.getTime() + identity.paymentTermsDays * 24 * 60 * 60 * 1000);
+
+  // Allocate a real invoice number with the same collision-retry loop as
+  // creation; the quote counter is not touched.
+  let converted: Awaited<ReturnType<typeof prisma.invoice.update>> | null = null;
+  let sheetNextCount: number | null = null;
+  let sheetSyncWarning = false;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const alloc = await getNextInvoiceNumber();
+    sheetNextCount = alloc.sheetNextCount;
+    sheetSyncWarning = alloc.sheetSyncWarning;
+    try {
+      converted = await prisma.invoice.update({
+        where: { id },
+        data: {
+          number: alloc.number,
+          isQuote: null,
+          quoteValidUntil: null,
+          // The customer's payment clock starts at conversion, not at the
+          // original quote date - restamp both dates from today.
+          issueDate: now,
+          dueDate,
+          // Back to DRAFT regardless of whether the quote was emailed: the
+          // operator reviews and sends the real invoice as its own step.
+          status: "DRAFT",
+          sentAt: null,
+        },
+      });
+      break;
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002" &&
+        attempt < 4
+      ) {
+        console.warn(`[invoices/convert] Number ${alloc.number} collided; re-allocating.`);
+        continue;
+      }
+      throw err;
+    }
+  }
+  if (!converted) {
+    return errorResponse("Could not allocate a unique invoice number", 500);
+  }
+
+  await writeBackInvoiceCounter(sheetNextCount);
+  console.log(`[invoices/convert] Quote ${previousNumber} converted to ${converted.number}.`);
+
+  // Re-render + re-upload the PDF under the new number (awaited; never throws).
+  await syncInvoicePdfToDriveById(id, "[invoices/convert]");
+
+  return NextResponse.json({ ok: true, invoice: converted, previousNumber, sheetSyncWarning });
+}

--- a/src/app/api/business/invoices/[id]/pay/route.ts
+++ b/src/app/api/business/invoices/[id]/pay/route.ts
@@ -48,6 +48,9 @@ export async function POST(
   if (invoice.status === "VOIDED") {
     return errorResponse("Cannot record payment on a voided invoice.", 409);
   }
+  if (invoice.isQuote) {
+    return errorResponse("Convert the quote to an invoice before recording payment.", 409);
+  }
 
   const body = (await request.json().catch(() => ({}))) as {
     paidAt?: unknown;

--- a/src/app/api/business/invoices/[id]/preview-email/route.ts
+++ b/src/app/api/business/invoices/[id]/preview-email/route.ts
@@ -59,7 +59,8 @@ export async function POST(
 
   // includeReviewOverride wins when set (so unchecking the box updates the
   // preview to drop the review line). Default is whatever eligibility says.
-  const includeReview = includeReviewOverride ?? eligibility.canSend;
+  // Quotes never carry a review ask, matching the send route.
+  const includeReview = !invoice.isQuote && (includeReviewOverride ?? eligibility.canSend);
   const reviewUrl =
     includeReview && "reviewUrl" in eligibility ? (eligibility.reviewUrl ?? null) : null;
 
@@ -72,6 +73,8 @@ export async function POST(
       dueDate: invoice.dueDate,
       total: invoice.total,
       driveWebUrl: invoice.driveWebUrl,
+      isQuote: invoice.isQuote,
+      quoteValidUntil: invoice.quoteValidUntil,
     },
     reviewUrl,
     greetingName,

--- a/src/app/api/business/invoices/[id]/route.ts
+++ b/src/app/api/business/invoices/[id]/route.ts
@@ -125,6 +125,7 @@ export async function PATCH(
       unsuccessfulDiscount: true,
       sentAt: true,
       paidAt: true,
+      isQuote: true,
     },
   });
   if (!current) {
@@ -231,6 +232,11 @@ export async function PATCH(
   const { status } = body;
   if (!["DRAFT", "SENT", "PAID", "VOIDED"].includes(status)) {
     return errorResponse("Invalid status", 400);
+  }
+  // Quotes can't be marked PAID - conversion is the only path to a payable
+  // invoice (the /pay route carries the same guard).
+  if (current.isQuote && status === "PAID") {
+    return errorResponse("Convert the quote to an invoice before recording payment.", 409);
   }
   const transitionErr = validateTransition(current.status, status as InvoiceStatus);
   if (transitionErr) {

--- a/src/app/api/business/invoices/[id]/send-email/route.ts
+++ b/src/app/api/business/invoices/[id]/send-email/route.ts
@@ -74,8 +74,10 @@ export async function POST(
 
   // Server-side gate: if the customer is in cooldown or already reviewed, an
   // explicit `includeReview: true` from a stale client is ignored - the UI
-  // blocks the checkbox but client state is not trusted.
-  const includeReview = (includeReviewOverride ?? eligibility.canSend) && eligibility.canSend;
+  // blocks the checkbox but client state is not trusted. Quotes never carry a
+  // review ask - the job hasn't happened yet.
+  const includeReview =
+    !invoice.isQuote && (includeReviewOverride ?? eligibility.canSend) && eligibility.canSend;
   const reviewUrl =
     includeReview && "reviewUrl" in eligibility ? (eligibility.reviewUrl ?? null) : null;
 
@@ -98,6 +100,8 @@ export async function POST(
       dueDate: invoice.dueDate,
       total: invoice.total,
       driveWebUrl: invoice.driveWebUrl,
+      isQuote: invoice.isQuote,
+      quoteValidUntil: invoice.quoteValidUntil,
     },
     pdfBytes,
     reviewUrl,

--- a/src/app/api/business/invoices/route.ts
+++ b/src/app/api/business/invoices/route.ts
@@ -2,16 +2,19 @@
 /**
  * @description Admin invoices collection endpoint. GET lists every invoice
  * (newest issue date first). POST creates one: validates line items, allocates
- * the next TTP-YYYY-XXXX number, computes totals via {@link calcInvoiceTotals}
- * (promo + unsuccessful-work discounts reduce the taxable amount), writes back
- * the Sheets counter, then fire-and-forget renders the PDF and uploads it to Drive.
+ * the next TTP-YYYY-XXXX number (or Q-YYYY-XXXX from the quote counter when
+ * `isQuote`), computes totals via {@link calcInvoiceTotals} (promo +
+ * unsuccessful-work discounts reduce the taxable amount), writes back the
+ * matching Sheets counter, then renders the PDF and uploads it to Drive.
  */
 
 import { calcInvoiceTotals, isValidLineItem } from "@/features/business/lib/business";
 import { syncInvoicePdfToDrive } from "@/features/business/lib/invoice-drive-sync";
 import {
   getNextInvoiceNumber,
+  getNextQuoteNumber,
   writeBackInvoiceCounter,
+  writeBackQuoteCounter,
 } from "@/features/business/lib/invoice-numbering";
 import { generateInvoicePdf, serializeInvoice } from "@/features/business/lib/invoice-pdf";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
@@ -69,6 +72,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Optional match back to the billed job (calculator event-prefill flow).
     bookingId,
     calendarEventId,
+    // Quote mode: Q- number from the quote counter, QUOTE PDF, no payment
+    // until converted to a real invoice.
+    isQuote,
+    quoteValidUntil,
   } = body as {
     clientName?: string;
     clientEmail?: string;
@@ -83,6 +90,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     unsuccessfulDiscount?: number | null;
     bookingId?: string | null;
     calendarEventId?: string | null;
+    isQuote?: boolean;
+    quoteValidUntil?: string | null;
   };
 
   if (!clientName || !clientEmail || !Array.isArray(lineItems)) {
@@ -102,6 +111,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const dueDateValue = dueDate
     ? new Date(dueDate)
     : new Date(Date.now() + identity.paymentTermsDays * 24 * 60 * 60 * 1000);
+  // Quote validity: explicit date wins; default 30 days out. dueDate still
+  // gets a value (schema requires one) but quotes never render or enforce it.
+  const quoteValidValue = isQuote
+    ? quoteValidUntil
+      ? new Date(quoteValidUntil)
+      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+    : null;
+  if (quoteValidValue && Number.isNaN(quoteValidValue.getTime())) {
+    return errorResponse("Invalid quote validity date", 400);
+  }
 
   // Validate the optional discount snapshots through the shared money parser so
   // a non-finite or absurd magnitude (e.g. Infinity, 1e12) can't reach the
@@ -139,13 +158,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   let sheetNextCount: number | null = null;
   let sheetSyncWarning = false;
   for (let attempt = 0; attempt < 5; attempt++) {
-    const alloc = await getNextInvoiceNumber();
+    const alloc = isQuote ? await getNextQuoteNumber() : await getNextInvoiceNumber();
     sheetNextCount = alloc.sheetNextCount;
     sheetSyncWarning = alloc.sheetSyncWarning;
     try {
       invoice = await prisma.invoice.create({
         data: {
           number: alloc.number,
+          isQuote: isQuote === true ? true : null,
+          quoteValidUntil: quoteValidValue,
           clientName,
           clientEmail,
           issueDate: issueDateValue,
@@ -187,8 +208,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // Keep the Sheets counter in sync; the helper swallows + logs failures so the
-  // just-saved invoice isn't compromised by a transient Sheets hiccup.
-  await writeBackInvoiceCounter(sheetNextCount);
+  // just-saved invoice isn't compromised by a transient Sheets hiccup. Quotes
+  // write back their own counter (SETTINGS!B12), invoices B19.
+  if (isQuote) {
+    await writeBackQuoteCounter(sheetNextCount);
+  } else {
+    await writeBackInvoiceCounter(sheetNextCount);
+  }
 
   // Generate the PDF and sync it to Drive. Awaited (not fire-and-forget) so it
   // completes before the response - Vercel freezes the instance once the

--- a/src/app/api/business/rates/route.ts
+++ b/src/app/api/business/rates/route.ts
@@ -33,6 +33,18 @@ const DEFAULTS = [
     isDefault: true,
   },
   {
+    // Business callouts: on-site work for companies bills above the home
+    // Standard rate. Surfaced on /business as baseRate + this delta; kept off
+    // the consumer pricing accordion.
+    label: "Business",
+    ratePerHour: null,
+    flatRate: null,
+    hourlyDelta: 20,
+    percentDelta: null,
+    unit: "modifier",
+    isDefault: false,
+  },
+  {
     label: "At home",
     ratePerHour: null,
     flatRate: null,
@@ -208,7 +220,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
 /**
  * DELETE /api/business/rates - Wipes every rate row and reseeds the defaults
- * (Standard base + modifier set + Travel flat rate).
+ * (Standard base + modifier set).
  * @param request - Incoming Next.js request
  * @returns JSON with the freshly-seeded rates array
  */

--- a/src/app/api/cron/send-invoice-reminders/route.ts
+++ b/src/app/api/cron/send-invoice-reminders/route.ts
@@ -3,6 +3,7 @@
 // invoice at the comms-settings offsets, idempotent via reminderCount. See docs/CRON.md.
 
 import { sendOverdueReminder } from "@/features/business/lib/invoice-reminders";
+import { NOT_A_QUOTE_FILTER } from "@/features/business/lib/invoice-status";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isCronAuthorized } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -35,7 +36,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       now.getTime() - comms.invoiceReminderFirstDays * 24 * 60 * 60 * 1000,
     );
     const candidates = await prisma.invoice.findMany({
-      where: { status: "SENT", dueDate: { lte: firstThreshold } },
+      // A SENT quote has a placeholder dueDate, not a payment deadline -
+      // never remind on quotes.
+      where: { status: "SENT", dueDate: { lte: firstThreshold }, ...NOT_A_QUOTE_FILTER },
       orderBy: { dueDate: "asc" },
     });
 

--- a/src/app/api/enquiry/business/route.ts
+++ b/src/app/api/enquiry/business/route.ts
@@ -1,0 +1,123 @@
+// src/app/api/enquiry/business/route.ts
+/**
+ * @description Public business enquiry endpoint. Validates the form payload,
+ * then emails the operator a notification and the enquirer an acknowledgement.
+ * Email-only - no DB record is written. Deliberately outside /api/business/*,
+ * which is the admin-guarded namespace.
+ */
+
+import { validateEmail } from "@/features/booking/lib/booking";
+import {
+  sendBusinessEnquiryAck,
+  sendBusinessEnquiryNotification,
+  type BusinessEnquiryData,
+} from "@/features/reviews/lib/email";
+import { errorResponse } from "@/shared/lib/api-response";
+import { validatePhone } from "@/shared/lib/normalise-phone";
+import { rateLimitOrReject } from "@/shared/lib/rate-limit";
+import { NextRequest, NextResponse } from "next/server";
+
+/** Optional select values accepted from the form; anything else is dropped. */
+const INTEREST_OPTIONS = ["One-off job", "Monthly retainer", "Not sure yet"] as const;
+const URGENCY_OPTIONS = ["This week", "This month", "Just exploring"] as const;
+
+/** Generous free-text ceilings so a pasted brief fits but abuse doesn't. */
+const MAX_SHORT_FIELD = 200;
+const MAX_NEEDS = 4000;
+
+interface BusinessEnquiryPayload {
+  /** "business" (default; company required) or "personal" (company omitted). */
+  kind?: string;
+  company?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  needs?: string;
+  interest?: string;
+  urgency?: string;
+  /** Honeypot field - real users never fill this; bots usually do. */
+  website?: string;
+}
+
+/**
+ * Narrows an optional select value to one of the allowed options, or null.
+ * @param value - Raw value from the payload.
+ * @param options - Allowed option strings.
+ * @returns The matched option, or null.
+ */
+function pickOption(value: unknown, options: readonly string[]): string | null {
+  return typeof value === "string" && options.includes(value) ? value : null;
+}
+
+/**
+ * POST /api/enquiry/business - accepts a business enquiry and sends the
+ * notification + ack emails.
+ * @param request - Next.js request with the enquiry payload.
+ * @returns JSON `{ ok }` or a 4xx error response.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const limited = rateLimitOrReject(request, "business-enquiry", 5, 60_000);
+  if (limited) return limited;
+
+  try {
+    const body = (await request.json()) as BusinessEnquiryPayload;
+
+    // Honeypot trip: silently report success without sending anything so the
+    // bot moves on. Real users never fill this field (it's visually hidden
+    // and tab-skipped on the form).
+    if (typeof body.website === "string" && body.website.trim().length > 0) {
+      console.warn("[enquiry/business] Honeypot tripped; faking success.", {
+        ip: request.headers.get("x-forwarded-for") ?? "unknown",
+      });
+      return NextResponse.json({ ok: true });
+    }
+
+    // Unknown kinds collapse to business (the stricter validation path).
+    const kind = body.kind === "personal" ? "personal" : "business";
+    const company = body.company?.trim() ?? "";
+    const name = body.name?.trim() ?? "";
+    const email = body.email?.trim() ?? "";
+    const needs = body.needs?.trim() ?? "";
+
+    if (kind === "business" && !company) {
+      return errorResponse("Please enter your company or trading name.", 400);
+    }
+    if (!name) return errorResponse("Please enter your name.", 400);
+    if (company.length > MAX_SHORT_FIELD || name.length > MAX_SHORT_FIELD) {
+      return errorResponse("Name fields are too long.", 400);
+    }
+    if (validateEmail(email) !== "ok") {
+      return errorResponse("Please enter a valid email address.", 400);
+    }
+    if (!needs) return errorResponse("Please tell me what you need help with.", 400);
+    if (needs.length > MAX_NEEDS) {
+      return errorResponse("That message is a bit long - please trim it down.", 400);
+    }
+
+    const phoneValidation = validatePhone(body.phone ?? "");
+    if (phoneValidation.result === "invalid") {
+      return errorResponse("Please enter a valid phone number, or leave it blank.", 400);
+    }
+
+    const enquiry: BusinessEnquiryData = {
+      // Personal enquiries carry no company even if one was typed then the
+      // toggle flipped - the kind is what the visitor last chose.
+      company: kind === "business" ? company : null,
+      name,
+      email,
+      phone: phoneValidation.e164 || null,
+      needs,
+      interest: pickOption(body.interest, INTEREST_OPTIONS),
+      urgency: pickOption(body.urgency, URGENCY_OPTIONS),
+    };
+
+    // Both senders warn-and-skip when email env is unconfigured - the enquiry
+    // still reports success so the visitor isn't shown an error they can't fix.
+    await Promise.all([sendBusinessEnquiryNotification(enquiry), sendBusinessEnquiryAck(enquiry)]);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[enquiry/business] Failed:", error);
+    return errorResponse("Something went wrong sending your enquiry. Please try again.", 500);
+  }
+}

--- a/src/app/booking/manage/ManageLookupForm.tsx
+++ b/src/app/booking/manage/ManageLookupForm.tsx
@@ -40,7 +40,7 @@ export function ManageLookupForm({ phone, phoneTel }: ManageLookupFormProps): Re
    * Submits the lookup.
    * @param e - Form submit event.
    */
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
+  async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
     setState({ kind: "sending" });
     try {

--- a/src/app/business/loading.tsx
+++ b/src/app/business/loading.tsx
@@ -1,0 +1,92 @@
+// src/app/business/loading.tsx
+/**
+ * @description Streaming skeleton for the business page: centred hero with CTA
+ * buttons, service grid, rates list, retainer tier cards, how-it-works row,
+ * FAQ block and the enquiry card.
+ */
+
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
+import { Bone } from "@/shared/components/Skeleton";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+
+/**
+ * Business route-loading skeleton.
+ * @returns Skeleton element.
+ */
+export default function BusinessLoading(): React.ReactElement {
+  return (
+    <PageShell>
+      <FrostedSection>
+        <div
+          className="flex flex-col gap-6 sm:gap-8"
+          role="status"
+          aria-live="polite"
+          aria-label="Loading business page"
+        >
+          {/* Hero: heading, two paragraphs, two CTA buttons */}
+          <section className={cn(CARD, "flex flex-col items-center text-center")}>
+            <Bone className="mb-4 h-9 w-80 max-w-full sm:h-10" />
+            <Bone className="mb-2 h-5 w-full max-w-2xl" />
+            <Bone className="mb-8 h-5 w-full max-w-xl" />
+            <div className="flex w-full flex-col items-center gap-4 sm:flex-row sm:justify-center">
+              <Bone className="h-12 w-full rounded-xl sm:w-48" />
+              <Bone className="h-12 w-full rounded-xl sm:w-48" />
+            </div>
+          </section>
+
+          {/* Services grid */}
+          <section className={cn(CARD)}>
+            <Bone className="mb-4 h-7 w-72 max-w-full" />
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Bone key={i} className="h-36 rounded-lg" />
+              ))}
+            </div>
+          </section>
+
+          {/* Rates */}
+          <section className={cn(CARD)}>
+            <Bone className="mb-3 h-7 w-48" />
+            <Bone className="mb-3 h-5 w-full max-w-lg" />
+            <div className="flex flex-col gap-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Bone key={i} className="h-5 w-full max-w-md" />
+              ))}
+            </div>
+          </section>
+
+          {/* Retainer tiers */}
+          <section className={cn(CARD)}>
+            <Bone className="mb-4 h-7 w-56" />
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Bone key={i} className="h-56 rounded-lg" />
+              ))}
+            </div>
+          </section>
+
+          {/* How it works + FAQ + enquiry */}
+          <section className={cn(CARD)}>
+            <Bone className="mb-4 h-7 w-44" />
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Bone key={i} className="h-24 rounded-lg" />
+              ))}
+            </div>
+          </section>
+          <section className={cn(CARD)}>
+            <Bone className="mb-4 h-7 w-56" />
+            <div className="flex flex-col gap-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Bone key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          </section>
+
+          <span className="sr-only">Loading business page...</span>
+        </div>
+      </FrostedSection>
+    </PageShell>
+  );
+}

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -1,0 +1,467 @@
+// src/app/business/page.tsx
+/**
+ * @description Business page: ad-hoc IT support and monthly retainers for
+ * Auckland small businesses. Reads the live business rate from the rate
+ * config; retainer tiers are page copy (nothing downstream derives from them).
+ */
+
+import { BusinessEnquiryForm } from "@/features/business/components/BusinessEnquiryForm";
+import { getPublicPricing } from "@/features/business/lib/pricing-policy.server";
+import { BreadcrumbJsonLd } from "@/shared/components/BreadcrumbJsonLd";
+import { Button } from "@/shared/components/Button";
+import { CARD, FrostedSection, PageShell } from "@/shared/components/PageLayout";
+import { PixelEvent } from "@/shared/components/PixelEvent";
+import { cn } from "@/shared/lib/cn";
+import { getSiteUrl } from "@/shared/lib/site-url";
+import type { Metadata } from "next";
+import type React from "react";
+import {
+  FaLaptop,
+  FaPhone,
+  FaPrint,
+  FaShieldHalved,
+  FaTruck,
+  FaUserPlus,
+  FaWifi,
+} from "react-icons/fa6";
+
+// ISR so rate edits propagate via the rate-config tag purge instead of
+// requiring a redeploy.
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Business IT Support - Ad-hoc Help & Monthly Retainers in Auckland",
+  description:
+    "On-call IT support for Auckland small businesses: workstation and email setup, network fixes, backups, staff device onboarding and office moves. Ad-hoc callouts or a simple monthly retainer - no lock-in.",
+  alternates: { canonical: "/business" },
+  openGraph: {
+    title: "Business IT Support - To The Point Tech",
+    description:
+      "Your on-call IT person, without hiring one. Ad-hoc help and monthly retainers for Auckland small businesses.",
+    url: "/business",
+  },
+};
+
+interface BusinessService {
+  icon: React.ReactElement;
+  label: string;
+  examples: string[];
+}
+
+const businessServices: ReadonlyArray<BusinessService> = [
+  {
+    icon: <FaLaptop />,
+    label: "Workstations & Email",
+    examples: ["New PC and laptop setup", "Email and Microsoft 365", "Shared files and printers"],
+  },
+  {
+    icon: <FaWifi />,
+    label: "Network & Wi-Fi",
+    examples: ["Fixing dropouts", "Coverage through the office", "Router and switch setup"],
+  },
+  {
+    icon: <FaShieldHalved />,
+    label: "Backups & Security",
+    examples: ["Backup checks and setup", "Password managers", "Basic security reviews"],
+  },
+  {
+    icon: <FaUserPlus />,
+    label: "Staff On/Offboarding",
+    examples: ["New staff device setup", "Account creation", "Departing-staff lockdown"],
+  },
+  {
+    icon: <FaPrint />,
+    label: "Printers & Peripherals",
+    examples: ["Network printing", "Scanners and EFTPOS-adjacent kit", "Driver issues"],
+  },
+  {
+    icon: <FaTruck />,
+    label: "Office Moves & Projects",
+    examples: ["Packing up and reconnecting IT", "Cable tidying", "One-off projects"],
+  },
+];
+
+interface RetainerTier {
+  name: string;
+  fromPrice: string;
+  tagline: string;
+  inclusions: string[];
+}
+
+// Marketing copy only - retainers are quoted per client and invoiced manually
+// through the normal invoice flow; no value below feeds billing.
+const retainerTiers: ReadonlyArray<RetainerTier> = [
+  {
+    name: "Essentials",
+    fromPrice: "from $99/month",
+    tagline: "A safety net for the smallest teams.",
+    inclusions: [
+      "Priority response when something breaks",
+      "Monthly check-in on backups and updates",
+      "Discounted callout rate",
+    ],
+  },
+  {
+    name: "Standard",
+    fromPrice: "from $249/month",
+    tagline: "Ongoing cover for offices that lean on their IT.",
+    inclusions: [
+      "Everything in Essentials",
+      "Around 2 hours of remote support included",
+      "Backup and security checks each month",
+    ],
+  },
+  {
+    name: "Custom",
+    fromPrice: "by quote",
+    tagline: "More staff, more devices, or specific needs.",
+    inclusions: [
+      "Scoped to your setup and headcount",
+      "On-site hours included if you want them",
+      "Reviewed together as you grow",
+    ],
+  },
+];
+
+const howItWorks: ReadonlyArray<{ step: string; title: string; body: string }> = [
+  {
+    step: "1",
+    title: "Get in touch",
+    body: "Send an enquiry or ring. Tell me what's bugging you - or what you keep putting off.",
+  },
+  {
+    step: "2",
+    title: "Quick scoping chat",
+    body: "A short call or site visit to see your setup. No charge, no obligation.",
+  },
+  {
+    step: "3",
+    title: "Start how you like",
+    body: "Book ad-hoc jobs as they come up, or go on a retainer for ongoing cover. No lock-in either way.",
+  },
+];
+
+const businessFaq: ReadonlyArray<{ q: string; a: string }> = [
+  {
+    q: "How fast can you respond?",
+    a: "Urgent business issues get same-day or next-day attention where the schedule allows. Retainer clients get priority when things are busy.",
+  },
+  {
+    q: "Remote or on-site?",
+    a: "Both. Plenty of business problems are fixed over a screen-share; anything physical - networks, printers, new hardware - gets a visit.",
+  },
+  {
+    q: "Retainer or ad-hoc - which suits us?",
+    a: "Start ad-hoc. If you find yourself calling regularly, a retainer usually works out cheaper and gets you priority response. There's no lock-in, so switching is easy.",
+  },
+  {
+    q: "How does billing work?",
+    a: "You get an itemised invoice after each job, or one monthly invoice on a retainer. No surprises - anything beyond the agreed scope is discussed before it's done.",
+  },
+];
+
+const siteUrl = getSiteUrl();
+
+/**
+ * Business page component.
+ * @returns Business page element.
+ */
+export default async function BusinessPage(): Promise<React.ReactElement> {
+  const pricing = await getPublicPricing();
+  const businessJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    name: "Small business IT support",
+    serviceType: "IT support",
+    description:
+      "Ad-hoc IT support and monthly retainers for small businesses in Auckland: workstation and email setup, networks, backups, staff device onboarding and office moves.",
+    areaServed: { "@type": "AdministrativeArea", name: "Auckland, New Zealand" },
+    provider: { "@id": `${siteUrl}#business` },
+    offers: {
+      "@type": "Offer",
+      priceCurrency: "NZD",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: pricing.businessRate,
+        priceCurrency: "NZD",
+        unitCode: "HUR",
+      },
+      availability: "https://schema.org/InStock",
+    },
+  };
+
+  return (
+    <PageShell>
+      <PixelEvent event="ViewContent" />
+      <script
+        id="ld-business"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(businessJsonLd) }}
+      />
+      <BreadcrumbJsonLd
+        crumbs={[
+          { name: "Home", path: "/" },
+          { name: "Business", path: "/business" },
+        ]}
+      />
+      <FrostedSection>
+        <div className="flex flex-col gap-6 sm:gap-8">
+          {/* Hero */}
+          <section
+            aria-labelledby="business-heading"
+            className={cn(CARD, "animate-fade-in text-center")}
+          >
+            <h1
+              id="business-heading"
+              className="mb-4 text-2xl font-extrabold text-russian-violet sm:text-3xl md:text-4xl"
+            >
+              IT support for Auckland small businesses
+            </h1>
+
+            <p className="mx-auto mb-4 max-w-2xl text-base text-rich-black sm:text-lg">
+              Your on-call IT person, without hiring one. I handle the tech jobs you keep putting
+              off - setups, migrations, network gremlins, new staff devices - so you can get back to
+              running the business.
+            </p>
+
+            <p className="mx-auto mb-8 max-w-2xl text-base text-rich-black/80 sm:text-lg">
+              Call me out when you need help, or set up a monthly retainer for ongoing cover. No
+              lock-in either way.
+            </p>
+
+            <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+              <Button href="#enquire" variant="primary" size="lg" className="w-full sm:w-auto">
+                Send an enquiry
+              </Button>
+              <Button
+                href="tel:+64212971237"
+                variant="secondary"
+                size="lg"
+                className="w-full sm:w-auto"
+              >
+                <FaPhone className="h-6 w-6" aria-hidden />
+                021 297 1237
+              </Button>
+            </div>
+          </section>
+
+          {/* Ad-hoc services */}
+          <section
+            aria-labelledby="adhoc-heading"
+            className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-100")}
+          >
+            <h2
+              id="adhoc-heading"
+              className="mb-3 text-xl font-bold text-russian-violet sm:text-2xl"
+            >
+              The stuff you don't want to do
+            </h2>
+
+            <p className="mb-4 text-base text-rich-black sm:text-lg">
+              One-off jobs, sorted properly and explained in plain English:
+            </p>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
+              {businessServices.map((area) => (
+                <div
+                  key={area.label}
+                  className="rounded-lg border border-seasalt-400/60 bg-seasalt-800 p-3 shadow-sm transition-all hover:shadow-md"
+                >
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="grid size-10 shrink-0 place-items-center rounded-lg border border-moonstone-500/40 bg-moonstone-600/20">
+                      <span className="text-2xl text-moonstone-600" aria-hidden>
+                        {area.icon}
+                      </span>
+                    </span>
+                    <h3 className="text-lg font-semibold text-rich-black sm:text-xl">
+                      {area.label}
+                    </h3>
+                  </div>
+                  <ul className="space-y-1 text-base text-rich-black/80 sm:text-lg">
+                    {area.examples.map((example) => (
+                      <li key={example} className="flex gap-2">
+                        <span className="mt-0.5 text-moonstone-600">•</span>
+                        <span>{example}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Rates */}
+          <section
+            aria-labelledby="rates-heading"
+            className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-200")}
+          >
+            <h2
+              id="rates-heading"
+              className="mb-3 text-xl font-bold text-russian-violet sm:text-2xl"
+            >
+              Business rates
+            </h2>
+
+            <p className="mb-3 text-base text-rich-black sm:text-lg">
+              Business work bills at{" "}
+              <span className="font-bold text-russian-violet">${pricing.businessRate}/hr</span>, on
+              site or remote. You only pay for the time the job takes.
+            </p>
+
+            <ul className="space-y-2 text-base text-rich-black/90 sm:text-lg">
+              <li className="flex gap-2">
+                <span className="mt-1 text-moonstone-600">•</span>
+                <span>
+                  Travel billed at ${pricing.travelRatePerHour}/hr for one round trip per visit
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-1 text-moonstone-600">•</span>
+                <span>Quick phone questions are usually free</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-1 text-moonstone-600">•</span>
+                <span>Itemised invoice after every job</span>
+              </li>
+            </ul>
+          </section>
+
+          {/* Retainers */}
+          <section
+            aria-labelledby="retainers-heading"
+            className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-300")}
+          >
+            <h2
+              id="retainers-heading"
+              className="mb-3 text-xl font-bold text-russian-violet sm:text-2xl"
+            >
+              Monthly retainers
+            </h2>
+
+            <p className="mb-4 text-base text-rich-black sm:text-lg">
+              Prefer someone already across your setup? A retainer makes me your IT person on an
+              ongoing basis. No lock-in, cancel any time, billed by invoice each month.
+            </p>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              {retainerTiers.map((tier) => (
+                <div
+                  key={tier.name}
+                  className="flex flex-col rounded-lg border border-seasalt-400/60 bg-seasalt-800 p-4 shadow-sm transition-all hover:shadow-md"
+                >
+                  <h3 className="text-lg font-semibold text-rich-black sm:text-xl">{tier.name}</h3>
+                  <p className="mb-1 text-lg font-bold text-russian-violet sm:text-xl">
+                    {tier.fromPrice}
+                  </p>
+                  <p className="mb-3 text-base text-rich-black/70">{tier.tagline}</p>
+                  <ul className="mb-4 flex-1 space-y-1 text-base text-rich-black/80 sm:text-lg">
+                    {tier.inclusions.map((inc) => (
+                      <li key={inc} className="flex gap-2">
+                        <span className="mt-0.5 text-moonstone-600">•</span>
+                        <span>{inc}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <Button href="#enquire" variant="tertiary" size="md" fullWidth>
+                    Ask about {tier.name}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* How it works */}
+          <section
+            aria-labelledby="how-heading"
+            className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-400")}
+          >
+            <h2 id="how-heading" className="mb-4 text-xl font-bold text-russian-violet sm:text-2xl">
+              How it works
+            </h2>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              {howItWorks.map((item) => (
+                <div key={item.step} className="flex gap-3">
+                  <span className="grid size-10 shrink-0 place-items-center rounded-full border border-moonstone-500/40 bg-moonstone-600/20 text-lg font-bold text-moonstone-600">
+                    {item.step}
+                  </span>
+                  <div>
+                    <h3 className="mb-1 text-lg font-semibold text-rich-black sm:text-xl">
+                      {item.title}
+                    </h3>
+                    <p className="text-base text-rich-black/80 sm:text-lg">{item.body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Business FAQ */}
+          <section
+            aria-labelledby="bfaq-heading"
+            className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-500")}
+          >
+            <h2
+              id="bfaq-heading"
+              className="mb-4 text-xl font-bold text-russian-violet sm:text-2xl"
+            >
+              Common questions
+            </h2>
+
+            <div className="space-y-4">
+              {businessFaq.map((item) => (
+                <div key={item.q}>
+                  <h3 className="mb-1 text-lg font-semibold text-rich-black sm:text-xl">
+                    {item.q}
+                  </h3>
+                  <p className="text-base text-rich-black/80 sm:text-lg">{item.a}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Enquiry */}
+          <section
+            id="enquire"
+            aria-labelledby="enquire-heading"
+            className={cn(
+              CARD,
+              "animate-slide-up animate-fill-both animate-delay-500 scroll-mt-24",
+            )}
+          >
+            <h2
+              id="enquire-heading"
+              className="mb-3 text-xl font-bold text-russian-violet sm:text-2xl"
+            >
+              Tell me what you need
+            </h2>
+
+            <p className="mb-4 text-base text-rich-black sm:text-lg">
+              A couple of sentences is plenty - I'll come back to you within one business day.
+            </p>
+
+            <BusinessEnquiryForm />
+
+            <p className="mt-6 text-base text-rich-black/80 sm:text-lg">
+              Prefer to talk? Ring{" "}
+              <a
+                href="tel:+64212971237"
+                className="font-semibold text-russian-violet underline underline-offset-2 hover:text-russian-violet/80"
+              >
+                021 297 1237
+              </a>{" "}
+              or email{" "}
+              <a
+                href="mailto:harrison@tothepoint.co.nz"
+                className="font-semibold text-russian-violet underline underline-offset-2 hover:text-russian-violet/80"
+              >
+                harrison@tothepoint.co.nz
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </FrostedSection>
+    </PageShell>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -255,6 +255,26 @@ export default async function Home(): Promise<React.ReactElement> {
             </div>
           </section>
 
+          {/* Business strip */}
+          <section
+            aria-labelledby="business-strip-heading"
+            className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-300 text-center")}
+          >
+            <h2
+              id="business-strip-heading"
+              className="mb-2 text-xl font-bold text-russian-violet sm:text-2xl"
+            >
+              Run a small business?
+            </h2>
+            <p className="mx-auto mb-4 max-w-2xl text-base text-rich-black/90 sm:text-lg">
+              Ad-hoc IT help when things break, or a monthly retainer for ongoing cover - no
+              lock-in.
+            </p>
+            <Button href="/business" variant="tertiary" size="md">
+              Business IT support
+            </Button>
+          </section>
+
           {/* About & Approach */}
           <section aria-label="About and approach" className="grid gap-5 md:grid-cols-2 md:gap-6">
             <article className={cn(CARD, "animate-slide-up animate-fill-both animate-delay-300")}>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -140,7 +140,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                     ${applyPromoToHourlyRate(baseRate, promo).toFixed(0)}/hr
                   </p>
                   <p className="text-base text-rich-black/80 sm:text-lg">
-                    One rate for every job - troubleshooting, setup, software, tune-ups, Wi-Fi,
+                    One rate for every home job - troubleshooting, setup, software, tune-ups, Wi-Fi,
                     backups, data recovery, hardware repairs, and more.
                   </p>
                 </div>
@@ -161,7 +161,7 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                   ${baseRate}/hr
                 </p>
                 <p className="text-base text-rich-black/80 sm:text-lg">
-                  One rate for every job - troubleshooting, setup, software, tune-ups, Wi-Fi,
+                  One rate for every home job - troubleshooting, setup, software, tune-ups, Wi-Fi,
                   backups, data recovery, hardware repairs, and more.
                 </p>
               </div>
@@ -189,6 +189,17 @@ export default async function PricingPage(): Promise<React.ReactElement> {
                 <span>
                   <strong>Not sure which rate applies?</strong> Just ask - I'll confirm before
                   starting.
+                </span>
+              </p>
+              <p className="flex gap-3 text-base text-rich-black/90 sm:text-lg">
+                <FaCheck className="mt-1.5 h-4 w-4 shrink-0 text-moonstone-600" aria-hidden />
+                <span>
+                  <strong>Running a business?</strong> Business rates and monthly retainers are on
+                  the{" "}
+                  <Link href="/business" className={linkStyle}>
+                    business page
+                  </Link>
+                  .
                 </span>
               </p>
             </div>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -313,8 +313,15 @@ export default async function ServicesPage(): Promise<React.ReactElement> {
               </ul>
 
               <p className="mt-3 text-base text-rich-black/90 sm:text-lg">
-                No ongoing contracts required. You call when you need help.
+                No lock-in required - call when you need help, or set up a monthly retainer for
+                ongoing cover.
               </p>
+
+              <div className="mt-4">
+                <Button href="/business" variant="tertiary" size="md">
+                  Business IT support
+                </Button>
+              </div>
             </section>
           </div>
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -27,6 +27,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   }> = [
     { path: "/", priority: 1.0, changeFrequency: "weekly", lastModified: now },
     { path: "/services", priority: 0.9, changeFrequency: "monthly", lastModified: monthStart },
+    { path: "/business", priority: 0.9, changeFrequency: "monthly", lastModified: monthStart },
     { path: "/pricing", priority: 0.9, changeFrequency: "monthly", lastModified: now },
     { path: "/booking", priority: 0.9, changeFrequency: "weekly", lastModified: now },
     { path: "/about", priority: 0.7, changeFrequency: "monthly", lastModified: monthStart },

--- a/src/features/admin/components/ContactAdminList.tsx
+++ b/src/features/admin/components/ContactAdminList.tsx
@@ -31,6 +31,8 @@ export interface ContactRow {
   createdAt: string;
   /** Google People API resource name if synced, or null */
   googleContactId: string | null;
+  /** Retainer tier label when this contact is a retainer client, or null. */
+  retainerTier: string | null;
   /** Reviews linked to this contact */
   reviews: Array<{
     id: string;
@@ -491,6 +493,7 @@ export function ContactAdminList({
   // since a contact is exactly one of synced or not.
   const [syncFilter, setSyncFilter] = useState<"all" | "synced" | "unsynced">("all");
   const [reviewedOnly, setReviewedOnly] = useState(false);
+  const [retainerOnly, setRetainerOnly] = useState(false);
   const [noEmail, setNoEmail] = useState(false);
   const [noPhone, setNoPhone] = useState(false);
   const [sort, setSort] = useState<"name" | "newest" | "oldest">("name");
@@ -548,11 +551,12 @@ export function ContactAdminList({
       )
     : contacts;
 
-  const anyFilter = syncFilter !== "all" || reviewedOnly || noEmail || noPhone;
+  const anyFilter = syncFilter !== "all" || reviewedOnly || retainerOnly || noEmail || noPhone;
   const filtered = visible.filter((c) => {
     if (syncFilter === "synced" && !c.googleContactId) return false;
     if (syncFilter === "unsynced" && c.googleContactId) return false;
     if (reviewedOnly && c.reviews.length === 0) return false;
+    if (retainerOnly && !c.retainerTier) return false;
     if (noEmail && c.email) return false;
     if (noPhone && c.phone) return false;
     return true;
@@ -915,6 +919,13 @@ export function ContactAdminList({
         >
           Has reviews
         </button>
+        <button
+          type="button"
+          onClick={() => setRetainerOnly((v) => !v)}
+          className={chipClass(retainerOnly)}
+        >
+          Retainer
+        </button>
         <button type="button" onClick={() => setNoEmail((v) => !v)} className={chipClass(noEmail)}>
           No email
         </button>
@@ -927,6 +938,7 @@ export function ContactAdminList({
             onClick={() => {
               setSyncFilter("all");
               setReviewedOnly(false);
+              setRetainerOnly(false);
               setNoEmail(false);
               setNoPhone(false);
             }}

--- a/src/features/admin/components/ContactDetailActions.tsx
+++ b/src/features/admin/components/ContactDetailActions.tsx
@@ -29,7 +29,22 @@ interface ContactDetailActionsProps {
   address: string | null;
   /** Google People resource id when synced, else null. */
   googleContactId: string | null;
+  /** Retainer tier label, or null when not a retainer client. */
+  retainerTier: string | null;
+  /** Agreed monthly retainer price, or null. */
+  retainerPrice: number | null;
+  /** Included support hours per month, or null. */
+  retainerHours: number | null;
+  /** Retainer start date as yyyy-mm-dd, or null. */
+  retainerSince: string | null;
+  /** Free-text notes on the arrangement, or null. */
+  retainerNotes: string | null;
+  /** Operator environment notes (router, ISP, tenant); never passwords. */
+  siteNotes: string | null;
 }
+
+/** Tier options offered in the edit modal; matches the /business page tiers. */
+const RETAINER_TIERS = ["Essentials", "Standard", "Custom"] as const;
 
 const inputClass =
   "w-full rounded-lg border border-admin-border bg-admin-surface px-3 py-2 text-sm text-admin-text focus:border-russian-violet focus:outline-none";
@@ -43,6 +58,12 @@ const inputClass =
  * @param props.phone - Current primary phone.
  * @param props.address - Current address.
  * @param props.googleContactId - Google resource id when synced.
+ * @param props.retainerTier - Retainer tier label, or null.
+ * @param props.retainerPrice - Agreed monthly price, or null.
+ * @param props.retainerHours - Included hours per month, or null.
+ * @param props.retainerSince - Retainer start date (yyyy-mm-dd), or null.
+ * @param props.retainerNotes - Arrangement notes, or null.
+ * @param props.siteNotes - Environment notes, or null.
  * @returns Action bar element.
  */
 export function ContactDetailActions({
@@ -52,6 +73,12 @@ export function ContactDetailActions({
   phone,
   address,
   googleContactId,
+  retainerTier,
+  retainerPrice,
+  retainerHours,
+  retainerSince,
+  retainerNotes,
+  siteNotes,
 }: ContactDetailActionsProps): React.ReactElement {
   const router = useRouter();
   const { toast } = useToast();
@@ -64,6 +91,12 @@ export function ContactDetailActions({
     email: email ?? "",
     phone: phone ?? "",
     address: address ?? "",
+    retainerTier: retainerTier ?? "",
+    retainerPrice: retainerPrice !== null ? String(retainerPrice) : "",
+    retainerHours: retainerHours !== null ? String(retainerHours) : "",
+    retainerSince: retainerSince ?? "",
+    retainerNotes: retainerNotes ?? "",
+    siteNotes: siteNotes ?? "",
   });
 
   /** PATCHes the edited fields, then refreshes the server data on success. */
@@ -72,12 +105,33 @@ export function ContactDetailActions({
       toast("Name can't be empty.", { tone: "error" });
       return;
     }
+    const price = form.retainerPrice.trim() ? Number(form.retainerPrice) : null;
+    const hours = form.retainerHours.trim() ? Number(form.retainerHours) : null;
+    if (
+      (price !== null && !Number.isFinite(price)) ||
+      (hours !== null && !Number.isFinite(hours))
+    ) {
+      toast("Retainer price and hours must be numbers.", { tone: "error" });
+      return;
+    }
     setBusy("save");
     try {
       const res = await fetch(`/api/admin/contacts/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(form),
+        body: JSON.stringify({
+          name: form.name,
+          email: form.email,
+          phone: form.phone,
+          address: form.address,
+          // No tier = no retainer: clearing the tier clears the whole arrangement.
+          retainerTier: form.retainerTier || null,
+          retainerPrice: form.retainerTier ? price : null,
+          retainerHours: form.retainerTier ? hours : null,
+          retainerSince: form.retainerTier ? form.retainerSince || null : null,
+          retainerNotes: form.retainerTier ? form.retainerNotes || null : null,
+          siteNotes: form.siteNotes || null,
+        }),
       });
       const data = (await res.json()) as { ok?: boolean; error?: string };
       if (!res.ok) throw new Error(data.error ?? "Request failed");
@@ -187,6 +241,86 @@ export function ContactDetailActions({
               className={inputClass}
             />
           </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-admin-muted">Site notes</span>
+            <textarea
+              rows={3}
+              value={form.siteNotes}
+              onChange={(e) => setForm((f) => ({ ...f, siteNotes: e.target.value }))}
+              className={inputClass}
+              placeholder="Router model, ISP, M365 tenant, where the NAS lives... never passwords."
+            />
+          </label>
+
+          {/* Retainer arrangement: tier gates the rest - no tier means not a
+              retainer client and clears the other fields on save. */}
+          <div className="mt-2 border-t border-admin-border pt-3">
+            <p className="mb-2 text-sm font-semibold text-admin-text">Retainer</p>
+            <div className="flex flex-col gap-3">
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-admin-muted">Tier</span>
+                <select
+                  value={form.retainerTier}
+                  onChange={(e) => setForm((f) => ({ ...f, retainerTier: e.target.value }))}
+                  className={inputClass}
+                >
+                  <option value="">Not a retainer client</option>
+                  {RETAINER_TIERS.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {form.retainerTier && (
+                <>
+                  <div className="grid grid-cols-2 gap-3">
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium text-admin-muted">$/month</span>
+                      <input
+                        type="number"
+                        min="0"
+                        step="1"
+                        value={form.retainerPrice}
+                        onChange={(e) => setForm((f) => ({ ...f, retainerPrice: e.target.value }))}
+                        className={inputClass}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium text-admin-muted">Included hrs/month</span>
+                      <input
+                        type="number"
+                        min="0"
+                        step="0.5"
+                        value={form.retainerHours}
+                        onChange={(e) => setForm((f) => ({ ...f, retainerHours: e.target.value }))}
+                        className={inputClass}
+                      />
+                    </label>
+                  </div>
+                  <label className="flex flex-col gap-1 text-sm">
+                    <span className="font-medium text-admin-muted">Since</span>
+                    <input
+                      type="date"
+                      value={form.retainerSince}
+                      onChange={(e) => setForm((f) => ({ ...f, retainerSince: e.target.value }))}
+                      className={inputClass}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-sm">
+                    <span className="font-medium text-admin-muted">Notes</span>
+                    <textarea
+                      rows={2}
+                      value={form.retainerNotes}
+                      onChange={(e) => setForm((f) => ({ ...f, retainerNotes: e.target.value }))}
+                      className={inputClass}
+                      placeholder="Agreed scope, rollover stance, discounted rate..."
+                    />
+                  </label>
+                </>
+              )}
+            </div>
+          </div>
         </div>
       </Modal>
 

--- a/src/features/admin/components/LoginForm.tsx
+++ b/src/features/admin/components/LoginForm.tsx
@@ -9,7 +9,7 @@
 
 import { useRouter } from "next/navigation";
 import type React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 interface LoginFormProps {
   /** Validated relative path to land on after a successful sign-in. */
@@ -29,14 +29,20 @@ export function LoginForm({ nextPath }: LoginFormProps): React.ReactElement {
   const [secret, setSecret] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const secretRef = useRef<HTMLInputElement>(null);
 
   /**
    * Submits the secret. On 2xx response, navigates to nextPath. On any other
    * response (4xx, 5xx, network) shows a generic error.
    * @param e - Form submit event.
    */
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
+  async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
+    // Read the live DOM value, not React state: a password-manager autofill
+    // can populate the field without firing an input event, leaving state
+    // empty while the input visibly holds the secret.
+    const value = secretRef.current?.value ?? secret;
+    if (!value) return;
     setError(null);
     setBusy(true);
     try {
@@ -44,7 +50,7 @@ export function LoginForm({ nextPath }: LoginFormProps): React.ReactElement {
         method: "POST",
         credentials: "same-origin",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ secret }),
+        body: JSON.stringify({ secret: value }),
       });
       if (!res.ok) {
         setError("Sign-in failed. Try again.");
@@ -63,10 +69,26 @@ export function LoginForm({ nextPath }: LoginFormProps): React.ReactElement {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      {/* Visually-hidden username: password managers key saved logins on a
+          username field, so a password-only form saves with a blank username
+          and autofill gets flaky. Off-screen (not display:none) so managers
+          still see it. */}
+      <input
+        type="text"
+        name="username"
+        autoComplete="username"
+        defaultValue="admin"
+        readOnly
+        aria-hidden="true"
+        tabIndex={-1}
+        style={{ position: "absolute", left: "-9999px", width: 1, height: 1 }}
+      />
       <label className="flex flex-col gap-1">
         <span className="text-xs font-semibold text-slate-600">Admin secret</span>
         <input
+          ref={secretRef}
           type="password"
+          name="password"
           autoComplete="current-password"
           autoFocus
           required
@@ -83,7 +105,7 @@ export function LoginForm({ nextPath }: LoginFormProps): React.ReactElement {
       )}
       <button
         type="submit"
-        disabled={busy || secret.length === 0}
+        disabled={busy}
         className="inline-flex h-11 items-center justify-center rounded-lg bg-russian-violet px-4 text-sm font-semibold text-white hover:opacity-90 disabled:opacity-50"
       >
         {busy ? "Signing in..." : "Sign in"}

--- a/src/features/business/components/BusinessEnquiryForm.tsx
+++ b/src/features/business/components/BusinessEnquiryForm.tsx
@@ -1,0 +1,317 @@
+// src/features/business/components/BusinessEnquiryForm.tsx
+/**
+ * @description Public business enquiry form for the /business page. Posts to
+ * /api/enquiry/business; on success the form swaps for a confirmation card.
+ * Follows the public BookingForm field conventions (text-base sizing, shared
+ * EmailInput/PhoneInput, hidden honeypot).
+ */
+
+"use client";
+
+import { validateEmail } from "@/features/booking/lib/booking";
+import { Button } from "@/shared/components/Button";
+import { EmailInput } from "@/shared/components/EmailInput";
+import { PhoneInput } from "@/shared/components/PhoneInput";
+import { cn } from "@/shared/lib/cn";
+import type React from "react";
+import { useState } from "react";
+import { FaCircleCheck } from "react-icons/fa6";
+
+const INTEREST_OPTIONS = ["One-off job", "Monthly retainer", "Not sure yet"] as const;
+const URGENCY_OPTIONS = ["This week", "This month", "Just exploring"] as const;
+
+const INPUT_CLASS = cn(
+  "rounded-md border border-seasalt-400/80 bg-seasalt px-4 py-3 text-base text-rich-black",
+  "focus:border-russian-violet focus:ring-1 focus:ring-russian-violet/30 focus:outline-none",
+);
+
+/**
+ * Business enquiry form: company + contact details, what they need, and two
+ * optional selects. Success replaces the form with a confirmation card.
+ * @returns Enquiry form element.
+ */
+export function BusinessEnquiryForm(): React.ReactElement {
+  // Who the help is for: a business (company required) or the person
+  // themselves (company hidden - sole traders and personal jobs both fit).
+  const [enquiryFor, setEnquiryFor] = useState<"business" | "personal">("business");
+  const [company, setCompany] = useState("");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [needs, setNeeds] = useState("");
+  const [interest, setInterest] = useState("");
+  const [urgency, setUrgency] = useState("");
+  const [website, setWebsite] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Validates the required fields and posts the enquiry.
+   * @param e - Form submit event.
+   */
+  async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault();
+    if (submitting) return;
+
+    const isBusiness = enquiryFor === "business";
+    if ((isBusiness && !company.trim()) || !name.trim() || !needs.trim()) {
+      setError(
+        isBusiness
+          ? "Please fill in your company, your name, and what you need help with."
+          : "Please fill in your name and what you need help with.",
+      );
+      return;
+    }
+    if (validateEmail(email) !== "ok") {
+      setError("Please enter a valid email address.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/enquiry/business", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          kind: enquiryFor,
+          company: isBusiness ? company.trim() : undefined,
+          name: name.trim(),
+          email: email.trim(),
+          phone: phone.trim() || undefined,
+          needs: needs.trim(),
+          interest: interest || undefined,
+          urgency: urgency || undefined,
+          website,
+        }),
+      });
+      const data = (await res.json()) as { ok?: boolean; error?: string };
+      if (!res.ok || !data.ok) {
+        setError(data.error || "Could not send your enquiry. Please try again.");
+        setSubmitting(false);
+        return;
+      }
+      setSubmitted(true);
+    } catch {
+      setError("Network error. Please try again.");
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div
+        role="status"
+        className="flex flex-col items-center gap-3 rounded-lg border border-moonstone-500/40 bg-moonstone-600/10 p-6 text-center"
+      >
+        <FaCircleCheck className="h-10 w-10 text-moonstone-600" aria-hidden />
+        <p className="text-lg font-semibold text-rich-black sm:text-xl">Enquiry sent - thanks!</p>
+        <p className="max-w-xl text-base text-rich-black/80 sm:text-lg">
+          I'll come back to you within one business day, usually sooner. A confirmation is on its
+          way to your inbox.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5" autoComplete="off">
+      {/* Honeypot: visually hidden + off-screen + tab-skipped + aria-hidden.
+          Real users never see or focus this; the server fakes success when a
+          bot fills it. */}
+      <div
+        aria-hidden="true"
+        style={{ position: "absolute", left: "-9999px", width: 1, height: 1, overflow: "hidden" }}
+      >
+        <label htmlFor="enquiry-website">Website (leave blank)</label>
+        <input
+          id="enquiry-website"
+          name="website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+        />
+      </div>
+
+      {/* Business vs personal: gates whether the company field shows. */}
+      <div className="flex flex-col gap-2">
+        <span className="text-base font-semibold text-rich-black">
+          Who's this for? <span className="text-coquelicot-500">*</span>
+        </span>
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-2">
+          <button
+            type="button"
+            aria-pressed={enquiryFor === "business"}
+            onClick={() => setEnquiryFor("business")}
+            className={cn(
+              "rounded-lg border px-5 py-2.5 text-base font-medium whitespace-nowrap transition-colors",
+              enquiryFor === "business"
+                ? "border-russian-violet bg-russian-violet/10 text-russian-violet"
+                : "border-seasalt-400/60 bg-seasalt text-rich-black hover:border-russian-violet/40",
+            )}
+          >
+            A business
+          </button>
+          <button
+            type="button"
+            aria-pressed={enquiryFor === "personal"}
+            onClick={() => setEnquiryFor("personal")}
+            className={cn(
+              "rounded-lg border px-5 py-2.5 text-base font-medium whitespace-nowrap transition-colors",
+              enquiryFor === "personal"
+                ? "border-russian-violet bg-russian-violet/10 text-russian-violet"
+                : "border-seasalt-400/60 bg-seasalt text-rich-black hover:border-russian-violet/40",
+            )}
+          >
+            Me personally
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {enquiryFor === "business" && (
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="enquiry-company" className="text-base font-semibold text-rich-black">
+              Company <span className="text-coquelicot-500">*</span>
+            </label>
+            <input
+              id="enquiry-company"
+              type="text"
+              autoComplete="organization"
+              required
+              aria-required
+              maxLength={200}
+              value={company}
+              onChange={(e) => setCompany(e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="enquiry-name" className="text-base font-semibold text-rich-black">
+            Your name <span className="text-coquelicot-500">*</span>
+          </label>
+          <input
+            id="enquiry-name"
+            type="text"
+            autoComplete="name"
+            required
+            aria-required
+            maxLength={200}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className={INPUT_CLASS}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="enquiry-email" className="text-base font-semibold text-rich-black">
+            Email <span className="text-coquelicot-500">*</span>
+          </label>
+          <EmailInput
+            id="enquiry-email"
+            value={email}
+            onChange={setEmail}
+            required
+            errorMessages={{ invalid: "Please enter a valid email address." }}
+            className={cn(
+              "border border-seasalt-400/80 bg-seasalt px-4 py-3 text-base text-rich-black",
+              "focus:border-russian-violet focus:ring-1 focus:ring-russian-violet/30",
+            )}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="enquiry-phone" className="text-base font-semibold text-rich-black">
+            Phone <span className="text-base text-rich-black/70">(optional)</span>
+          </label>
+          <PhoneInput
+            id="enquiry-phone"
+            value={phone}
+            onChange={setPhone}
+            errorMessages={{ invalid: "Please enter a valid phone number." }}
+            className={cn(
+              "border border-seasalt-400/80 bg-seasalt px-4 py-3 text-base text-rich-black",
+              "focus:border-russian-violet focus:ring-1 focus:ring-russian-violet/30",
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="enquiry-needs" className="text-base font-semibold text-rich-black">
+          What do you need help with? <span className="text-coquelicot-500">*</span>
+        </label>
+        <textarea
+          id="enquiry-needs"
+          required
+          aria-required
+          rows={4}
+          maxLength={4000}
+          value={needs}
+          onChange={(e) => setNeeds(e.target.value)}
+          placeholder="e.g. Two new staff laptops to set up, and our Wi-Fi drops out in the back office."
+          className={cn(INPUT_CLASS, "resize-y")}
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="enquiry-interest" className="text-base font-semibold text-rich-black">
+            What are you after? <span className="text-base text-rich-black/70">(optional)</span>
+          </label>
+          <select
+            id="enquiry-interest"
+            value={interest}
+            onChange={(e) => setInterest(e.target.value)}
+            className={INPUT_CLASS}
+          >
+            <option value="">Choose one...</option>
+            {INTEREST_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="enquiry-urgency" className="text-base font-semibold text-rich-black">
+            How urgent? <span className="text-base text-rich-black/70">(optional)</span>
+          </label>
+          <select
+            id="enquiry-urgency"
+            value={urgency}
+            onChange={(e) => setUrgency(e.target.value)}
+            className={INPUT_CLASS}
+          >
+            <option value="">Choose one...</option>
+            {URGENCY_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-base font-medium text-coquelicot-600">
+          {error}
+        </p>
+      )}
+
+      <div>
+        <Button type="submit" variant="primary" size="lg" disabled={submitting}>
+          {submitting ? "Sending..." : "Send enquiry"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/business/components/CalculatorView.tsx
+++ b/src/features/business/components/CalculatorView.tsx
@@ -467,6 +467,8 @@ export function CalculatorView({
   // True while the in-flight save is a "Save & send" (routes to ?send=1 and
   // skips the calculator's add-to-contacts gate); drives the two button labels.
   const [saveSendMode, setSaveSendMode] = useState(false);
+  // True while the in-flight save is a "Save as quote"; drives its busy label.
+  const [saveQuoteMode, setSaveQuoteMode] = useState(false);
   const [saveInvoiceError, setSaveInvoiceError] = useState<string | null>(null);
   const [pendingInvoiceId, setPendingInvoiceId] = useState<string | null>(null);
   const { toast } = useToast();
@@ -1348,11 +1350,15 @@ export function CalculatorView({
    * @param send - When true ("Save & send"), skip the add-to-contacts gate and
    *   route to the detail page with `?send=1` so it auto-opens the send preview
    *   (which has its own add-to-contacts hook-in + contactId backfill).
+   * @param quote - When true ("Save as quote"), the row saves as a QUOTE: a
+   *   Q- number from the quote counter, QUOTE PDF, 30-day validity default,
+   *   convertible to a real invoice from the detail page.
    */
-  async function handleSaveInvoice(send = false): Promise<void> {
+  async function handleSaveInvoice(send = false, quote = false): Promise<void> {
     // Validate required fields
     setSaveInvoiceError(null);
     setSaveSendMode(send);
+    setSaveQuoteMode(quote);
     if (!clientName.trim()) {
       setSaveInvoiceError("Client name is required.");
       return;
@@ -1404,6 +1410,8 @@ export function CalculatorView({
           // schedule's "Bill in calculator" action.
           bookingId: eventPrefill?.bookingId ?? null,
           calendarEventId: eventPrefill?.calendarEventId ?? null,
+          // Quote mode: server allocates a Q- number + 30-day validity.
+          isQuote: quote || undefined,
           // issueDate, dueDate, number all defaulted server-side.
         }),
       });
@@ -1416,9 +1424,12 @@ export function CalculatorView({
         | { error: string };
       if ("error" in d) throw new Error(d.error);
       if (d.sheetSyncWarning) {
-        toast("Invoice saved - sheet counter sync failed. Update SETTINGS!B17.", {
-          tone: "warning",
-        });
+        toast(
+          quote
+            ? "Quote saved - sheet counter sync failed. Update SETTINGS!B12."
+            : "Invoice saved - sheet counter sync failed. Update SETTINGS!B19.",
+          { tone: "warning" },
+        );
       }
       const invoiceId = d.invoice.id;
       // Add-to-contacts gate: defer nav until the modal closes so
@@ -1613,9 +1624,9 @@ export function CalculatorView({
   }
 
   /**
-   * Wipes every rate row and reseeds the defaults (Standard base + modifier set
-   * + Travel flat). Confirms first since this drops any custom rates. Also
-   * cancels any in-progress edit so the form doesn't hold a stale ID.
+   * Wipes every rate row and reseeds the defaults (Standard base + modifier
+   * set). Confirms first since this drops any custom rates. Also cancels any
+   * in-progress edit so the form doesn't hold a stale ID.
    */
   async function handleResetRates(): Promise<void> {
     handleCancelEdit();
@@ -1786,7 +1797,7 @@ export function CalculatorView({
       <ConfirmDialog
         open={confirmResetOpen}
         title="Reset all rates?"
-        body="This wipes every rate and reseeds the defaults (Standard, At home, Remote, Public Holiday, Travel). Any custom rates you've added will be deleted."
+        body="This wipes every rate and reseeds the defaults (Standard, Business, At home, Remote, Phone, Public Holiday). Any custom rates you've added will be deleted."
         confirmLabel="Reset rates"
         tone="danger"
         onConfirm={() => {
@@ -2315,6 +2326,15 @@ export function CalculatorView({
               className="w-full rounded-lg border border-russian-violet px-4 py-2 text-sm font-semibold text-russian-violet hover:bg-russian-violet/5 disabled:opacity-50"
             >
               {savingInvoice && saveSendMode ? "Saving..." : "Save & send"}
+            </button>
+            <button
+              onClick={() => void handleSaveInvoice(false, true)}
+              disabled={savingInvoice || parsing}
+              suppressHydrationWarning
+              title="Save as a Q-numbered quote - convert it to an invoice once the client accepts."
+              className="w-full rounded-lg border border-russian-violet px-4 py-2 text-sm font-semibold text-russian-violet hover:bg-russian-violet/5 disabled:opacity-50"
+            >
+              {savingInvoice && saveQuoteMode ? "Saving..." : "Save as quote"}
             </button>
             <button
               onClick={handleSaveIncome}

--- a/src/features/business/components/InvoicesListView.tsx
+++ b/src/features/business/components/InvoicesListView.tsx
@@ -27,8 +27,8 @@ import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { FaCaretRight } from "react-icons/fa6";
 
-/** Status filter buckets (OVERDUE is derived, not a stored status). */
-type FilterKey = "all" | "DRAFT" | "SENT" | "OVERDUE" | "PAID" | "VOIDED";
+/** Status filter buckets (OVERDUE and QUOTE are derived, not stored statuses). */
+type FilterKey = "all" | "QUOTE" | "DRAFT" | "SENT" | "OVERDUE" | "PAID" | "VOIDED";
 /** Sortable column keys. */
 type SortKey = "number" | "client" | "issued" | "due" | "total" | "status";
 /** Sort direction. */
@@ -49,6 +49,7 @@ const COLUMNS: { key: SortKey; label: string }[] = [
 /** Status-filter dropdown options. */
 const FILTER_OPTIONS: { value: FilterKey; label: string }[] = [
   { value: "all", label: "All statuses" },
+  { value: "QUOTE", label: "Quotes" },
   { value: "DRAFT", label: "Draft" },
   { value: "SENT", label: "Sent" },
   { value: "OVERDUE", label: "Overdue" },
@@ -71,7 +72,7 @@ const PAGE_SIZE = 25;
  * @returns True when the Record-payment action should show.
  */
 function canPay(inv: Invoice): boolean {
-  return inv.status === "SENT";
+  return inv.status === "SENT" && !inv.isQuote;
 }
 
 /**
@@ -193,6 +194,8 @@ export function InvoicesListView(): React.ReactElement {
 
   // Summary across ALL invoices (not the filtered view). Legacy PAID rows with no
   // paidAt are excluded from "paid this month" - their pay date is unknown.
+  // Quotes are not money owed - they get their own counter and stay out of
+  // every dollar stat.
   const summary = useMemo(() => {
     const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
     let outstanding = 0;
@@ -202,7 +205,16 @@ export function InvoicesListView(): React.ReactElement {
     let paidCount = 0;
     let draftCount = 0;
     let draftSum = 0;
+    let quoteCount = 0;
+    let quoteSum = 0;
     for (const inv of invoices) {
+      if (inv.isQuote) {
+        if (inv.status !== "VOIDED") {
+          quoteCount += 1;
+          quoteSum += inv.total;
+        }
+        continue;
+      }
       if (inv.status === "SENT") {
         outstanding += inv.total;
         if (isInvoiceOverdue(inv, now)) {
@@ -219,7 +231,17 @@ export function InvoicesListView(): React.ReactElement {
         draftSum += inv.total;
       }
     }
-    return { outstanding, overdue, overdueCount, paidThisMonth, paidCount, draftCount, draftSum };
+    return {
+      outstanding,
+      overdue,
+      overdueCount,
+      paidThisMonth,
+      paidCount,
+      draftCount,
+      draftSum,
+      quoteCount,
+      quoteSum,
+    };
   }, [invoices, now]);
 
   const filtered = useMemo(() => {
@@ -232,7 +254,11 @@ export function InvoicesListView(): React.ReactElement {
       }
       if (statusFilter === "OVERDUE") {
         if (!isInvoiceOverdue(inv, now)) return false;
-      } else if (statusFilter !== "all" && inv.status !== statusFilter) {
+      } else if (statusFilter === "QUOTE") {
+        if (!inv.isQuote) return false;
+      } else if (statusFilter !== "all" && (inv.status !== statusFilter || inv.isQuote)) {
+        // Stored-status buckets are invoice-only: a quote is DRAFT/SENT under
+        // the hood but must not surface under those filters.
         return false;
       }
       const issued = new Date(inv.issueDate);
@@ -308,7 +334,7 @@ export function InvoicesListView(): React.ReactElement {
       />
 
       {/* Summary cards double as one-click status filters. */}
-      <div className="mb-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <div className="mb-5 grid grid-cols-2 gap-3 lg:grid-cols-5">
         <StatCard
           label="Outstanding"
           value={formatNZD(summary.outstanding)}
@@ -339,6 +365,13 @@ export function InvoicesListView(): React.ReactElement {
           sub={formatNZD(summary.draftSum)}
           onClick={() => toggleFilter("DRAFT")}
           active={statusFilter === "DRAFT"}
+        />
+        <StatCard
+          label="Quotes"
+          value={summary.quoteCount}
+          sub={`${formatNZD(summary.quoteSum)} quoted`}
+          onClick={() => toggleFilter("QUOTE")}
+          active={statusFilter === "QUOTE"}
         />
       </div>
 
@@ -470,9 +503,9 @@ export function InvoicesListView(): React.ReactElement {
                     size="xs"
                     variant="secondary"
                     href={`/admin/business/invoices/${inv.id}?send=1`}
-                    aria-label={`Send invoice ${inv.number}`}
+                    aria-label={`Send ${inv.isQuote ? "quote" : "invoice"} ${inv.number}`}
                   >
-                    Send invoice
+                    {inv.isQuote ? "Send quote" : "Send invoice"}
                   </AdminButton>
                 </div>
               )}
@@ -569,9 +602,9 @@ export function InvoicesListView(): React.ReactElement {
                           size="xs"
                           variant="secondary"
                           href={`/admin/business/invoices/${inv.id}?send=1`}
-                          aria-label={`Send invoice ${inv.number}`}
+                          aria-label={`Send ${inv.isQuote ? "quote" : "invoice"} ${inv.number}`}
                         >
-                          Send invoice
+                          {inv.isQuote ? "Send quote" : "Send invoice"}
                         </AdminButton>
                       )}
                       {canPay(inv) && (

--- a/src/features/business/components/invoice/InvoiceStatusBadge.tsx
+++ b/src/features/business/components/invoice/InvoiceStatusBadge.tsx
@@ -19,6 +19,10 @@ const TONE: Record<string, StatusTone> = {
   PAID: "success",
   OVERDUE: "critical",
   VOIDED: "violet",
+  // Quote states: violet matches the PDF's brand-coloured QUOTE treatment
+  // (VOIDED shares the tone but never the text); EXPIRED warns without alarm.
+  QUOTE: "violet",
+  EXPIRED: "warning",
 };
 
 /** Props for {@link InvoiceStatusBadge}. */

--- a/src/features/business/lib/google-sheets.ts
+++ b/src/features/business/lib/google-sheets.ts
@@ -75,6 +75,71 @@ export async function getInvoiceCounter(): Promise<InvoiceCounterData> {
   return { prefix, yearCode, lastNumber, nextNumber, nextFormatted };
 }
 
+export interface QuoteCounterData {
+  yearCode: string;
+  lastNumber: number;
+  nextNumber: number;
+  nextFormatted: string;
+}
+
+/**
+ * Reads the quote counter state from the SETTINGS tab. Quotes number from
+ * their own cell (B12) so they never consume the invoice counter; the format
+ * is `Q-{yearCode}-{NNNN}` (no operator prefix - "Q" IS the prefix).
+ * Cell layout (current template):
+ *   - B11: Financial Year (shared with the invoice counter)
+ *   - B12: Quote counter (last issued number; blank = 0)
+ * @returns Quote counter data including next formatted number
+ */
+export async function getQuoteCounter(): Promise<QuoteCounterData> {
+  const sheets = getSheetsClient();
+  const spreadsheetId = getSheetId();
+  const res = await withRetry(
+    () =>
+      sheets.spreadsheets.values.batchGet({
+        spreadsheetId,
+        ranges: ["SETTINGS!B11", "SETTINGS!B12"],
+      }),
+    { label: "quote-counter-read" },
+  );
+  const ranges = res.data.valueRanges ?? [];
+  const yearRaw = ((ranges[0]?.values?.[0]?.[0] as string | undefined) ?? "").trim();
+  const lastRaw = ranges[1]?.values?.[0]?.[0];
+  const yearCode = yearRaw.replace("-", "");
+  // Same malformed-cell guards as the invoice counter: throwing hands off to
+  // the DB-max fallback instead of minting a poisoned number.
+  if (!/^\d{4,6}$/.test(yearCode)) {
+    throw new Error(`Quote counter: SETTINGS!B11 financial year is malformed ("${yearRaw}")`);
+  }
+  const lastNumber =
+    lastRaw != null && String(lastRaw).trim() !== "" ? parseInt(String(lastRaw), 10) : 0;
+  if (!Number.isInteger(lastNumber) || lastNumber < 0) {
+    throw new Error(`Quote counter: SETTINGS!B12 is not a valid number ("${String(lastRaw)}")`);
+  }
+  const nextNumber = lastNumber + 1;
+  const nextFormatted = `Q-${yearCode}-${String(nextNumber).padStart(4, "0")}`;
+  return { yearCode, lastNumber, nextNumber, nextFormatted };
+}
+
+/**
+ * Writes a new quote count back to the SETTINGS tab at B12.
+ * @param newCount - The new quote count to persist
+ */
+export async function setQuoteCounter(newCount: number): Promise<void> {
+  const sheets = getSheetsClient();
+  const spreadsheetId = getSheetId();
+  await withRetry(
+    () =>
+      sheets.spreadsheets.values.update({
+        spreadsheetId,
+        range: "SETTINGS!B12",
+        valueInputOption: "RAW",
+        requestBody: { values: [[newCount]] },
+      }),
+    { label: "quote-counter-write" },
+  );
+}
+
 /**
  * Writes a new invoice count back to the Google Sheet SETTINGS tab at B19.
  * @param newCount - The new invoice count to persist

--- a/src/features/business/lib/invoice-email-defaults.ts
+++ b/src/features/business/lib/invoice-email-defaults.ts
@@ -9,6 +9,10 @@
 export const DEFAULT_INVOICE_EMAIL_BODY =
   "Thanks so much for the work - I really appreciate you choosing me for your tech support. Your invoice is attached below.";
 
+/** Default intro for quote emails - acceptance instructions live in the details block + PDF. */
+export const DEFAULT_QUOTE_EMAIL_BODY =
+  "Thanks for getting in touch - your quote is attached. If you're happy with it, just reply to this email or give me a ring and I'll get it booked in.";
+
 /**
  * Default body for the "your invoice has been voided" notification email.
  * Sent atomically when the operator voids a SENT or PAID invoice and ticks the

--- a/src/features/business/lib/invoice-numbering.ts
+++ b/src/features/business/lib/invoice-numbering.ts
@@ -8,7 +8,12 @@
  */
 
 import { nextInvoiceNumber } from "@/features/business/lib/business";
-import { getInvoiceCounter, setInvoiceCounter } from "@/features/business/lib/google-sheets";
+import {
+  getInvoiceCounter,
+  getQuoteCounter,
+  setInvoiceCounter,
+  setQuoteCounter,
+} from "@/features/business/lib/google-sheets";
 import { prisma } from "@/shared/lib/prisma";
 
 export interface NextInvoiceNumber {
@@ -32,7 +37,12 @@ export interface NextInvoiceNumber {
 export async function getNextInvoiceNumber(): Promise<NextInvoiceNumber> {
   try {
     const data = await getInvoiceCounter();
+    // Quote rows share the table + unique index but number from their own
+    // counter - exclude them so a Q- number can never seed the invoice
+    // sequence (isQuote catches converted rows whose flag was later cleared;
+    // the prefix filter catches any legacy row).
     const last = await prisma.invoice.findFirst({
+      where: { NOT: { number: { startsWith: "Q-" } } },
       orderBy: { number: "desc" },
       select: { number: true },
     });
@@ -47,7 +57,10 @@ export async function getNextInvoiceNumber(): Promise<NextInvoiceNumber> {
         : `${data.prefix}-${data.yearCode}-${String(nextNumber).padStart(4, "0")}`;
     return { number, sheetNextCount: nextNumber, sheetSyncWarning: false };
   } catch {
-    const last = await prisma.invoice.findFirst({ orderBy: { number: "desc" } });
+    const last = await prisma.invoice.findFirst({
+      where: { NOT: { number: { startsWith: "Q-" } } },
+      orderBy: { number: "desc" },
+    });
     const now = new Date();
     const fy = now.getMonth() >= 3 ? now.getFullYear() : now.getFullYear() - 1;
     const yearCode = String(fy) + String(fy + 1).slice(2);
@@ -56,6 +69,57 @@ export async function getNextInvoiceNumber(): Promise<NextInvoiceNumber> {
       sheetNextCount: null,
       sheetSyncWarning: true,
     };
+  }
+}
+
+/**
+ * Fetches the next QUOTE number as `max(sheet quote counter, highest existing
+ * Q- number in the DB)` - the same convergence rule as invoices, against the
+ * dedicated SETTINGS!B12 counter. Falls back to the DB max alone when Sheets
+ * is unreachable. Callers pass `sheetNextCount` to
+ * {@link writeBackQuoteCounter} after the row is created.
+ * @returns Next Q- number plus the write-back counter (or null on fallback).
+ */
+export async function getNextQuoteNumber(): Promise<NextInvoiceNumber> {
+  // Highest existing Q- row; shared by both paths below.
+  const last = await prisma.invoice.findFirst({
+    where: { number: { startsWith: "Q-" } },
+    orderBy: { number: "desc" },
+    select: { number: true },
+  });
+  const dbMatch = last?.number.match(/-(\d+)$/);
+  const dbNext = (dbMatch ? parseInt(dbMatch[1], 10) : 0) + 1;
+  try {
+    const data = await getQuoteCounter();
+    const nextNumber = Math.max(data.nextNumber, dbNext);
+    const number =
+      nextNumber === data.nextNumber
+        ? data.nextFormatted
+        : `Q-${data.yearCode}-${String(nextNumber).padStart(4, "0")}`;
+    return { number, sheetNextCount: nextNumber, sheetSyncWarning: false };
+  } catch {
+    const now = new Date();
+    const fy = now.getMonth() >= 3 ? now.getFullYear() : now.getFullYear() - 1;
+    const yearCode = String(fy) + String(fy + 1).slice(2);
+    return {
+      number: `Q-${yearCode}-${String(dbNext).padStart(4, "0")}`,
+      sheetNextCount: null,
+      sheetSyncWarning: true,
+    };
+  }
+}
+
+/**
+ * Writes the just-used quote counter back to SETTINGS!B12. Same no-op /
+ * swallow semantics as {@link writeBackInvoiceCounter}.
+ * @param count - The numeric counter that was just consumed.
+ */
+export async function writeBackQuoteCounter(count: number | null): Promise<void> {
+  if (count === null) return;
+  try {
+    await setQuoteCounter(count);
+  } catch (err) {
+    console.error("[invoice-numbering] Sheets quote-counter write-back failed:", err);
   }
 }
 

--- a/src/features/business/lib/invoice-pdf.ts
+++ b/src/features/business/lib/invoice-pdf.ts
@@ -138,6 +138,8 @@ export function serializeInvoice(inv: PrismaInvoice): Invoice {
     paidAt: inv.paidAt?.toISOString() ?? null,
     paymentMethod: inv.paymentMethod,
     paymentReference: inv.paymentReference,
+    isQuote: inv.isQuote,
+    quoteValidUntil: inv.quoteValidUntil?.toISOString() ?? null,
     driveFileId: inv.driveFileId,
     driveWebUrl: inv.driveWebUrl,
     createdAt: inv.createdAt.toISOString(),
@@ -152,9 +154,12 @@ export function serializeInvoice(inv: PrismaInvoice): Invoice {
  * @param invoice - Invoice being rendered.
  */
 function drawStatusWatermark(ctx: PdfCtx, invoice: Invoice): void {
-  const isOverdue = isInvoiceOverdue(invoice);
-  const text =
-    invoice.status === "PAID"
+  // Quotes short-circuit: a quote is never PAID/OVERDUE, and even a voided
+  // quote reads better watermarked QUOTE with the VOID status line beside it.
+  const isOverdue = !invoice.isQuote && isInvoiceOverdue(invoice);
+  const text = invoice.isQuote
+    ? "QUOTE"
+    : invoice.status === "PAID"
       ? "PAID"
       : invoice.status === "VOIDED"
         ? "VOID"
@@ -162,8 +167,9 @@ function drawStatusWatermark(ctx: PdfCtx, invoice: Invoice): void {
           ? "OVERDUE"
           : null;
   if (!text) return;
-  const color =
-    invoice.status === "PAID"
+  const color = invoice.isQuote
+    ? BRAND
+    : invoice.status === "PAID"
       ? PAID_COLOR
       : invoice.status === "VOIDED"
         ? VOID_COLOR
@@ -208,8 +214,9 @@ function drawHeader(ctx: PdfCtx, invoice: Invoice, logoPaths: LogoPath[]): numbe
   }
 
   const rightX = MARGIN + CONTENT_W;
-  // IRD requires "Tax invoice" wording when GST-registered.
-  const invTitle = ctx.identity.gstNumber ? "TAX INVOICE" : "INVOICE";
+  // IRD requires "Tax invoice" wording when GST-registered; a quote is never
+  // a tax document, so QUOTE wins regardless of registration.
+  const invTitle = invoice.isQuote ? "QUOTE" : ctx.identity.gstNumber ? "TAX INVOICE" : "INVOICE";
   let rightY = HEADER_TOP - 20;
   ctx.page.drawText(invTitle, {
     x: rightX - ctx.bold.widthOfTextAtSize(invTitle, 20),
@@ -227,16 +234,27 @@ function drawHeader(ctx: PdfCtx, invoice: Invoice, logoPaths: LogoPath[]): numbe
     color: DARK,
   });
   rightY -= 16;
+  // Quotes hide the DRAFT/SENT lifecycle (meaningless to the customer) and
+  // show the validity date instead; a voided quote still shows VOID.
+  const statusText = invoice.isQuote
+    ? invoice.status === "VOIDED"
+      ? "VOID"
+      : invoice.quoteValidUntil
+        ? `Valid until ${formatDateShort(invoice.quoteValidUntil)}`
+        : "QUOTE"
+    : invoice.status;
   const statusColor =
     invoice.status === "PAID"
       ? PAID_COLOR
-      : invoice.status === "SENT"
-        ? rgb(0.1, 0.35, 0.75)
-        : invoice.status === "VOIDED"
-          ? VOID_COLOR
-          : MID;
-  ctx.page.drawText(invoice.status, {
-    x: rightX - ctx.bold.widthOfTextAtSize(invoice.status, 11),
+      : invoice.status === "VOIDED"
+        ? VOID_COLOR
+        : invoice.isQuote
+          ? BRAND
+          : invoice.status === "SENT"
+            ? rgb(0.1, 0.35, 0.75)
+            : MID;
+  ctx.page.drawText(statusText, {
+    x: rightX - ctx.bold.widthOfTextAtSize(statusText, 11),
     y: rightY,
     size: 11,
     font: ctx.bold,
@@ -313,7 +331,15 @@ function drawBillToBlock(ctx: PdfCtx, invoice: Invoice, y: number): number {
     });
   };
   drawDateRow("Issued:", formatDateShort(invoice.issueDate), 0);
-  drawDateRow("Due:", formatDateShort(invoice.dueDate), -18);
+  if (invoice.isQuote) {
+    // A quote has no payment due date - the second row shows how long the
+    // quoted prices are honoured instead.
+    if (invoice.quoteValidUntil) {
+      drawDateRow("Valid to:", formatDateShort(invoice.quoteValidUntil), -18);
+    }
+  } else {
+    drawDateRow("Due:", formatDateShort(invoice.dueDate), -18);
+  }
 
   const sepY = infoY - 48;
   ctx.page.drawLine({
@@ -597,6 +623,62 @@ function drawPaymentCallout(ctx: PdfCtx, invoice: Invoice, y: number): number {
 }
 
 /**
+ * Quote variant of the call-out box: how to accept, plus the validity line.
+ * No bank details - payment comes with the invoice after acceptance.
+ * @param ctx - PDF drawing context.
+ * @param invoice - Quote being rendered.
+ * @param y - Top of the block.
+ * @returns Y coordinate below the box, including the gap before notes.
+ */
+function drawQuoteCallout(ctx: PdfCtx, invoice: Invoice, y: number): number {
+  const boxTop = y - 8;
+  const BOX_PAD_X = 14;
+  const BOX_PAD_Y = 14;
+  const lineH = 16;
+  const boxLines = 3; // heading + accept line + validity line
+  const BOX_H = BOX_PAD_Y * 2 + 22 + (boxLines - 1) * lineH;
+  ctx.page.drawRectangle({
+    x: MARGIN,
+    y: boxTop - BOX_H,
+    width: CONTENT_W,
+    height: BOX_H,
+    borderColor: LIGHT,
+    borderWidth: 0.8,
+  });
+
+  let by = boxTop - BOX_PAD_Y - 2;
+  ctx.page.drawText("Accepting this quote", {
+    x: MARGIN + BOX_PAD_X,
+    y: by,
+    size: 14,
+    font: ctx.bold,
+    color: BRAND,
+  });
+  by -= 22;
+  ctx.page.drawText(`Reply to the email or ring ${ctx.identity.phone} to go ahead.`, {
+    x: MARGIN + BOX_PAD_X,
+    y: by,
+    size: 12,
+    font: ctx.font,
+    color: DARK,
+  });
+  by -= lineH;
+  ctx.page.drawText(
+    invoice.quoteValidUntil
+      ? `Prices are held until ${formatDateShort(invoice.quoteValidUntil)}.`
+      : "Prices may change if the scope does - anything extra is agreed first.",
+    {
+      x: MARGIN + BOX_PAD_X,
+      y: by,
+      size: 12,
+      font: ctx.font,
+      color: MID,
+    },
+  );
+  return boxTop - BOX_H - 14;
+}
+
+/**
  * Draws the operator-supplied notes line, if any. Wraps to the page width.
  * @param ctx - PDF drawing context.
  * @param invoice - Invoice being rendered.
@@ -661,7 +743,7 @@ export async function generateInvoicePdf(invoice: Invoice): Promise<Buffer> {
   y = drawBillToBlock(ctx, invoice, y);
   y = drawLineItemsTable(ctx, invoice, y);
   y = drawTotalsBlock(ctx, invoice, y);
-  y = drawPaymentCallout(ctx, invoice, y);
+  y = invoice.isQuote ? drawQuoteCallout(ctx, invoice, y) : drawPaymentCallout(ctx, invoice, y);
   drawNotes(ctx, invoice, y);
   drawFooter(ctx);
 

--- a/src/features/business/lib/invoice-status.ts
+++ b/src/features/business/lib/invoice-status.ts
@@ -20,16 +20,38 @@ export interface OverdueCheckInput {
   status: InvoiceStatus;
   /** Due date as an ISO string or a Date. */
   dueDate: string | Date;
+  /** True when the row is a quote; null/undefined reads as false. */
+  isQuote?: boolean | null;
+  /** Quote validity end; past it the quote displays as EXPIRED. */
+  quoteValidUntil?: string | Date | null;
 }
+
+/** What the admin UI shows on the pill: a stored status or a derived one. */
+export type InvoiceDisplayStatus = InvoiceStatus | "OVERDUE" | "QUOTE" | "EXPIRED";
+
+/**
+ * Prisma where-fragment excluding quote rows. MUST be this OR shape: on the
+ * Mongo connector, `NOT: { isQuote: true }` and `isQuote: { not: true }` both
+ * fail to match documents where the field is UNSET (every invoice created
+ * before the quote feature), silently dropping legacy invoices. Spread into a
+ * `where` that has no OR of its own (wrap in AND otherwise).
+ */
+export const NOT_A_QUOTE_FILTER = {
+  // Plain mutable shape (no `as const`): Prisma's InvoiceWhereInput requires
+  // a mutable OR array.
+  OR: [{ isQuote: null }, { isQuote: false }, { isQuote: { isSet: false } }],
+};
 
 /**
  * Whether an invoice is overdue: SENT with a due date before the start of
- * `now`'s day.
+ * `now`'s day. Quotes are never overdue - their dueDate is a schema
+ * placeholder, not a payment deadline.
  * @param invoice - Invoice status + due date.
  * @param now - Reference instant (defaults to the current time).
  * @returns True when the invoice is SENT and past due.
  */
 export function isInvoiceOverdue(invoice: OverdueCheckInput, now: Date = new Date()): boolean {
+  if (invoice.isQuote) return false;
   if (invoice.status !== "SENT") return false;
   const startOfToday = new Date(now);
   startOfToday.setHours(0, 0, 0, 0);
@@ -37,15 +59,20 @@ export function isInvoiceOverdue(invoice: OverdueCheckInput, now: Date = new Dat
 }
 
 /**
- * The status to DISPLAY for an invoice: the stored status, except a SENT invoice
- * past due surfaces as "OVERDUE". PAID / VOIDED / DRAFT pass through unchanged.
- * @param invoice - Invoice status + due date.
+ * The status to DISPLAY for an invoice: the stored status, except a SENT
+ * invoice past due surfaces as "OVERDUE", and a quote surfaces as "QUOTE"
+ * (or "EXPIRED" once its validity date passes). A voided quote still shows
+ * VOIDED - terminal states win.
+ * @param invoice - Invoice status + due date (+ quote fields).
  * @param now - Reference instant (defaults to the current time).
- * @returns The display status (a stored status, or the derived "OVERDUE").
+ * @returns The display status.
  */
 export function deriveInvoiceDisplayStatus(
   invoice: OverdueCheckInput,
   now: Date = new Date(),
-): InvoiceStatus | "OVERDUE" {
+): InvoiceDisplayStatus {
+  if (invoice.isQuote && invoice.status !== "VOIDED") {
+    return invoice.quoteValidUntil && new Date(invoice.quoteValidUntil) < now ? "EXPIRED" : "QUOTE";
+  }
   return isInvoiceOverdue(invoice, now) ? "OVERDUE" : invoice.status;
 }

--- a/src/features/business/lib/pricing-policy.server.ts
+++ b/src/features/business/lib/pricing-policy.server.ts
@@ -7,6 +7,7 @@
 
 import {
   FALLBACK_BASE_RATE,
+  FALLBACK_BUSINESS_DELTA,
   GST_RATE,
   HOME_REGION,
   NZ_REGION,
@@ -103,6 +104,8 @@ export interface PublicPricing {
   baseRate: number;
   /** Travel hourly rate, used for round-trip drive billing. */
   travelRatePerHour: number;
+  /** Effective business hourly rate (base + Business modifier delta); shown on /business only. */
+  businessRate: number;
   /** Customer-facing modifier list rendered in the Modifiers accordion. */
   modifiers: PublicModifier[];
   /** Most-recent updatedAt across all RateConfig rows; powers the "rates last updated" footer. */
@@ -137,6 +140,14 @@ export const getPublicPricing = cache(async (): Promise<PublicPricing> => {
   // Travel rate is a pricing setting, not a rate row - the operator edits it
   // in Settings > Pricing and it can't drift via the calculator's rate panel.
   const travelRatePerHour = pricing.travelRatePerHour;
+
+  // Business rate = base + the Business modifier row's delta. The row is
+  // deliberately absent from the consumer accordion allowlist below; only the
+  // /business page renders this figure.
+  const businessDelta =
+    rows.find((r) => r.label === "Business" && r.unit === "modifier")?.hourlyDelta ??
+    FALLBACK_BUSINESS_DELTA;
+  const businessRate = Math.round((baseRate + businessDelta) * 100) / 100;
 
   // Public Holiday uses percentDelta; the rest use hourlyDelta.
   const modifiers: PublicModifier[] = [];
@@ -180,6 +191,7 @@ export const getPublicPricing = cache(async (): Promise<PublicPricing> => {
   return {
     baseRate,
     travelRatePerHour,
+    businessRate,
     modifiers,
     ratesUpdatedAt: isoMax ? new Date(isoMax) : null,
   };

--- a/src/features/business/lib/pricing-policy.ts
+++ b/src/features/business/lib/pricing-policy.ts
@@ -46,6 +46,9 @@ const WORKMANSHIP_WINDOW_DAYS = 30;
 /** Fallback Standard base rate ($/hr) when no default hourly RateConfig row exists; mirrors the seed default. */
 export const FALLBACK_BASE_RATE = 65;
 
+/** Fallback Business modifier ($/hr on top of the base rate) when no Business RateConfig row exists; mirrors the seed default. */
+export const FALLBACK_BUSINESS_DELTA = 20;
+
 /** Region label for nationwide NZ public holidays in the PublicHoliday table. */
 export const NZ_REGION = "NZ";
 /** Region for the operator's regional anniversary day (also charged the uplift). */

--- a/src/features/business/types/business.ts
+++ b/src/features/business/types/business.ts
@@ -66,6 +66,10 @@ export interface Invoice {
   reminderLastSentAt?: string | null;
   /** How many overdue reminders have gone out; null reads as 0 (Mongo backfill rule). */
   reminderCount?: number | null;
+  /** True when this row is a quote (Q- number, no payment until converted). Null reads as false. */
+  isQuote?: boolean | null;
+  /** ISO date the quote's pricing is honoured until; null = no stated expiry. */
+  quoteValidUntil?: string | null;
   driveFileId: string | null;
   driveWebUrl: string | null;
   createdAt: string;

--- a/src/features/reviews/lib/email.ts
+++ b/src/features/reviews/lib/email.ts
@@ -8,6 +8,7 @@ import { buildIcs } from "@/features/booking/lib/ics";
 import { formatNZD } from "@/features/business/lib/business";
 import {
   DEFAULT_INVOICE_EMAIL_BODY,
+  DEFAULT_QUOTE_EMAIL_BODY,
   DEFAULT_VOID_EMAIL_BODY,
 } from "@/features/business/lib/invoice-email-defaults";
 import { cancellationCopy } from "@/features/business/lib/pricing-policy";
@@ -806,6 +807,10 @@ export interface InvoiceEmailData {
   dueDate: Date;
   total: number;
   driveWebUrl?: string | null;
+  /** True when the row is a quote - switches subject/body to quote wording. */
+  isQuote?: boolean | null;
+  /** Quote validity end; shown in place of the due date. */
+  quoteValidUntil?: Date | null;
 }
 
 interface BuildInvoiceEmailArgs {
@@ -833,10 +838,12 @@ export async function buildInvoiceEmail({
 }: BuildInvoiceEmailArgs): Promise<{ subject: string; html: string }> {
   const siteUrl = getSiteUrl();
   const identity = await getIdentity();
-  const bodyText = (customBody ?? DEFAULT_INVOICE_EMAIL_BODY).trim();
+  const isQuote = invoice.isQuote === true;
+  const defaultBody = isQuote ? DEFAULT_QUOTE_EMAIL_BODY : DEFAULT_INVOICE_EMAIL_BODY;
+  const bodyText = (customBody ?? defaultBody).trim();
   // pre-wrap preserves line breaks the operator typed; escape first so the
   // body can never inject markup.
-  const safeBody = escapeHtml(bodyText || DEFAULT_INVOICE_EMAIL_BODY);
+  const safeBody = escapeHtml(bodyText || defaultBody);
   // Greeting: caller-supplied override wins; otherwise fall back to the first
   // word of clientName. The Send modal lets the operator type the right name
   // per send, so there's no auto-detection of company vs person here.
@@ -848,15 +855,35 @@ export async function buildInvoiceEmail({
   const dueDate = escapeHtml(formatDateShort(invoice.dueDate));
   const totalLabel = escapeHtml(formatNZD(invoice.total));
   const driveLink = invoice.driveWebUrl
-    ? `<p style="margin:0 0 16px;font-size:14px;color:#555">An online copy is also here: <a href="${escapeHtml(invoice.driveWebUrl)}" style="color:#43bccd">view invoice</a>.</p>`
+    ? `<p style="margin:0 0 16px;font-size:14px;color:#555">An online copy is also here: <a href="${escapeHtml(invoice.driveWebUrl)}" style="color:#43bccd">view ${isQuote ? "quote" : "invoice"}</a>.</p>`
     : "";
-  const reviewLine = reviewUrl
-    ? `<p style="margin:24px 0 0;font-size:14px;color:#555">If you've got a moment, I'd love to hear how it went - you can <a href="${escapeHtml(reviewUrl)}" style="color:#43bccd">leave a quick review here</a>. It's anonymous if you'd prefer.</p>`
-    : "";
+  // No review ask on a quote - the job hasn't happened yet.
+  const reviewLine =
+    reviewUrl && !isQuote
+      ? `<p style="margin:24px 0 0;font-size:14px;color:#555">If you've got a moment, I'd love to hear how it went - you can <a href="${escapeHtml(reviewUrl)}" style="color:#43bccd">leave a quick review here</a>. It's anonymous if you'd prefer.</p>`
+      : "";
+
+  // Quote emails swap the due line for validity and drop the bank block -
+  // payment details come with the invoice after acceptance.
+  const dateLine = isQuote
+    ? invoice.quoteValidUntil
+      ? `<p style="margin:0"><strong>Valid until:</strong> ${escapeHtml(formatDateShort(invoice.quoteValidUntil))}</p>`
+      : ""
+    : `<p style="margin:0"><strong>Due:</strong> ${dueDate} (${identity.paymentTermsDays} days from issue)</p>`;
+  const paymentBlock = isQuote
+    ? ""
+    : `<p style="margin:0 0 8px;font-size:14px;color:#333"><strong>Bank transfer:</strong></p>
+    <p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:#333">
+      Payee: ${escapeHtml(identity.name)}<br />
+      Account: <strong>${escapeHtml(identity.bankAccount)}</strong><br />
+      Reference: <strong>${safeNumber}</strong>
+    </p>`;
 
   // Append " Tech" to match the signature and body brand name, so the subject
   // and the rest of the same email show one consistent business name.
-  const subject = `Your invoice from ${identity.company} Tech (${invoice.number})`;
+  const subject = isQuote
+    ? `Your quote from ${identity.company} Tech (${invoice.number})`
+    : `Your invoice from ${identity.company} Tech (${invoice.number})`;
   const html = `<!doctype html>
 <html lang="en">
 <head><meta charset="utf-8" /></head>
@@ -867,19 +894,14 @@ export async function buildInvoiceEmail({
     <p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:#333;white-space:pre-wrap">${safeBody}</p>
 
     <div style="margin:0 0 16px;padding:12px 16px;background:#f3f4f6;border-radius:8px;font-size:14px;color:#333">
-      <p style="margin:0 0 4px"><strong>Invoice:</strong> ${safeNumber}</p>
+      <p style="margin:0 0 4px"><strong>${isQuote ? "Quote" : "Invoice"}:</strong> ${safeNumber}</p>
       <p style="margin:0 0 4px"><strong>Total:</strong> ${totalLabel}</p>
-      <p style="margin:0"><strong>Due:</strong> ${dueDate} (${identity.paymentTermsDays} days from issue)</p>
+      ${dateLine}
     </div>
 
     ${driveLink}
 
-    <p style="margin:0 0 8px;font-size:14px;color:#333"><strong>Bank transfer:</strong></p>
-    <p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:#333">
-      Payee: ${escapeHtml(identity.name)}<br />
-      Account: <strong>${escapeHtml(identity.bankAccount)}</strong><br />
-      Reference: <strong>${safeNumber}</strong>
-    </p>
+    ${paymentBlock}
 
     <p style="margin:0;font-size:14px;color:#333">Any questions, just reply.</p>
 
@@ -946,7 +968,7 @@ export async function sendInvoiceEmail({
       html,
       attachments: [
         {
-          filename: `Invoice ${invoice.number}.pdf`,
+          filename: `${invoice.isQuote ? "Quote" : "Invoice"} ${invoice.number}.pdf`,
           content: Buffer.from(pdfBytes),
         },
       ],
@@ -1186,5 +1208,150 @@ export async function sendVoidNotification({
   } catch (error) {
     console.error(`[email] Failed to send void notification for ${invoice.number}:`, error);
     return false;
+  }
+}
+
+/** Business enquiry data used for the operator notification + enquirer ack. */
+export interface BusinessEnquiryData {
+  /** Company or trading name; null for a personal enquiry. */
+  company: string | null;
+  /** Contact person's name. */
+  name: string;
+  /** Contact email (reply-to target for the notification). */
+  email: string;
+  /** Contact phone in E.164, or null when not supplied. */
+  phone: string | null;
+  /** What they need help with (free text). */
+  needs: string;
+  /** Interest level: one-off job, retainer, or unsure. Optional. */
+  interest: string | null;
+  /** Urgency: this week / this month / exploring. Optional. */
+  urgency: string | null;
+}
+
+/**
+ * Sends the operator a notification email for a new business enquiry.
+ * Failures are caught and logged - never throws.
+ * @param enquiry - The enquiry details.
+ * @returns Promise that resolves when the email is sent (or silently fails).
+ */
+export async function sendBusinessEnquiryNotification(enquiry: BusinessEnquiryData): Promise<void> {
+  const adminEmail = process.env.ADMIN_EMAIL;
+  const from = process.env.EMAIL_FROM;
+
+  if (!adminEmail || !from || !process.env.RESEND_API_KEY) {
+    console.warn(
+      `[email] Not configured (${missingEmailEnv("ADMIN_EMAIL", "EMAIL_FROM", "RESEND_API_KEY")}) - skipping business enquiry notification.`,
+    );
+    return;
+  }
+
+  const safeName = escapeHtml(enquiry.name);
+  const safeEmail = escapeHtml(enquiry.email);
+  const safeMailto = encodeURIComponent(enquiry.email);
+  const needsHtml = escapeHtml(enquiry.needs).replace(/\n/g, "<br>");
+  const companyBlock = enquiry.company
+    ? `<p style="margin:0 0 4px;font-size:14px;color:#888">Company</p>
+      <p style="margin:0 0 12px;font-size:15px;color:#0c0a3e;font-weight:600">${escapeHtml(enquiry.company)}</p>`
+    : `<p style="margin:0 0 12px;font-size:14px;color:#888">Personal enquiry (no company)</p>`;
+  const metaLine = [enquiry.interest, enquiry.urgency]
+    .filter(Boolean)
+    .map((v) => escapeHtml(v as string))
+    .join(" · ");
+  const phoneLine = enquiry.phone
+    ? `<p style="margin:0 0 12px;font-size:14px;color:#444"><a href="tel:${escapeHtml(enquiry.phone)}" style="color:#43bccd">${escapeHtml(enquiry.phone)}</a></p>`
+    : "";
+
+  const html = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="font-family:system-ui,sans-serif;background:#f6f7f8;margin:0;padding:24px">
+  <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;box-shadow:0 2px 8px rgba(0,0,0,.08)">
+    <h2 style="margin:0 0 4px;color:#0c0a3e;font-size:20px">New business enquiry</h2>
+    ${metaLine ? `<p style="margin:0 0 16px;color:#555;font-size:14px">${metaLine}</p>` : ""}
+
+    <div style="background:#f6f7f8;border-radius:8px;padding:16px;margin-bottom:20px">
+      ${companyBlock}
+      <p style="margin:0 0 4px;font-size:14px;color:#888">Contact</p>
+      <p style="margin:0 0 4px;font-size:15px;color:#0c0a3e;font-weight:600">${safeName}</p>
+      <p style="margin:0 0 12px;font-size:14px;color:#444"><a href="mailto:${safeMailto}" style="color:#43bccd">${safeEmail}</a></p>
+      ${phoneLine}
+      <p style="margin:0 0 4px;font-size:14px;color:#888">What they need</p>
+      <p style="margin:0;font-size:14px;color:#444;line-height:1.6">${needsHtml}</p>
+    </div>
+  </div>
+</body>
+</html>`;
+
+  try {
+    await getResend().emails.send({
+      from,
+      // Reply goes straight back to the enquirer, not the owner inbox.
+      replyTo: enquiry.email,
+      to: adminEmail,
+      subject: enquiry.company
+        ? `Business enquiry - ${enquiry.company} (${enquiry.name})`
+        : `Business enquiry - ${enquiry.name} (personal)`,
+      html,
+    });
+  } catch (error) {
+    console.error("[email] Failed to send business enquiry notification:", error);
+  }
+}
+
+/**
+ * Sends the enquirer a short acknowledgement of their business enquiry.
+ * Failures are caught and logged - never throws.
+ * @param enquiry - The enquiry details.
+ * @returns Promise that resolves when the email is sent (or silently fails).
+ */
+export async function sendBusinessEnquiryAck(enquiry: BusinessEnquiryData): Promise<void> {
+  const from = process.env.EMAIL_FROM;
+  const siteUrl = getSiteUrl();
+
+  if (!from || !process.env.RESEND_API_KEY) {
+    console.warn(
+      `[email] Not configured (${missingEmailEnv("EMAIL_FROM", "RESEND_API_KEY")}) - skipping business enquiry ack.`,
+    );
+    return;
+  }
+
+  const firstName = enquiry.name.split(" ")[0];
+  const safeFirstName = escapeHtml(firstName);
+  // Personal enquiries thank the person directly rather than a company.
+  const aboutTarget = enquiry.company ? ` for ${escapeHtml(enquiry.company)}` : "";
+  const signature = await buildEmailSignature(siteUrl);
+
+  const html = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="font-family:system-ui,sans-serif;background:#f6f7f8;margin:0;padding:24px">
+  <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;box-shadow:0 2px 8px rgba(0,0,0,.08)">
+    <h2 style="margin:0 0 16px;color:#0c0a3e;font-size:20px">Thanks for getting in touch</h2>
+    <p style="margin:0 0 12px;color:#222;font-size:15px;line-height:1.6">Hi ${safeFirstName},</p>
+    <p style="margin:0 0 12px;color:#222;font-size:15px;line-height:1.6">
+      Thanks for your enquiry about IT support${aboutTarget}. I'll come back to you within
+      one business day - usually sooner.
+    </p>
+    <p style="margin:0;color:#222;font-size:15px;line-height:1.6">
+      If it's urgent, feel free to ring me directly.
+    </p>
+    ${signature}
+  </div>
+</body>
+</html>`;
+
+  try {
+    await getResend().emails.send({
+      from,
+      replyTo: process.env.ADMIN_EMAIL,
+      to: enquiry.email,
+      subject: "Thanks for your enquiry - To The Point Tech",
+      html,
+    });
+  } catch (error) {
+    console.error("[email] Failed to send business enquiry ack:", error);
   }
 }

--- a/src/shared/components/NavBar.tsx
+++ b/src/shared/components/NavBar.tsx
@@ -24,6 +24,7 @@ const HIDDEN_PATHS: ReadonlyArray<string> = ["/poster"];
 const HIDDEN_PREFIXES: ReadonlyArray<string> = ["/admin"];
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { label: "Services", href: "/services", activePrefix: "/services" },
+  { label: "Business", href: "/business", activePrefix: "/business" },
   { label: "Pricing", href: "/pricing", activePrefix: "/pricing" },
   { label: "About", href: "/about", activePrefix: "/about" },
   { label: "FAQ", href: "/faq", activePrefix: "/faq" },

--- a/src/shared/components/SiteFooter.tsx
+++ b/src/shared/components/SiteFooter.tsx
@@ -18,6 +18,7 @@ const HIDDEN_PREFIXES: ReadonlyArray<string> = ["/admin"];
 
 const LINKS: ReadonlyArray<{ label: string; href: string }> = [
   { label: "Services", href: "/services" },
+  { label: "Business", href: "/business" },
   { label: "Pricing", href: "/pricing" },
   { label: "About", href: "/about" },
   { label: "FAQ", href: "/faq" },


### PR DESCRIPTION
## Summary

Launches the business/B2B offering end-to-end: a public /business page selling ad-hoc IT work and monthly retainers, a business enquiry intake that emails the operator, a business hourly rate wired through the live rate config, retainer-client tracking with a monthly "invoice them" prompt, per-contact site notes, and a full quote pipeline (Q-numbered from the sheet's own counter, QUOTE PDF/email, one-click convert to invoice). Plus a login password-manager fix.

## feat(business): /business page, enquiry form, business rate, copy reconciliation

- New /business page: hero, business services grid, live rates card, three retainer tiers (from $99 / from $249 / custom), how-it-works, mini FAQ, and the enquiry form. Canonical, OpenGraph, breadcrumb + Service JSON-LD, sitemap entry, nav + footer links, home-page strip.
- Business rate is a "Business" +$20 modifier row in RateConfig (effective $85/hr on the $65 base), admin-editable, exposed as `businessRate` on `PublicPricing` with a fallback const. Kept off the consumer pricing accordion; appears automatically in the calculator's modifier picker and the AI parse vocabulary.
- Enquiry: `POST /api/enquiry/business` with a "Who's this for?" toggle - a business (company required) or me personally (company hidden). Honeypot fake-success, rate limit, shared email/phone validators, email-only (no DB writes). Operator notification (reply-to = enquirer, subject flags personal enquiries) + auto-ack with the standard signature.
- Copy reconciliation: services/about pages drop "no contracts" for no-lock-in + retainer wording; pricing page reads "One rate for every home job" and points business customers at /business.

## fix(admin): login autofill, SubmitEvent sweep

- Hidden `autocomplete="username"` field + `name` attributes so password managers save and fill the admin login; submit reads the DOM value so an event-less autofill can't strand a disabled button.
- `React.FormEvent` > `React.SubmitEvent` in all three form components (deprecated in @types/react 19.2).

## feat(contacts): retainer management, site notes, retainers-due panel

- Optional `retainerTier/Price/Hours/Since/Notes` + `siteNotes` on Contact; edited in the contact modal (tier select gates the rest), shown as detail-rail cards, "Retainer" filter chip on the list. Fields survive merges and never sync to Google.
- Dashboard "Retainers due" panel: retainer clients with no invoice this month carrying a "retainer" line item (linked by contactId, voided + quote rows excluded). Hidden until the first retainer client exists.

## feat(invoices): quotes

- "Save as quote" in the calculator mints `Q-YYYY-NNNN` from the sheet's SETTINGS!B12 quote counter with the same max(sheet, DB) + collision-retry + write-back hardening as invoices; the invoice allocator now excludes Q- rows so the sequences can't cross-contaminate. Also fixes the sheet-warning toast naming the wrong cell (B17 > B19).
- PDF renders QUOTE title + brand-violet watermark, "Valid to" instead of a due date, and an "Accepting this quote" box in place of bank details (30-day validity default). Email gets quote wording, no bank block, no review ask.
- "Convert to invoice" on the detail page allocates the next TTP number, restamps issue/due from today, returns the row to DRAFT, and re-uploads the Drive PDF under the new number.
- Guards: payment on a quote 409s in both the pay route and status PATCH; the reminder cron skips quotes; list stats, dashboard outstanding, business-overview revenue, and retainers-due all exclude quotes.
- `NOT_A_QUOTE_FILTER`: on the Mongo connector `NOT: { isQuote: true }` fails to match documents where the field is unset (every pre-quote invoice), silently dropping legacy invoices from money stats - the shared OR-shape (null / false / unset) is the only correct form, verified against live rows.

## Verification

- Full local pass against the live DB + real sheet: quote created as Q-202627-0001 (B12 0>1, B19 untouched), pay attempts 409'd, converted to TTP-202627-0054 (B19 53>54), re-convert 409'd, money stats excluded the quote while legacy invoices still counted; counters reset afterwards.
- Enquiry: honeypot fake-success, validation 400s, real business + personal submissions delivered (notification + ack).
- Retainers: PATCH > detail card > due panel; issuing a retainer invoice flipped the panel to "all invoiced". Site notes round-tripped through the modal and detail card.
- /business verified in the browser: live $85 rate via tag purge after a rates-panel edit, consumer accordion clean, sitemap/JSON-LD/canonical correct.
