### PR TITLE
v4.14.2: parse dates and ids through the shared validators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tech-support-site",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tech-support-site",
-      "version": "4.14.1",
+      "version": "4.14.2",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "6.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-support-site",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/api/booking/request/route.ts
+++ b/src/app/api/booking/request/route.ts
@@ -20,6 +20,7 @@ import { formatQuotedRange } from "@/features/business/lib/estimate-range";
 import { lookupPublicHoliday } from "@/features/business/lib/pricing-policy.server";
 import { getActivePromo } from "@/features/business/lib/promos";
 import { lookupDriveRoundTrip } from "@/features/business/lib/travel-distance";
+import { parseObjectId } from "@/features/business/lib/validation";
 import {
   createBookingEvent,
   deleteBookingEvent,
@@ -228,7 +229,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let quotedMinsAtBooking: number | null = null;
     let quotedCategoryAtBooking: AiEstimateCategory | null = null;
     let quotedTasksAtBooking: EstimateTask[] = [];
-    if (estimateId && /^[a-f0-9]{24}$/i.test(estimateId)) {
+    if (parseObjectId(estimateId)) {
       const est = await prisma.priceEstimateLog
         .findUnique({ where: { id: estimateId } })
         .catch(() => null);

--- a/src/app/api/business/expenses/[id]/route.ts
+++ b/src/app/api/business/expenses/[id]/route.ts
@@ -16,7 +16,7 @@ import {
   resolveSheetIdForDate,
   updateRowBySyncId,
 } from "@/features/business/lib/sheets-sync";
-import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { parseAmount, parseDate, parseRate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -58,6 +58,11 @@ export async function PUT(
     return errorResponse("Invalid GST rate", 400);
   }
 
+  const entryDate = parseDate(date);
+  if (entryDate === null) {
+    return errorResponse("Invalid date", 400);
+  }
+
   const existing = await prisma.expenseEntry.findUnique({ where: { id } });
   if (!existing) {
     return errorResponse("Expense entry not found", 404);
@@ -68,7 +73,7 @@ export async function PUT(
   const updated = await prisma.expenseEntry.update({
     where: { id },
     data: {
-      date: new Date(date),
+      date: entryDate,
       supplier,
       description,
       category,

--- a/src/app/api/business/expenses/route.ts
+++ b/src/app/api/business/expenses/route.ts
@@ -7,7 +7,7 @@
 
 import { recordExpense } from "@/features/business/lib/expense-recording";
 import { GST_RATE } from "@/features/business/lib/pricing-policy";
-import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { parseAmount, parseDate, parseRate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -58,8 +58,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Invalid GST rate", 400);
   }
 
+  const entryDate = parseDate(date);
+  if (entryDate === null) {
+    return errorResponse("Invalid date", 400);
+  }
+
   const { entry, sheetRowKey, sheetSyncWarning } = await recordExpense({
-    date: new Date(date),
+    date: entryDate,
     supplier,
     description,
     category,

--- a/src/app/api/business/income/[id]/route.ts
+++ b/src/app/api/business/income/[id]/route.ts
@@ -13,7 +13,7 @@ import {
   resolveSheetIdForDate,
   updateRowBySyncId,
 } from "@/features/business/lib/sheets-sync";
-import { parseAmount } from "@/features/business/lib/validation";
+import { parseAmount, parseDate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -49,12 +49,16 @@ export async function PUT(
     return errorResponse("Invalid amount", 400);
   }
 
+  const entryDate = parseDate(date);
+  if (entryDate === null) {
+    return errorResponse("Invalid date", 400);
+  }
+
   const existing = await prisma.incomeEntry.findUnique({ where: { id } });
   if (!existing) {
     return errorResponse("Income entry not found", 404);
   }
 
-  const entryDate = new Date(date);
   const updated = await prisma.incomeEntry.update({
     where: { id },
     data: {

--- a/src/app/api/business/income/route.ts
+++ b/src/app/api/business/income/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { recordIncome } from "@/features/business/lib/income-recording";
-import { parseAmount } from "@/features/business/lib/validation";
+import { parseAmount, parseDate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -52,8 +52,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Invalid amount", 400);
   }
 
+  const entryDate = parseDate(date);
+  if (entryDate === null) {
+    return errorResponse("Invalid date", 400);
+  }
+
   const { entry, sheetRowKey } = await recordIncome({
-    date: new Date(date),
+    date: entryDate,
     customer,
     description,
     amount: safeAmount,

--- a/src/app/api/business/invoices/[id]/route.ts
+++ b/src/app/api/business/invoices/[id]/route.ts
@@ -14,7 +14,7 @@ import { parseDate, parseObjectId } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
-import type { InvoiceStatus } from "@prisma/client";
+import { InvoiceStatus } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 
 // Raise the serverless ceiling so a slow upstream call (LLM / Google API / PDF) cannot 504 on the default timeout.
@@ -60,18 +60,16 @@ function statusDataFor(
   return data;
 }
 
-/** Every valid {@link InvoiceStatus}, guarding both PATCH branches before the cast. */
-const INVOICE_STATUSES: readonly string[] = ["DRAFT", "SENT", "PAID", "VOIDED"];
-
 /**
  * Narrows an untrusted status from a request body. Prisma rejects an unknown
  * enum value outright, so casting without this check turns a bad status into a
- * 500 rather than a 400.
+ * 500 rather than a 400. Reads the accepted values off the generated enum, so
+ * a status added to the schema is covered without editing a second list.
  * @param value - Raw status from a request body.
- * @returns True when the value is one of the four invoice statuses.
+ * @returns True when the value is one of the invoice statuses.
  */
 function isInvoiceStatus(value: unknown): value is InvoiceStatus {
-  return typeof value === "string" && INVOICE_STATUSES.includes(value);
+  return typeof value === "string" && Object.values(InvoiceStatus).includes(value as InvoiceStatus);
 }
 
 /**

--- a/src/app/api/business/invoices/preview-pdf/route.ts
+++ b/src/app/api/business/invoices/preview-pdf/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { generateInvoicePdf } from "@/features/business/lib/invoice-pdf";
+import { parseDate } from "@/features/business/lib/validation";
 import type { Invoice, LineItem } from "@/features/business/types/business";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
@@ -48,6 +49,13 @@ export async function POST(request: NextRequest): Promise<Response> {
   if (!body.number || !body.clientName) {
     return errorResponse("number and clientName are required", 400);
   }
+  // serializeInvoice calls toISOString on both dates, which throws a RangeError
+  // on an Invalid Date - the shape a cleared date input on the edit form sends.
+  const issueDate = parseDate(body.issueDate);
+  const dueDate = parseDate(body.dueDate);
+  if (!issueDate || !dueDate) {
+    return errorResponse("Enter a valid issue date and due date", 400);
+  }
 
   // Build the minimum Invoice shape generateInvoicePdf needs. Status is
   // forced to DRAFT so the watermark stays off for in-progress previews.
@@ -56,8 +64,8 @@ export async function POST(request: NextRequest): Promise<Response> {
     number: body.number,
     clientName: body.clientName,
     clientEmail: body.clientEmail,
-    issueDate: new Date(body.issueDate),
-    dueDate: new Date(body.dueDate),
+    issueDate,
+    dueDate,
     lineItems: body.lineItems,
     gst: body.gstAmount > 0,
     subtotal: body.subtotal,

--- a/src/app/api/business/promos/[id]/route.ts
+++ b/src/app/api/business/promos/[id]/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { ACTIVE_PROMO_TAG } from "@/features/business/lib/promos";
+import { parseDate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -48,8 +49,14 @@ export async function PATCH(
   // in a state POST would reject - both discount fields set, percentDiscount out of
   // range, or endAt before startAt - which then flows straight into public pricing
   // ("500% off", $0/hr).
-  const startAt = body.startAt !== undefined ? new Date(body.startAt) : existing.startAt;
-  const endAt = body.endAt !== undefined ? new Date(body.endAt) : existing.endAt;
+  // Parse rather than trusting `!== undefined`: a cleared date input sends "",
+  // which becomes an Invalid Date that compares false against everything, so it
+  // would slide past the start-before-end check into Prisma and 500 the update.
+  const startAt = body.startAt !== undefined ? parseDate(body.startAt) : existing.startAt;
+  const endAt = body.endAt !== undefined ? parseDate(body.endAt) : existing.endAt;
+  if (!startAt || !endAt) {
+    return errorResponse("startAt and endAt must be valid dates", 400);
+  }
   const flatHourlyRate =
     body.flatHourlyRate !== undefined ? body.flatHourlyRate : existing.flatHourlyRate;
   const percentDiscount =

--- a/src/app/api/business/promos/route.ts
+++ b/src/app/api/business/promos/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { ACTIVE_PROMO_TAG } from "@/features/business/lib/promos";
+import { parseDate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -31,7 +32,13 @@ interface PromoBody {
 function validatePromo(body: PromoBody): string | null {
   if (!body.title || typeof body.title !== "string") return "title is required";
   if (!body.startAt || !body.endAt) return "startAt and endAt are required";
-  if (new Date(body.startAt) >= new Date(body.endAt)) {
+  // Parse before comparing: an unparseable date compares false against
+  // everything, so `start >= end` would pass it through to Prisma, which
+  // rejects an Invalid Date and 500s the create.
+  const startAt = parseDate(body.startAt);
+  const endAt = parseDate(body.endAt);
+  if (!startAt || !endAt) return "startAt and endAt must be valid dates";
+  if (startAt >= endAt) {
     return "startAt must be before endAt";
   }
   const hasFlat = typeof body.flatHourlyRate === "number" && body.flatHourlyRate > 0;
@@ -75,8 +82,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     data: {
       title: body.title!,
       description: body.description ?? null,
-      startAt: new Date(body.startAt!),
-      endAt: new Date(body.endAt!),
+      startAt: parseDate(body.startAt)!,
+      endAt: parseDate(body.endAt)!,
       flatHourlyRate: body.flatHourlyRate ?? null,
       percentDiscount: body.percentDiscount ?? null,
       isActive: body.isActive ?? true,

--- a/src/app/api/business/subscriptions/[id]/route.ts
+++ b/src/app/api/business/subscriptions/[id]/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { VALID_FREQUENCIES } from "@/features/business/lib/constants";
-import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { parseAmount, parseDate, parseRate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -69,7 +69,8 @@ export async function PATCH(
 
   // Reject an unparseable nextDue before it reaches Prisma as an Invalid Date
   // (which would surface as a 500 rather than a clean 400).
-  if (nextDue !== undefined && Number.isNaN(new Date(nextDue).getTime())) {
+  const nextDueValue = nextDue !== undefined ? parseDate(nextDue) : undefined;
+  if (nextDueValue === null) {
     return errorResponse("Invalid nextDue date", 400);
   }
 
@@ -84,7 +85,7 @@ export async function PATCH(
         ...(safeRate !== undefined && { gstRate: safeRate }),
         ...(method !== undefined && { method }),
         ...(frequency !== undefined && { frequency }),
-        ...(nextDue !== undefined && { nextDue: new Date(nextDue) }),
+        ...(nextDueValue && { nextDue: nextDueValue }),
         ...(isActive !== undefined && { isActive }),
         ...(notes !== undefined && { notes }),
       },

--- a/src/app/api/business/subscriptions/route.ts
+++ b/src/app/api/business/subscriptions/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { VALID_FREQUENCIES } from "@/features/business/lib/constants";
-import { parseAmount, parseRate } from "@/features/business/lib/validation";
+import { parseAmount, parseDate, parseRate } from "@/features/business/lib/validation";
 import { errorResponse } from "@/shared/lib/api-response";
 import { isAdminRequest } from "@/shared/lib/auth";
 import { prisma } from "@/shared/lib/prisma";
@@ -69,6 +69,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Invalid GST rate", 400);
   }
 
+  const nextDueValue = parseDate(nextDue);
+  if (nextDueValue === null) {
+    return errorResponse("Invalid nextDue date", 400);
+  }
+
   const subscription = await prisma.subscription.create({
     data: {
       description,
@@ -78,7 +83,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       gstRate: safeRate,
       method: method ?? "Business Account",
       frequency,
-      nextDue: new Date(nextDue),
+      nextDue: nextDueValue,
       isActive: true,
       notes: notes ?? null,
     },

--- a/src/features/booking/components/BookingForm.tsx
+++ b/src/features/booking/components/BookingForm.tsx
@@ -18,6 +18,7 @@ import {
   type TimeOfDay,
 } from "@/features/booking/lib/booking";
 import { fetchQuickEstimate } from "@/features/business/lib/quick-estimate";
+import { parseObjectId } from "@/features/business/lib/validation";
 import { Button } from "@/shared/components/Button";
 import { EmailInput } from "@/shared/components/EmailInput";
 import { PhoneInput } from "@/shared/components/PhoneInput";
@@ -156,7 +157,7 @@ export default function BookingForm({
   // (?estimate=<id>, 24-hex) and replaced if they run the inline estimate below.
   const estimateParam = useSearchParams().get("estimate");
   const [estimateId, setEstimateId] = useState<string | undefined>(
-    estimateParam && /^[a-f0-9]{24}$/i.test(estimateParam) ? estimateParam : undefined,
+    parseObjectId(estimateParam) ?? undefined,
   );
   // Inline "get a rough estimate" state (new bookings only).
   const [estimating, setEstimating] = useState(false);

--- a/src/features/business/lib/sheets-import.ts
+++ b/src/features/business/lib/sheets-import.ts
@@ -16,6 +16,7 @@ import {
   buildExpenseCells,
   resolveSheetIdForDate,
 } from "@/features/business/lib/sheets-sync";
+import { parseObjectId } from "@/features/business/lib/validation";
 import { prisma } from "@/shared/lib/prisma";
 import type { ExpenseEntry, IncomeEntry } from "@prisma/client";
 import { randomUUID } from "crypto";
@@ -202,9 +203,6 @@ function expenseDiffers(db: ExpenseEntry, data: ExpenseRowData): boolean {
   );
 }
 
-/** 24-hex Mongo ObjectId shape - guards live findUnique({ id }) against legacy UUID Sync IDs. */
-const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
-
 /**
  * Whether two money amounts differ by at least a cent. Both are rounded to
  * cents first so float representation drift and the GST percent integer
@@ -332,7 +330,7 @@ async function importFromSheet(
           // before creating a DUPLICATE - a deterministic Sync ID equals the
           // entry's Mongo id, so a hit means "already recorded - just link it".
           // Gate on the ObjectId shape; a legacy UUID would throw on findUnique.
-          const idLink = OBJECT_ID_RE.test(syncId)
+          const idLink = parseObjectId(syncId)
             ? await prisma.incomeEntry.findUnique({ where: { id: syncId } })
             : null;
           if (idLink) {
@@ -471,7 +469,7 @@ async function importFromSheet(
         } else {
           // Live id-fallback link before creating a duplicate - see the income
           // loop above for the full rationale.
-          const idLink = OBJECT_ID_RE.test(syncId)
+          const idLink = parseObjectId(syncId)
             ? await prisma.expenseEntry.findUnique({ where: { id: syncId } })
             : null;
           if (idLink) {


### PR DESCRIPTION
Follow-up to `v4.14.1`. Tracing that 500 turned up the same shape in seven more write routes: a value off the request body goes straight into `new Date(...)` or a `@db.ObjectId` field, and Prisma answers a malformed one with a 500 instead of the route answering 400. Each route had its own spelling of the check, or none at all.

`parseDate` and `parseObjectId` now sit alongside `parseAmount` / `parseRate` in `validation.ts`, and every caller routes through them.

## Fixes, not just tidying

- **Promos PATCH had the identical hole the invoice PATCH did.** It gated on `!== undefined`, so a cleared date input arrived as `""` and became an Invalid Date. Its start-before-end check could not catch it either: an Invalid Date compares false against everything, so the value slid straight past into Prisma. `validatePromo` on the POST side had the same blind comparison.
- **The invoice PDF preview threw rather than rendering something odd.** It built its Invoice with `new Date(body.issueDate)`, and `serializeInvoice` calls `toISOString()` on that, which raises a `RangeError` on an Invalid Date. Reachable from the same edit form as the PATCH bug, via the live preview panel.
- Income, expenses and subscriptions gated with `!date`, which catches a cleared input but not a malformed one, so garbage was still a 500 rather than a 400.

## Tidying only

- The 24-hex ObjectId literal appeared in three places plus a duplicate `OBJECT_ID_RE` const in `sheets-import`. It now exists once, in `validation.ts`.
- `isInvoiceStatus` reads its accepted values off the generated Prisma enum instead of a hand-written array, so a status added to the schema is covered without remembering to edit a second list.

`subscriptions` PATCH already did this correctly, with a comment naming the reason. That check was the model for the rest; it now shares the helper rather than spelling it out alone.

## Verification

- No `new Date(<body value>)` reaches a Prisma write or a serialiser in `src/app/api` any more, and the ObjectId literal appears in exactly one file. Both confirmed by grep after the change.
- Behaviour of the helpers is covered by the 13 guard cases added with `v4.14.1`.
- Lint, typecheck, the address fixtures, build and the 32-page smoke test are green.

No schema or data changes.