### PR TITLE
v4.14.1: invoice saving 500s on any job with hourly labour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "4.14.0",
+      "version": "4.14.1",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "6.19.3",
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.0.tgz",
-      "integrity": "sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3859,9 +3859,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -3906,9 +3906,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.9",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.9.tgz",
-      "integrity": "sha512-cp447VUsGS07+n1Dqf7YSQ8maeJrjEhaDxTm1ZefbqDtypHBC5GzGMQbklR6IPR13Y8OAJRHZWEMtZipJLCttg==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4150,9 +4150,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001807",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001807.tgz",
+      "integrity": "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -4878,9 +4878,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.399",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
-      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6085,17 +6085,26 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
+      "integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
         "json-bigint": "^1.0.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/generator-function": {
@@ -6197,9 +6206,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6306,12 +6315,12 @@
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.2.0.tgz",
+      "integrity": "sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/googleapis": {
@@ -6342,6 +6351,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -7155,9 +7173,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "funding": [
         {
           "type": "github",
@@ -8104,9 +8122,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10079,9 +10097,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -10424,9 +10442,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
-      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10479,9 +10497,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "dev": true,
       "funding": [
         {
@@ -10825,9 +10843,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -451,6 +451,14 @@ type LineItem {
   qty         Float
   unitPrice   Float
   lineTotal   Float
+  // Whole billed minutes, authoritative on hourly labour rows: `qty` is those
+  // minutes in hours and can't hold a 5-minute grid exactly (10 min = 0.1667h),
+  // so renderers show this as h:mm. Must stay in step with the optional
+  // `minutes` on the app-side LineItem type - Prisma rejects a composite field
+  // it doesn't declare, which 500s the whole create. Float, not Int, so a
+  // fractional value can't turn into that same rejection. Unset on flat rows
+  // (travel, parts, surcharges) and on invoices issued before the switch.
+  minutes     Float?
 }
 
 model Invoice {

--- a/src/app/api/business/invoices/[id]/route.ts
+++ b/src/app/api/business/invoices/[id]/route.ts
@@ -10,6 +10,7 @@
 import { calcInvoiceTotals, isValidLineItem } from "@/features/business/lib/business";
 import { syncInvoicePdfToDriveById } from "@/features/business/lib/invoice-drive-sync";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
+import { parseDate, parseObjectId } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -57,6 +58,20 @@ function statusDataFor(
     data.paymentReference = null;
   }
   return data;
+}
+
+/** Every valid {@link InvoiceStatus}, guarding both PATCH branches before the cast. */
+const INVOICE_STATUSES: readonly string[] = ["DRAFT", "SENT", "PAID", "VOIDED"];
+
+/**
+ * Narrows an untrusted status from a request body. Prisma rejects an unknown
+ * enum value outright, so casting without this check turns a bad status into a
+ * 500 rather than a 400.
+ * @param value - Raw status from a request body.
+ * @returns True when the value is one of the four invoice statuses.
+ */
+function isInvoiceStatus(value: unknown): value is InvoiceStatus {
+  return typeof value === "string" && INVOICE_STATUSES.includes(value);
 }
 
 /**
@@ -173,8 +188,17 @@ export async function PATCH(
     ) {
       return errorResponse("Invalid line item", 400);
     }
+    // A cleared <input type="date"> submits "", not undefined, so it reaches
+    // this branch. Parse both dates up front: an unparseable one has to 400
+    // here, because Prisma rejects an Invalid Date and would 500 the update.
+    const issueDateValue = issueDate !== undefined ? parseDate(issueDate) : undefined;
+    const dueDateValue = dueDate !== undefined ? parseDate(dueDate) : undefined;
+    if (issueDateValue === null || dueDateValue === null) {
+      return errorResponse("Enter a valid issue date and due date", 400);
+    }
     if (status !== undefined) {
-      const err = validateTransition(current.status, status as InvoiceStatus);
+      if (!isInvoiceStatus(status)) return errorResponse("Invalid status", 400);
+      const err = validateTransition(current.status, status);
       if (err) return errorResponse(err, 409);
     }
     // GST mode is driven by the live pricing settings (gstRegistered); the
@@ -190,14 +214,14 @@ export async function PATCH(
       preservedDiscount,
       GST_REGISTERED,
     );
-    const statusPatch = status !== undefined ? statusDataFor(status as InvoiceStatus, current) : {};
+    const statusPatch = isInvoiceStatus(status) ? statusDataFor(status, current) : {};
     const invoice = await prisma.invoice.update({
       where: { id },
       data: {
         ...(clientName !== undefined && { clientName }),
         ...(clientEmail !== undefined && { clientEmail }),
-        ...(issueDate !== undefined && { issueDate: new Date(issueDate) }),
-        ...(dueDate !== undefined && { dueDate: new Date(dueDate) }),
+        ...(issueDateValue && { issueDate: issueDateValue }),
+        ...(dueDateValue && { dueDate: dueDateValue }),
         ...(lineItems !== undefined && {
           lineItems,
           subtotal,
@@ -218,10 +242,7 @@ export async function PATCH(
   // contact after the invoice is created. Handle it before the status branch so
   // a contactId-only PATCH is not rejected as an invalid status.
   if (body.contactId !== undefined && body.status === undefined) {
-    const contactId =
-      typeof body.contactId === "string" && /^[a-f0-9]{24}$/i.test(body.contactId)
-        ? body.contactId
-        : null;
+    const contactId = parseObjectId(body.contactId);
     const invoice = await prisma.invoice.update({ where: { id }, data: { contactId } });
     return NextResponse.json({ ok: true, invoice });
   }
@@ -230,7 +251,7 @@ export async function PATCH(
   // trigger the void notification flow (that lives at /void); statusDataFor
   // stamps/clears voidedAt so the detail page label stays in sync.
   const { status } = body;
-  if (!["DRAFT", "SENT", "PAID", "VOIDED"].includes(status)) {
+  if (!isInvoiceStatus(status)) {
     return errorResponse("Invalid status", 400);
   }
   // Quotes can't be marked PAID - conversion is the only path to a payable
@@ -238,13 +259,13 @@ export async function PATCH(
   if (current.isQuote && status === "PAID") {
     return errorResponse("Convert the quote to an invoice before recording payment.", 409);
   }
-  const transitionErr = validateTransition(current.status, status as InvoiceStatus);
+  const transitionErr = validateTransition(current.status, status);
   if (transitionErr) {
     return errorResponse(transitionErr, 409);
   }
   const invoice = await prisma.invoice.update({
     where: { id },
-    data: statusDataFor(status as InvoiceStatus, current),
+    data: statusDataFor(status, current),
   });
   // Status changes (Mark as paid, etc.) should be reflected in the Drive archive copy.
   await syncInvoicePdfToDriveById(id, "[invoice-patch]");

--- a/src/app/api/business/invoices/route.ts
+++ b/src/app/api/business/invoices/route.ts
@@ -18,7 +18,7 @@ import {
 } from "@/features/business/lib/invoice-numbering";
 import { generateInvoicePdf, serializeInvoice } from "@/features/business/lib/invoice-pdf";
 import { getPolicy } from "@/features/business/lib/pricing-policy.server";
-import { parseAmount } from "@/features/business/lib/validation";
+import { parseAmount, parseObjectId } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { getIdentity } from "@/shared/lib/business-identity.server";
@@ -181,10 +181,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           unsuccessful: unsuccessful === true,
           unsuccessfulDiscount: unsuccessfulDiscountValue > 0 ? unsuccessfulDiscountValue : null,
           notes: notes ?? null,
-          contactId: contactId ?? null,
-          // ObjectId shape enforced here (Prisma throws on malformed ids at read
-          // time otherwise); calendarEventId is a free-form Google id.
-          bookingId: bookingId && /^[a-f0-9]{24}$/i.test(bookingId) ? bookingId : null,
+          // ObjectId shape enforced on both ids (Prisma throws on a malformed
+          // id, which would 500 the create; it also throws at read time
+          // otherwise); calendarEventId is a free-form Google id.
+          contactId: parseObjectId(contactId),
+          bookingId: parseObjectId(bookingId),
           calendarEventId:
             typeof calendarEventId === "string" && calendarEventId ? calendarEventId : null,
         },

--- a/src/features/business/lib/business.ts
+++ b/src/features/business/lib/business.ts
@@ -118,16 +118,26 @@ export function calcInvoiceTotals(
 }
 
 /**
+ * Every key a persisted line item may carry. Must match the Prisma `LineItem`
+ * composite type exactly: Prisma rejects a composite field it doesn't declare,
+ * and an unguarded extra key turns that into a 500 on invoice create/update.
+ * Rejecting here fails loudly as a 400 instead, and surfaces the mismatch in
+ * local dev rather than in production.
+ */
+const LINE_ITEM_FIELDS = new Set(["description", "qty", "unitPrice", "lineTotal", "minutes"]);
+
+/**
  * Validates one untrusted line-item payload before it reaches
  * {@link calcInvoiceTotals} or the database. Rejects non-object items, blank
- * descriptions, and non-finite numerics (which would otherwise yield NaN totals
- * or a malformed persisted invoice).
+ * descriptions, non-finite numerics (which would otherwise yield NaN totals or a
+ * malformed persisted invoice), and any key outside {@link LINE_ITEM_FIELDS}.
  * @param item - Candidate line item from a request body.
- * @returns True when the item has a non-empty description and finite qty, unit price, and line total.
+ * @returns True when the item carries only known fields, a non-empty description, finite qty, unit price and line total, and minutes either absent or finite.
  */
 export function isValidLineItem(item: unknown): item is LineItem {
   if (!item || typeof item !== "object") return false;
-  const { description, qty, unitPrice, lineTotal } = item as Record<string, unknown>;
+  if (!Object.keys(item).every((key) => LINE_ITEM_FIELDS.has(key))) return false;
+  const { description, qty, unitPrice, lineTotal, minutes } = item as Record<string, unknown>;
   return (
     typeof description === "string" &&
     description.trim().length > 0 &&
@@ -136,7 +146,8 @@ export function isValidLineItem(item: unknown): item is LineItem {
     typeof unitPrice === "number" &&
     Number.isFinite(unitPrice) &&
     typeof lineTotal === "number" &&
-    Number.isFinite(lineTotal)
+    Number.isFinite(lineTotal) &&
+    (minutes == null || (typeof minutes === "number" && Number.isFinite(minutes)))
   );
 }
 
@@ -481,10 +492,10 @@ export function formatBilledTime(mins: number): string {
  * before minutes were recorded.
  * @param item - Invoice line item.
  * @param item.qty - Decimal quantity (hours on labour rows, a count on flat rows).
- * @param item.minutes - Billed minutes; present only on hourly labour rows.
+ * @param item.minutes - Billed minutes; present only on hourly labour rows. Null on rows Prisma read back without the field.
  * @returns Text for the Qty cell.
  */
-export function lineItemQtyLabel(item: { qty: number; minutes?: number }): string {
+export function lineItemQtyLabel(item: { qty: number; minutes?: number | null }): string {
   return item.minutes == null ? String(item.qty) : formatBilledTime(item.minutes);
 }
 

--- a/src/features/business/lib/validation.ts
+++ b/src/features/business/lib/validation.ts
@@ -30,3 +30,31 @@ export function parseRate(value: unknown): number | null {
   if (n < 0 || n > 1) return null;
   return n;
 }
+
+/** MongoDB ObjectId hex shape, the only string Prisma accepts for a `@db.ObjectId` field. */
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
+
+/**
+ * Parses a foreign key bound for a `@db.ObjectId` column. Prisma throws on a
+ * malformed id rather than storing it, so an unchecked value from a request
+ * body 500s the write instead of failing as a 400.
+ * @param value - Raw value from a request body.
+ * @returns The id, or null when it isn't a 24-character hex ObjectId.
+ */
+export function parseObjectId(value: unknown): string | null {
+  return typeof value === "string" && OBJECT_ID_RE.test(value) ? value : null;
+}
+
+/**
+ * Parses a date from a request body. Rejects the empty string a cleared
+ * `<input type="date">` submits, which `new Date("")` turns into an Invalid
+ * Date - Prisma rejects that outright ("Provided Date object is invalid"), so
+ * passing it through 500s the write.
+ * @param value - Raw value from a request body.
+ * @returns The parsed date, or null when the value is missing or unparseable.
+ */
+export function parseDate(value: unknown): Date | null {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/src/features/business/types/business.ts
+++ b/src/features/business/types/business.ts
@@ -31,9 +31,11 @@ export interface LineItem {
    * minutes in hours and cannot hold a 5-minute grid exactly (10 min = 0.1667h),
    * so renderers show this as h:mm and money is derived from it. Absent on
    * flat rows (travel, parts, surcharges) and on invoices issued before the
-   * switch, which keep rendering their decimal `qty`.
+   * switch, which keep rendering their decimal `qty`. Null as well as undefined
+   * because Prisma reads a missing optional composite field back as null;
+   * readers must treat the two the same.
    */
-  minutes?: number;
+  minutes?: number | null;
 }
 
 export type InvoiceStatus = "DRAFT" | "SENT" | "PAID" | "VOIDED";


### PR DESCRIPTION
Hotfix for a production 500 on `POST /api/business/invoices`, plus three more unchecked writes of the same shape found while tracing it.

## The break

`jobToLineItems` attaches `minutes` to hourly labour rows, but the Prisma `LineItem` composite type never declared the field. Prisma rejects a composite field it does not declare, so `prisma.invoice.create` threw a `PrismaClientValidationError` straight out of the route.

- Live from the moment `v4.14.0` deployed. Last invoice saved 2026-08-05 19:45, first save after the deploy 500'd.
- **Looked intermittent but was not.** `minutes` is only attached to hourly rows, so an invoice of travel, parts or surcharges alone still saved. Anything with labour on it did not.
- Editing a draft went the same way, since the line-item editor emits `minutes` too.
- Nothing in MongoDB needed changing. Mongo is schemaless and would have stored the field; the rejection was the generated client validating against its own schema, so the fix is the schema line plus the `prisma generate` that runs on build.
- Prisma reads a missing optional composite field back as `null`, not `undefined`, so the app-side type and the Qty label helper now accept both. `tsc` caught this, not me.

No data repair needed: the failed saves wrote nothing, so the DB max is still `TTP-202627-0058` and the sheet counter still reads 59. No counter drift.

## Three more of the same shape

Same class in all three: a value the client controls reaches Prisma unchecked and fails a constraint TypeScript cannot see, so a bad request answers 500 instead of 400.

- **Clearing a date on the invoice edit form 500'd.** A cleared `<input type="date">` submits `""`, not `undefined`, so it passed the PATCH `!== undefined` gate and reached Prisma as an Invalid Date. Both dates now parse up front. The sibling business routes already gate with `!date`, which catches this.
- `contactId` on invoice create skipped the ObjectId check that `bookingId` carries on the very next line, and that the PATCH backfill branch carries too.
- The full-update PATCH branch cast `status` straight to the enum. Only the status-only branch whitelisted it, so any request carrying another field could smuggle an unknown status through to a Prisma enum rejection.

`isValidLineItem` now rejects unknown keys rather than ignoring them, so the next field added to the app-side type without the schema fails as a 400 in local dev instead of a 500 in production. Shared `parseObjectId` / `parseDate` join the existing parsers in `validation.ts`.

## Verification

- Reproduced the original failure against the live Prisma client inside a rolled-back transaction: `minutes` present > `PrismaClientValidationError`, absent > accepted. After the schema change: present > accepted, mixed hourly and flat rows > accepted, an arbitrary unknown key > still rejected. Nothing persisted, 0 leftover rows.
- Proved the Invalid Date path the same way: `Provided Date object is invalid. Expected Date.`
- Ruled out a duplicate-number collision first: sheet counter 59, DB max `0058`, `TTP-202627-0059` free.
- Checked and cleared: the other composite type (`EstimateTask`) cannot drift the same way, since `quotedTasksAtBooking` uses the generated type and `aiTasks` goes through `cleanTasks`, which rebuilds `{label, mins}` and rounds.
- Checked and refuted: a fractional value into an `Int` column, which was the obvious next suspect. Prisma's Mongo connector accepts it rather than throwing, so there is no 500 there.
- 13 guard cases pass over `isValidLineItem`, `parseDate` and `parseObjectId`. Lint, typecheck, build and the 32-page smoke test are green.